### PR TITLE
Simplify AdGuard deploy: root-only, no base bootstrap

### DIFF
--- a/.github/workflows/ansible-adguard.yaml
+++ b/.github/workflows/ansible-adguard.yaml
@@ -57,17 +57,6 @@ jobs:
           eval `ssh-agent -s`
           ssh-add ~/.ssh/id_ed25519
 
-      - name: Bootstrap base configuration
-        working-directory: Ansible
-        env:
-          PROXMOX_TOKEN_SECRET: ${{ matrix.site == 'hawkfield' && secrets.PROXMOX_TOKEN_HAWKFIELD_ANSIBLE || secrets.PROXMOX_TOKEN_LONDON_ANSIBLE }}
-        run: |
-          ansible-playbook base.yml \
-            --inventory inventory/${{ matrix.site }}.proxmox.yml \
-            --vault-password-file vault \
-            --limit adguard \
-            -e ansible_user=root || true
-
       - name: Run AdGuard Home playbook
         working-directory: Ansible
         env:

--- a/Ansible/roles/adguard/tasks/install.yml
+++ b/Ansible/roles/adguard/tasks/install.yml
@@ -5,9 +5,12 @@
   register: adguard_binary
 
 - name: Install passlib for bcrypt password hashing
-  ansible.builtin.pip:
-    name: passlib[bcrypt]
+  ansible.builtin.apt:
+    name:
+      - python3-passlib
+      - python3-bcrypt
     state: present
+    update_cache: true
 
 - name: Download AdGuard Home
   vars:

--- a/Ansible/roles/sudoers/tasks/main.yml
+++ b/Ansible/roles/sudoers/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
-- name: "Install sudo"
-  ansible.builtin.apt:
-    name: sudo
-    state: present
-    update_cache: true
-
 - name: "Sudoers configuration"
   ansible.builtin.copy:
     src: "{{ item }}"

--- a/Ansible/roles/sudoers/tasks/main.yml
+++ b/Ansible/roles/sudoers/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: "Install sudo"
+  ansible.builtin.apt:
+    name: sudo
+    state: present
+    update_cache: true
+
 - name: "Sudoers configuration"
   ansible.builtin.copy:
     src: "{{ item }}"


### PR DESCRIPTION
## Summary

AdGuard LXCs only need root SSH to function — Terraform already injects the ansible key into `/root/.ssh/authorized_keys` at create time. Running `users` / `sudoers` / `base` against them is dead weight, and on a fresh Debian 12 LXC it actively broke ([run 24264869726](https://github.com/clincha-org/clincha/actions/runs/24264869726/job/70857446232)) because `sudo` isn't installed, which cascaded into the AdGuard play failing on pip.

### Changes

- `.github/workflows/ansible-adguard.yaml`: drop the *Bootstrap base configuration* step entirely.
- `roles/adguard`: install `python3-passlib` + `python3-bcrypt` via apt instead of pip. Matches the repo convention of native modules and avoids depending on pip.

### Not included

- ~~`sudoers` role installing the `sudo` package~~ — reverted; no longer needed now that the bootstrap step is gone.

## Test plan

- [ ] `ansible-adguard` workflow succeeds against `dns-hawk-1` (fresh LXC)
- [ ] Still succeeds against the existing London LXC
- [ ] AdGuard Home service active with admin password set