### PR TITLE
Scale ingress-nginx to 3 replicas with externalTrafficPolicy: Local

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/ingress-nginx/values.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/ingress-nginx/values.yml
@@ -1,4 +1,16 @@
 controller:
+  replicaCount: 3
+  minAvailable: 2
   service:
+    externalTrafficPolicy: Local
     annotations:
       metallb.io/loadBalancerIPs: 10.1.2.205
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: ingress-nginx
+          app.kubernetes.io/instance: ingress-nginx
+          app.kubernetes.io/component: controller


### PR DESCRIPTION
## Summary

- Scale `ingress-nginx` controller from 1 replica to 3 (one per Hawkfield control-plane node) with a `minAvailable: 2` PDB and a `kubernetes.io/hostname` topology spread.
- Switch the controller service to `externalTrafficPolicy: Local` so kube-proxy keeps traffic on the receiving node, the real client IP is preserved, and MetalLB L2 auto-announces the VIP only from nodes holding a healthy local endpoint.
- Single-file change to `kubernetes/flux/infrastructure/hawkfield/ingress-nginx/values.yml` — base HelmRelease and MetalLB `L2Advertisement` are untouched.

## Why

WebSocket-based services on Hawkfield (Sonarr SignalR, Radarr, Uptime Kuma) have been dropping with close code **1006** at irregular intervals (≈9s–200s between drops — not a fixed timeout). The cluster is stable at the pod/conntrack/CNI level; the failure mode is the ingress path itself:

- Only 1 `ingress-nginx` replica (on `k8s-hawk-3`).
- MetalLB VIP `10.1.2.205` is announced from `k8s-hawk-2`.
- `externalTrafficPolicy: Cluster` → every request is SNAT'd across the Calico VXLAN overlay from the VIP-holder to the controller node.
- Any brief hiccup (GC pause, scheduler blip, worker restart) severs every in-flight WebSocket cluster-wide.

HA + `Local` removes the single point of failure and the overlay hop.

## Test plan

After Flux reconciles:

- [ ] `kubectl -n ingress-nginx get deploy ingress-nginx-ingress-nginx-controller -o jsonpath='{.spec.replicas}'` → `3`
- [ ] `kubectl -n ingress-nginx get svc  ingress-nginx-ingress-nginx-controller -o jsonpath='{.spec.externalTrafficPolicy}'` → `Local`
- [ ] `kubectl -n ingress-nginx get pods -o wide` → one controller pod per node
- [ ] `kubectl get pdb -n ingress-nginx` shows PDB with `MINAVAILABLE: 2`
- [ ] `kubectl -n ingress-nginx get endpointslice` shows one endpoint per node
- [ ] Open Sonarr in a browser for 5+ min — no repeating `1006` SignalR reconnects in the console
- [ ] Repeat for Radarr and Uptime Kuma

Rollback is a one-line revert of the values.yml commit; Flux will re-reconcile.