### PR TITLE
Use YAML-safe rotation script for AdGuard admin password

### DIFF
--- a/Ansible/roles/adguard/files/rotate_admin_password.py
+++ b/Ansible/roles/adguard/files/rotate_admin_password.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Rotate the AdGuard Home admin password in /opt/AdGuardHome/AdGuardHome.yaml.
+
+Reads username and new password from environment variables, replaces the user's
+bcrypt hash, writes back, and verifies the hash matches the new password.
+
+Run by the `adguard` Ansible role's rotate-password task — not intended for
+direct use.
+"""
+import os
+import sys
+
+import yaml
+
+try:
+    from passlib.hash import bcrypt as _bcrypt
+
+    def _hash(pw: str) -> str:
+        return _bcrypt.hash(pw)
+
+    def _verify(pw: str, h: str) -> bool:
+        return _bcrypt.verify(pw, h)
+
+except ImportError:
+    import bcrypt as _b
+
+    def _hash(pw: str) -> str:
+        return _b.hashpw(pw.encode(), _b.gensalt()).decode()
+
+    def _verify(pw: str, h: str) -> bool:
+        return _b.checkpw(pw.encode(), h.encode())
+
+
+CONFIG = "/opt/AdGuardHome/AdGuardHome.yaml"
+
+
+def main() -> int:
+    username = os.environ["ADGUARD_USER"]
+    password = os.environ["ADGUARD_PW"]
+
+    with open(CONFIG) as f:
+        cfg = yaml.safe_load(f)
+
+    users = cfg.get("users") or []
+    user = next((u for u in users if u.get("name") == username), None)
+    if user is None:
+        print(f"FAIL: user '{username}' not in {CONFIG}", file=sys.stderr)
+        return 1
+
+    user["password"] = _hash(password)
+
+    with open(CONFIG, "w") as f:
+        yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=False)
+
+    with open(CONFIG) as f:
+        cfg = yaml.safe_load(f)
+    user = next(u for u in cfg["users"] if u["name"] == username)
+    if not _verify(password, user["password"]):
+        print("FAIL: post-write verify did not match", file=sys.stderr)
+        return 2
+
+    print("rotated and verified")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Ansible/roles/adguard/files/rotate_admin_password.py
+++ b/Ansible/roles/adguard/files/rotate_admin_password.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Rotate the AdGuard Home admin password in /opt/AdGuardHome/AdGuardHome.yaml.
 
-Reads username and new password from environment variables, replaces the user's
-bcrypt hash, writes back, and verifies the hash matches the new password.
+Reads the username and the new password from environment variables, replaces
+the user's bcrypt hash, writes back, and verifies the stored hash against the
+input password before exiting 0.
 
 Run by the `adguard` Ansible role's rotate-password task — not intended for
 direct use.
@@ -10,44 +11,25 @@ direct use.
 import os
 import sys
 
+import bcrypt
 import yaml
-
-try:
-    from passlib.hash import bcrypt as _bcrypt
-
-    def _hash(pw: str) -> str:
-        return _bcrypt.hash(pw)
-
-    def _verify(pw: str, h: str) -> bool:
-        return _bcrypt.verify(pw, h)
-
-except ImportError:
-    import bcrypt as _b
-
-    def _hash(pw: str) -> str:
-        return _b.hashpw(pw.encode(), _b.gensalt()).decode()
-
-    def _verify(pw: str, h: str) -> bool:
-        return _b.checkpw(pw.encode(), h.encode())
-
 
 CONFIG = "/opt/AdGuardHome/AdGuardHome.yaml"
 
 
 def main() -> int:
     username = os.environ["ADGUARD_USER"]
-    password = os.environ["ADGUARD_PW"]
+    password = os.environ["ADGUARD_PW"].encode()
 
     with open(CONFIG) as f:
         cfg = yaml.safe_load(f)
 
-    users = cfg.get("users") or []
-    user = next((u for u in users if u.get("name") == username), None)
+    user = next((u for u in cfg.get("users") or [] if u.get("name") == username), None)
     if user is None:
         print(f"FAIL: user '{username}' not in {CONFIG}", file=sys.stderr)
         return 1
 
-    user["password"] = _hash(password)
+    user["password"] = bcrypt.hashpw(password, bcrypt.gensalt()).decode()
 
     with open(CONFIG, "w") as f:
         yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=False)
@@ -55,7 +37,7 @@ def main() -> int:
     with open(CONFIG) as f:
         cfg = yaml.safe_load(f)
     user = next(u for u in cfg["users"] if u["name"] == username)
-    if not _verify(password, user["password"]):
+    if not bcrypt.checkpw(password, user["password"].encode()):
         print("FAIL: post-write verify did not match", file=sys.stderr)
         return 2
 

--- a/Ansible/roles/adguard/tasks/rotate-password.yml
+++ b/Ansible/roles/adguard/tasks/rotate-password.yml
@@ -1,4 +1,13 @@
 ---
+- name: Ensure python bcrypt is available on the target
+  ansible.builtin.apt:
+    name: python3-bcrypt
+    state: present
+    update_cache: false
+  tags:
+    - never
+    - rotate-password
+
 - name: Stop AdGuardHome before rotating admin password
   ansible.builtin.systemd:
     name: AdGuardHome
@@ -7,21 +16,14 @@
     - never
     - rotate-password
 
-- name: Compute new bcrypt hash for admin password
-  ansible.builtin.set_fact:
-    adguard_admin_password_hash: >-
-      {{ adguard_admin_password | password_hash('bcrypt') }}
-  no_log: true
-  tags:
-    - never
-    - rotate-password
-
-- name: Replace admin password in AdGuardHome.yaml
-  ansible.builtin.replace:
-    path: /opt/AdGuardHome/AdGuardHome.yaml
-    regexp: '(- name: {{ adguard_admin_username }}\n    password: )\S+'
-    replace: '\g<1>{{ adguard_admin_password_hash }}'
-  no_log: true
+- name: Rotate and verify admin password in AdGuardHome.yaml
+  ansible.builtin.script:
+    cmd: rotate_admin_password.py
+    executable: python3
+  environment:
+    ADGUARD_USER: "{{ adguard_admin_username }}"
+    ADGUARD_PW: "{{ adguard_admin_password }}"
+  changed_when: true
   tags:
     - never
     - rotate-password


### PR DESCRIPTION
## Summary

- Replaces the regex-based `ansible.builtin.replace` step with a python script (`files/rotate_admin_password.py`) shipped via `ansible.builtin.script`.
- The script loads `AdGuardHome.yaml` with PyYAML, updates the admin user's `password:` field with a fresh bcrypt hash, writes the file back, then re-reads it and **verifies the stored hash against the input password** before exiting 0.
- Adds `python3-bcrypt` as a target dependency (already present on Debian/Ubuntu).

## Why

The previous regex approach reported `changed: true` but the resulting password did not authenticate against the AdGuard login API (returned 403). YAML-safe parsing eliminates indentation-format assumptions, and the post-write verify means the task only succeeds when the rotation is observably correct.

## Test plan

- [ ] Trigger workflow with `site=hawkfield`, `tags=rotate-password`; run goes green (the script self-verifies; non-matching hash would fail the task).
- [ ] `POST /control/login` to Hawkfield with the Bitwarden password returns 200.
- [ ] Repeat for London (verify in browser).