### PR TITLE
Use dedicated per-site Packer token secrets

### DIFF
--- a/.github/workflows/packer.yaml
+++ b/.github/workflows/packer.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Packer Build
         working-directory: packer/ubuntu2404
         env:
-          PROXMOX_TOKEN: ${{ matrix.proxmox_token_secret == 'HAWKFIELD' && secrets.HAWKFIELD_PROXMOX_TOKEN_SECRET || secrets.LONDON_PROXMOX_TOKEN_SECRET }}
+          PROXMOX_TOKEN: ${{ matrix.proxmox_token_secret == 'HAWKFIELD' && secrets.PACKER_PROXMOX_TOKEN_HAWKFIELD || secrets.PACKER_PROXMOX_TOKEN_LONDON }}
         run: |
           packer build -force \
             -var-file="${{ matrix.host }}.pkrvars.hcl" \


### PR DESCRIPTION
## Summary
- Previous fix pointed at `HAWKFIELD_PROXMOX_TOKEN_SECRET` / `LONDON_PROXMOX_TOKEN_SECRET` which are admin tokens for the Ansible proxmox playbook, not the `packer@pam!packer` user
- This caused 401 Authentication failed on all hosts
- Updated to reference `PACKER_PROXMOX_TOKEN_HAWKFIELD` and `PACKER_PROXMOX_TOKEN_LONDON` — dedicated Packer token secrets that need to be created in repo settings

## Prerequisites
- [ ] Create `PACKER_PROXMOX_TOKEN_HAWKFIELD` secret with the packer@pam!packer token for Hawkfield
- [ ] Create `PACKER_PROXMOX_TOKEN_LONDON` secret with the packer@pam!packer token for London

## Test plan
- [ ] Trigger packer workflow after secrets are created and confirm all 4 jobs pass