### PR TITLE
Connect to AdGuard LXCs as root

### DIFF
--- a/Ansible/group_vars/adguard.yml
+++ b/Ansible/group_vars/adguard.yml
@@ -1,1 +1,3 @@
 ---
+ansible_user: root
+ansible_ssh_pass: null


### PR DESCRIPTION
## Summary

The AdGuard playbook fails to reach `dns-hawk-1` with `Permission denied` ([run 24264245536](https://github.com/clincha-org/clincha/actions/runs/24264245536/job/70855377033)).

Terraform creates the LXC from the Debian 12 template and injects the ansible ed25519 public key via Proxmox's `ssh_public_keys`, which lands in `/root/.ssh/authorized_keys`. There is no `ansible` user inside the container. The inherited `ansible_user: ansible` + `ansible_ssh_pass` from `group_vars/all.yml` / `group_vars/hawkfield.yml` therefore can't authenticate.

Simplest fix: connect as `root` for the `adguard` group so we use the key that's already there. A proper LXC bootstrap play (mirroring `proxmox-bootstrap.yml`) to create an `ansible` user inside containers can follow if we want to standardise.

## Test plan

- [ ] `ansible-adguard` workflow succeeds against `dns-hawk-1`
- [ ] AdGuard Home service active on the container