### PR TITLE
Add tag-gated AdGuard admin password rotation

### DIFF
--- a/.github/workflows/ansible-adguard.yaml
+++ b/.github/workflows/ansible-adguard.yaml
@@ -9,6 +9,19 @@ on:
       - '.github/workflows/ansible-adguard.yaml'
       - 'Ansible/**'
   workflow_dispatch:
+    inputs:
+      site:
+        description: 'Target site (default: both)'
+        type: choice
+        options:
+          - all
+          - hawkfield
+          - london
+        default: all
+      tags:
+        description: 'Ansible --tags (e.g. rotate-password). Leave empty for normal run.'
+        type: string
+        default: ''
 concurrency:
   group: "adguard-${{ github.event.inputs.site || 'all' }}"
 jobs:
@@ -17,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        site: [hawkfield, london]
+        site: ${{ fromJSON(inputs.site == 'hawkfield' && '["hawkfield"]' || inputs.site == 'london' && '["london"]' || '["hawkfield","london"]') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -62,7 +75,10 @@ jobs:
         env:
           PROXMOX_TOKEN_SECRET: ${{ matrix.site == 'hawkfield' && secrets.PROXMOX_TOKEN_HAWKFIELD_ANSIBLE || secrets.PROXMOX_TOKEN_LONDON_ANSIBLE }}
           ADGUARD_ADMIN_PASSWORD: ${{ matrix.site == 'hawkfield' && secrets.ADGUARD_ADMIN_PASSWORD_HAWKFIELD || secrets.ADGUARD_ADMIN_PASSWORD_LONDON }}
+          ANSIBLE_TAGS: ${{ inputs.tags }}
         run: |
-          ansible-playbook adguard.yml \
-            --inventory inventory/${{ matrix.site }}.proxmox.yml \
-            --vault-password-file vault
+          args=(--inventory inventory/${{ matrix.site }}.proxmox.yml --vault-password-file vault)
+          if [ -n "$ANSIBLE_TAGS" ]; then
+            args+=(--tags "$ANSIBLE_TAGS")
+          fi
+          ansible-playbook adguard.yml "${args[@]}"

--- a/Ansible/roles/adguard/tasks/main.yml
+++ b/Ansible/roles/adguard/tasks/main.yml
@@ -4,3 +4,6 @@
 
 - name: Configure AdGuard Home
   ansible.builtin.import_tasks: configure.yml
+
+- name: Rotate AdGuard Home admin password (opt-in via tag)
+  ansible.builtin.import_tasks: rotate-password.yml

--- a/Ansible/roles/adguard/tasks/rotate-password.yml
+++ b/Ansible/roles/adguard/tasks/rotate-password.yml
@@ -1,0 +1,35 @@
+---
+- name: Stop AdGuardHome before rotating admin password
+  ansible.builtin.systemd:
+    name: AdGuardHome
+    state: stopped
+  tags:
+    - never
+    - rotate-password
+
+- name: Compute new bcrypt hash for admin password
+  ansible.builtin.set_fact:
+    adguard_admin_password_hash: >-
+      {{ adguard_admin_password | password_hash('bcrypt') }}
+  no_log: true
+  tags:
+    - never
+    - rotate-password
+
+- name: Replace admin password in AdGuardHome.yaml
+  ansible.builtin.replace:
+    path: /opt/AdGuardHome/AdGuardHome.yaml
+    regexp: '(- name: {{ adguard_admin_username }}\n    password: )\S+'
+    replace: '\g<1>{{ adguard_admin_password_hash }}'
+  no_log: true
+  tags:
+    - never
+    - rotate-password
+
+- name: Start AdGuardHome after rotating admin password
+  ansible.builtin.systemd:
+    name: AdGuardHome
+    state: started
+  tags:
+    - never
+    - rotate-password


### PR DESCRIPTION
## Summary

- New `tasks/rotate-password.yml` in the `adguard` role: stops the service, regenerates the bcrypt hash, replaces the `password:` line under the admin user in `/opt/AdGuardHome/AdGuardHome.yaml`, restarts the service. All tasks tagged `never` + `rotate-password` so routine runs are inert.
- Wires the new file into `tasks/main.yml`; tag inheritance keeps it opt-in.
- Workflow gains `workflow_dispatch.inputs.site` (`all` / `hawkfield` / `london`) and `inputs.tags`, so we can target one site with one tag from the Actions UI. Push-triggered behaviour is unchanged (both sites, no tags).

## Why

Angus forgot the admin passwords for both AdGuard Home instances. The bootstrap template runs with `force: false`, so a normal Ansible run won't re-template the password. The rotation task is the deliberate, IaC-driven path to set a new password (sourced from the per-site GH secrets, which have just been updated from Bitwarden).

## Test plan

- [ ] Lint passes (`ansible-lint` green locally).
- [ ] Trigger workflow with `site=hawkfield`, `tags=rotate-password`; run goes green.
- [ ] `POST /control/login` to Hawkfield with the new password returns 200; old password returns 403.
- [ ] Repeat for London (verify in browser since Dave can't reach the LAN there).
- [ ] Routine push-triggered run after merge leaves passwords unchanged (rotation tasks skipped via `never`).