### PR TITLE
Replace shell-based gh auth with declarative config file

### DIFF
--- a/.github/workflows/ansible-claude.yaml
+++ b/.github/workflows/ansible-claude.yaml
@@ -61,6 +61,7 @@ jobs:
           BW_CLIENT_ID: ${{ secrets.BW_CLIENT_ID }}
           BW_CLIENT_SECRET: ${{ secrets.BW_CLIENT_SECRET }}
           BW_MASTER_PASSWORD: ${{ secrets.BW_MASTER_PASSWORD }}
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           ansible-playbook claude.yml \
             --inventory inventory/hawkfield.proxmox.yml \

--- a/Ansible/roles/claude/tasks/main.yml
+++ b/Ansible/roles/claude/tasks/main.yml
@@ -179,19 +179,25 @@
   become_user: claude
   changed_when: true
 
-- name: "Authenticate GitHub CLI"
-  ansible.builtin.shell:
-    cmd: |
-      set -o pipefail
-      export BW_CLIENTID="{{ lookup('env', 'BW_CLIENT_ID') }}"
-      export BW_CLIENTSECRET="{{ lookup('env', 'BW_CLIENT_SECRET') }}"
-      bw login --apikey --raw
-      MASTER="{{ lookup('env', 'BW_MASTER_PASSWORD') }}"
-      export BW_SESSION=$(echo "${MASTER}" | bw unlock --raw)
-      bw get password "GitHub PAT" | gh auth login --with-token
-  become: true
-  become_user: claude
-  changed_when: true
+- name: "Ensure gh config directory exists"
+  ansible.builtin.file:
+    path: /home/claude/.config/gh
+    state: directory
+    owner: claude
+    group: claude
+    mode: "0700"
+
+- name: "Authenticate GitHub CLI via config file"
+  ansible.builtin.copy:
+    content: |
+      github.com:
+          oauth_token: {{ lookup('env', 'GH_PAT') }}
+          git_protocol: ssh
+          user: open-dave
+    dest: /home/claude/.config/gh/hosts.yml
+    owner: claude
+    group: claude
+    mode: "0600"
   no_log: true
 
 - name: "Verify Claude Code installation"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,3 +101,8 @@ GitHub Actions workflows use Tailscale to connect to internal infrastructure. Se
 - Be concise in commit messages and PR descriptions
 - Always branch from master for each change; do not reuse branches
 - Secrets managed via Ansible Vault and SOPS — never commit plaintext secrets
+- Prefer native Ansible modules (`get_url`, `apt_repository`, `copy`, `template`) over `shell`/`command` tasks
+- For apt repo setup: download GPG key with `get_url`, add repo with `apt_repository` — no shell piping
+- If a CLI command just writes a config file, write the file declaratively instead
+- Only add `yamllint disable` comments when the line genuinely exceeds limits
+- Remove unused secrets, env vars, and workflow config — don't leave dead references


### PR DESCRIPTION
## Summary

- Replace fragile Bitwarden shell pipeline in `Authenticate GitHub CLI` task with `ansible.builtin.copy` writing `~/.config/gh/hosts.yml` directly
- Add `GH_PAT` GitHub Actions secret (already set in repo) to workflow env block
- Fixes clincha-org/clincha#run/24022169677

## Test plan

- [ ] Merge and watch Actions run — `Authenticate GitHub CLI via config file` should show `ok` or `changed`
- [ ] SSH to `claude-hawk-1` as claude and run `gh auth status` — should show authenticated as `open-dave`