### PR TITLE
docs(workflows): sync README with terraform matrix

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,7 +37,7 @@ These run when changes are pushed to `master` (i.e. a PR is merged).
 | Workflow | File | Triggers | Sites | What it does |
 |----------|------|----------|-------|-------------|
 | **Packer Build** | `packer.yaml` | Push to master (paths: `packer/**`), weekly Sunday 04:00 UTC, manual | hawk01–03, lon01 | Builds Ubuntu 24.04 VM templates on all Proxmox nodes (matrix build, one per host) |
-| **Terraform Apply** | `terraform.yaml` | Push to master (paths: `terraform/**`), manual | Hawkfield only | Plans then applies Terraform. Apply job requires `production` environment approval |
+| **Terraform Apply** | `terraform.yaml` | Push to master (paths: `terraform/**`), manual | Hawkfield, London | Plans then applies Terraform for both sites (matrix). Apply job requires `production` environment approval |
 | **Ansible Base** | `ansible-base.yaml` | Push to master (paths: `Ansible/**`), hourly, manual | Hawkfield only | Runs `base.yml` playbook — user accounts, sudoers, base packages |
 | **Proxmox Config** | `ansible-proxmox.yaml` | Push to master (paths: `Ansible/proxmox.yml`), hourly, manual | Hawkfield, London (parallel) | Configures Proxmox API roles, users, and ACLs via `proxmox.yml` playbook |
 
@@ -62,7 +62,8 @@ Workflows use concurrency groups to prevent dangerous parallel runs:
 
 | Group | Workflows | Behaviour |
 |-------|-----------|-----------|
-| `cluster-hawkfield` | terraform.yaml, ansible-base.yaml | Serialised — only one at a time |
+| `cluster-{site}` | terraform.yaml | Per-site — hawkfield and london apply independently |
+| `cluster-hawkfield` | ansible-base.yaml | Serialised with any hawkfield terraform run |
 | `cluster-{input}` | cluster-rebuild.yaml | Per-cluster — hawkfield and london can run independently |
 | `terraform-plan-{PR}` | terraform-plan.yaml | Per-PR, cancels in-progress — only latest plan matters |
 | `packer-{host}` | packer.yaml | Per-host — prevents parallel builds on the same Proxmox node |
@@ -84,7 +85,7 @@ All secrets are stored in GitHub repository settings.
 | `PROXMOX_TOKEN_HAWKFIELD_PACKER` | Proxmox API token for Packer (Bristol) | packer |
 | `PROXMOX_TOKEN_LONDON_PACKER` | Proxmox API token for Packer (London) | packer |
 | `PROXMOX_TOKEN_HAWKFIELD_TERRAFORM` | Proxmox API token for Terraform (Bristol) | terraform, terraform-plan, cluster-rebuild |
-| `PROXMOX_TOKEN_LONDON_TERRAFORM` | Proxmox API token for Terraform (London) | terraform-plan, cluster-rebuild |
+| `PROXMOX_TOKEN_LONDON_TERRAFORM` | Proxmox API token for Terraform (London) | terraform, terraform-plan, cluster-rebuild |
 | `PACKER_SSH_PASSWORD` | SSH password for Packer VM provisioning | packer |
 | `PROXMOX_ROOT_PASSWORD` | Root password for bootstrap | ansible-proxmox-bootstrap |
 | `GH_PAT` | GitHub Personal Access Token | ansible-proxmox-bootstrap |
@@ -93,6 +94,5 @@ All secrets are stored in GitHub repository settings.
 
 Tracked in the [CI/CD Improvements](https://github.com/clincha-org/clincha/milestone/6) milestone:
 
-- **Terraform apply is hawkfield-only** — `terraform.yaml` only applies to the hawkfield site. London terraform changes must be applied manually. [#213](https://github.com/clincha-org/clincha/issues/213)
 - **ansible-base is hawkfield-only** — the hourly base config reconciliation only targets hawkfield. London base config must be applied manually. [#214](https://github.com/clincha-org/clincha/issues/214)
 - **Boilerplate repetition** — Tailscale setup, Ansible setup (Python, pip, galaxy, vault, SSH key) are copy-pasted across workflows. These could be extracted into composite actions. [#215](https://github.com/clincha-org/clincha/issues/215)


### PR DESCRIPTION
## Summary
- Mark `terraform.yaml` as applying to both Hawkfield and London (matrix already implemented)
- Split the concurrency groups row: `cluster-{site}` for terraform, `cluster-hawkfield` still for ansible-base
- Add `terraform` to the list of workflows using `PROXMOX_TOKEN_LONDON_TERRAFORM`
- Remove the stale "Terraform apply is hawkfield-only" known-gap entry (closes #213)

No workflow behaviour changes — docs only.

## Test plan
- [ ] Markdown tables render cleanly on GitHub