### PR TITLE
adguard: use /etc/hosts for local DNS instead of rewrites block

### DIFF
--- a/Ansible/group_vars/adguard.yml
+++ b/Ansible/group_vars/adguard.yml
@@ -2,7 +2,7 @@
 ansible_user: root
 ansible_ssh_pass: null
 
-adguard_dns_rewrites:
+adguard_local_dns_entries:
   - domain: "hawk01.clinch-home.com"
     answer: "10.1.2.11"
   - domain: "hawk02.clinch-home.com"

--- a/Ansible/roles/adguard/defaults/main.yml
+++ b/Ansible/roles/adguard/defaults/main.yml
@@ -6,4 +6,4 @@ adguard_upstream_dns:
   - "1.0.0.1"
 adguard_admin_username: "admin"
 adguard_admin_password: "{{ lookup('env', 'ADGUARD_ADMIN_PASSWORD') }}"
-adguard_dns_rewrites: []
+adguard_local_dns_entries: []

--- a/Ansible/roles/adguard/tasks/configure.yml
+++ b/Ansible/roles/adguard/tasks/configure.yml
@@ -1,9 +1,46 @@
 ---
-- name: Template AdGuard Home configuration
+- name: Bootstrap AdGuard Home configuration (first install only)
   ansible.builtin.template:
     src: AdGuardHome.yaml.j2
     dest: /opt/AdGuardHome/AdGuardHome.yaml
     owner: root
     group: root
     mode: "0600"
+    force: false
   notify: Restart AdGuardHome
+
+- name: Template /etc/hosts for local DNS entries
+  ansible.builtin.template:
+    src: hosts.j2
+    dest: /etc/hosts
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Read current AdGuard Home configuration
+  ansible.builtin.slurp:
+    src: /opt/AdGuardHome/AdGuardHome.yaml
+  register: adguard_current_config
+
+- name: Apply hostsfile_enabled to AdGuard config (stop → edit → start)
+  vars:
+    adguard_config_text: "{{ adguard_current_config.content | b64decode }}"
+  when: "'hostsfile_enabled: true' not in adguard_config_text"
+  block:
+    - name: Stop AdGuardHome before editing its config
+      ansible.builtin.systemd:
+        name: AdGuardHome
+        state: stopped
+
+    - name: Ensure hostsfile_enabled is true in AdGuard config
+      ansible.builtin.lineinfile:
+        path: /opt/AdGuardHome/AdGuardHome.yaml
+        regexp: '^  hostsfile_enabled:'
+        line: "  hostsfile_enabled: true"
+        insertafter: '^dns:'
+        state: present
+
+    - name: Start AdGuardHome after editing its config
+      ansible.builtin.systemd:
+        name: AdGuardHome
+        state: started

--- a/Ansible/roles/adguard/templates/AdGuardHome.yaml.j2
+++ b/Ansible/roles/adguard/templates/AdGuardHome.yaml.j2
@@ -29,12 +29,7 @@ dns:
   safebrowsing_enabled: false
   safe_search:
     enabled: false
-  rewrites:
-{% for rewrite in adguard_dns_rewrites %}
-    - domain: {{ rewrite.domain }}
-      answer: {{ rewrite.answer }}
-      enabled: true
-{% endfor %}
+  hostsfile_enabled: true
 filters:
   - enabled: true
     url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt

--- a/Ansible/roles/adguard/templates/hosts.j2
+++ b/Ansible/roles/adguard/templates/hosts.j2
@@ -1,0 +1,13 @@
+# Ansible managed — do not edit by hand.
+# Source: Ansible/roles/adguard/templates/hosts.j2
+# Local DNS entries for AdGuard Home (hostsfile_enabled: true).
+
+127.0.0.1   localhost
+127.0.1.1   {{ ansible_hostname }}
+::1         localhost ip6-localhost ip6-loopback
+ff02::1     ip6-allnodes
+ff02::2     ip6-allrouters
+
+{% for entry in adguard_local_dns_entries %}
+{{ entry.answer }}   {{ entry.domain }}
+{% endfor %}


### PR DESCRIPTION
## Problem

Local DNS entries managed via the `dns.rewrites` block in `AdGuardHome.yaml` vanish on every AdGuard service restart. AdGuard Home treats its config file as its own state file and **rewrites it from in-memory state on shutdown** — [documented in the AdGuard wiki](https://github.com/AdguardTeam/AdGuardHome/wiki/Configuration): *"any changes to the file will be lost because the running program will overwrite them"*.

Symptoms:
- Playbook applies the template successfully
- Service restart clobbers the rewrites block
- Only manual workaround is stop → edit → start
- Any future restart (updates, reboots, upstream DNS blips) breaks local name resolution

`user_rules` with `\$dnsrewrite=` was considered and rejected — same file, same overwrite problem.

## Fix

Use AdGuard's first-class `hostsfile_enabled` option: AdGuard watches `/etc/hosts` at runtime and reloads it live, no service bounce, no risk of being clobbered by AdGuard's state serialisation. `/etc/hosts` is templated declaratively from Ansible, fully decoupled from AdGuard's config file.

### Changes

- **`templates/AdGuardHome.yaml.j2`** (bootstrap-only): remove `rewrites:` block, add `hostsfile_enabled: true`
- **`templates/hosts.j2`** (new): full `/etc/hosts` with preserved loopback entries + templated local DNS entries
- **`tasks/configure.yml`**:
  - Bootstrap template now has `force: false` (AdGuard owns the file after install)
  - Template `/etc/hosts` (AdGuard reloads live, no handler)
  - `slurp`-gated stop → `lineinfile` → start block ensures `hostsfile_enabled: true` on existing installs. Only fires on first run (or if AdGuard ever loses the setting). Subsequent runs are fully no-op.
- **Variable rename**: `adguard_dns_rewrites` → `adguard_local_dns_entries` (shape unchanged — `list[{domain, answer}]`). Field names kept — still semantically valid for a DNS name→address mapping, even though `answer` is now an A-record value rather than an AdGuard rewrite answer.

## Trade-offs

- **No wildcards** — `/etc/hosts` doesn't support `*.clinch-home.com`. Current entries are all explicit, so no regression.
- **No CNAMEs** — only A/AAAA. Revisit with CoreDNS/Unbound upstream if ever needed.
- **First playbook run bounces DNS once** (stop → lineinfile → start). Subsequent runs no-op.

## Verification

- [x] `ansible-lint Ansible/roles/adguard/` passes at production profile
- [ ] Apply to AdGuard host via `ansible-playbook ... --limit adguard`
- [ ] `grep hostsfile_enabled /opt/AdGuardHome/AdGuardHome.yaml` returns true
- [ ] `/etc/hosts` contains managed header + clinch-home entries
- [ ] `dig @<adguard-ip> hawk01.clinch-home.com +short` returns `10.1.2.11`
- [ ] **Restart regression test**: `systemctl restart AdGuardHome` twice, confirm DNS still resolves (the old bug only fully manifested on the second restart)
- [ ] Re-run playbook → zero changes, AdGuard not bounced