### PR TITLE
Install bcrypt backend on Ansible runner for AdGuard templating

### DIFF
--- a/Ansible/requirements.txt
+++ b/Ansible/requirements.txt
@@ -1,7 +1,7 @@
 ansible-core==2.17.14 # locked for compatibility with Kubespray
 distlib==0.4.0 # Required to install collections
 requests==2.33.0 # Required for Proxmox dynamic inventory
-passlib==1.7.4
+passlib[bcrypt]==1.7.4
 netaddr
 jmespath
 boto3 # Required for amazon.aws.s3_object (kubeconfig upload to MinIO)

--- a/Ansible/roles/adguard/tasks/install.yml
+++ b/Ansible/roles/adguard/tasks/install.yml
@@ -4,14 +4,6 @@
     path: /opt/AdGuardHome/AdGuardHome
   register: adguard_binary
 
-- name: Install passlib for bcrypt password hashing
-  ansible.builtin.apt:
-    name:
-      - python3-passlib
-      - python3-bcrypt
-    state: present
-    update_cache: true
-
 - name: Download AdGuard Home
   vars:
     base: "https://github.com/AdguardTeam"


### PR DESCRIPTION
## Summary

After #277 the AdGuard deploy gets much further but the *Template AdGuard Home configuration* task fails with:

```
passlib.exc.MissingBackendError: bcrypt: no backends available
-- recommend you install one (e.g. 'pip install bcrypt')
```

The template uses `{{ adguard_admin_password | password_hash('bcrypt') }}`. The `password_hash` Jinja filter runs on the **control node** (the GitHub Actions runner), not the remote LXC — and the runner has `passlib==1.7.4` but no `bcrypt` backend library.

## Changes

- `Ansible/requirements.txt`: `passlib==1.7.4` → `passlib[bcrypt]==1.7.4` so pip pulls the `bcrypt` extra onto the runner.
- `Ansible/roles/adguard/tasks/install.yml`: delete the *Install passlib for bcrypt password hashing* task. It installed `python3-passlib`/`python3-bcrypt` on the AdGuard LXC, where nothing uses them — hashing happens on the runner.

## Out of scope (flagged, not fixed here)

The **London job is silently skipping**, not succeeding. Its Proxmox inventory fails to parse (`Could not set ansible_host for host lon01: 'None' has no attribute 'split'`), so `adguard` matches zero hosts and the play is a no-op. `lon01` has no IP in the Proxmox compose expression — pre-existing, needs a separate fix.

## Test plan

- [ ] `ansible-adguard` workflow succeeds against `dns-hawk-1`; *Template AdGuard Home configuration* runs without `MissingBackendError`
- [ ] `systemctl status AdGuardHome` active on `dns-hawk-1`
- [ ] Admin login works with `ADGUARD_ADMIN_PASSWORD_HAWKFIELD`
- [ ] London job still runs (even if skipping) — no further regression