### PR TITLE
Fix ingress-nginx topology spread labelSelector

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/ingress-nginx/values.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/ingress-nginx/values.yml
@@ -12,5 +12,4 @@ controller:
       labelSelector:
         matchLabels:
           app.kubernetes.io/name: ingress-nginx
-          app.kubernetes.io/instance: ingress-nginx
           app.kubernetes.io/component: controller


### PR DESCRIPTION
## Summary

Follow-up to #285. After that PR merged, all three controller pods scheduled onto `k8s-hawk-1` instead of spreading one per node. The `topologySpreadConstraints.labelSelector` in `hawkfield/ingress-nginx/values.yml` used `app.kubernetes.io/instance: ingress-nginx`, but the controller pods' actual label is `app.kubernetes.io/instance: ingress-nginx-ingress-nginx` — Flux names the Helm release `<namespace>-<name>` when the HelmRelease has no explicit `releaseName`, and the chart propagates that into the instance label.

A selector that matches zero pods makes every domain look empty to the scheduler, so `maxSkew: 1` is trivially satisfied and all replicas piled onto the highest-scoring node.

Fix: drop the instance label and keep `name: ingress-nginx` + `component: controller`, which uniquely identifies the controller pods without depending on the Helm release name.

## Test plan

- [ ] After Flux reconciles, `kubectl -n ingress-nginx get pods -o wide` shows one controller pod per node (`k8s-hawk-1`, `k8s-hawk-2`, `k8s-hawk-3`)
- [ ] `kubectl -n ingress-nginx get endpointslice` shows three endpoints, one per node IP
- [ ] MetalLB is free to announce the VIP from any of the three nodes
- [ ] WebSocket smoke test (Sonarr / Radarr / Uptime Kuma) still clean