### PR TITLE
Fix empty ansible_host in Proxmox inventory

### DIFF
--- a/Ansible/inventory/hawkfield.proxmox.yml
+++ b/Ansible/inventory/hawkfield.proxmox.yml
@@ -6,11 +6,12 @@ token_id: "ansible"
 validate_certs: false
 want_facts: true
 want_proxmox_nodes_ansible_host: true
+strict: true
 compose:
   ansible_host: >-
-    (proxmox_ipconfig0.ip |
-    default(proxmox_net0.ip | default('')) |
-    default(ansible_host)).split('/') | first
+    ((proxmox_ipconfig0.ip | default('')) or
+    (proxmox_net0.ip | default('')) or
+    ansible_host | default('')).split('/') | first
   site: "'hawkfield'"
 groups:
   hawkfield: true

--- a/Ansible/inventory/london.proxmox.yml
+++ b/Ansible/inventory/london.proxmox.yml
@@ -6,11 +6,12 @@ token_id: "ansible"
 validate_certs: false
 want_facts: true
 want_proxmox_nodes_ansible_host: true
+strict: true
 compose:
   ansible_host: >-
-    (proxmox_ipconfig0.ip |
-    default(proxmox_net0.ip | default('')) |
-    default('10.2.2.11')).split('/') | first
+    ((proxmox_ipconfig0.ip | default('')) or
+    (proxmox_net0.ip | default('')) or
+    ansible_host | default('')).split('/') | first
   site: "'london'"
 groups:
   london: "true"


### PR DESCRIPTION
## Summary

- Fix compose expression that produced empty `ansible_host` for Proxmox nodes since `cea9633` (2026-03-31)
- Replace chained `default()` with `or`-based fallback — handles both undefined and empty/falsy values
- Add `strict: true` to both inventory files so compose errors fail loudly at inventory time
- Remove London's hardcoded `10.2.2.11` fallback (unnecessary with `want_proxmox_nodes_ansible_host: true`)

## Root cause

`default('')` converts undefined to `''`, which is *defined* in Jinja2 — the outer `default(ansible_host)` never triggers, overwriting the plugin's valid `ansible_host` with an empty string.

## Test plan

- [ ] Hourly cron or PR-triggered workflow runs both Hawkfield and London Ansible jobs
- [ ] All hosts (nodes, QEMU VMs, LXC) resolve correct IPs
- [ ] `strict: true` catches any future compose errors at inventory stage