### PR TITLE
Add python3-yaml dep and always-start AdGuardHome after rotation

### DIFF
--- a/Ansible/roles/adguard/tasks/rotate-password.yml
+++ b/Ansible/roles/adguard/tasks/rotate-password.yml
@@ -1,37 +1,35 @@
 ---
-- name: Ensure python bcrypt is available on the target
+- name: Ensure python deps for rotation are available on the target
   ansible.builtin.apt:
-    name: python3-bcrypt
+    name:
+      - python3-bcrypt
+      - python3-yaml
     state: present
     update_cache: false
   tags:
     - never
     - rotate-password
 
-- name: Stop AdGuardHome before rotating admin password
-  ansible.builtin.systemd:
-    name: AdGuardHome
-    state: stopped
+- name: Stop, rotate, and start AdGuardHome
   tags:
     - never
     - rotate-password
+  block:
+    - name: Stop AdGuardHome before rotating admin password
+      ansible.builtin.systemd:
+        name: AdGuardHome
+        state: stopped
 
-- name: Rotate and verify admin password in AdGuardHome.yaml
-  ansible.builtin.script:
-    cmd: rotate_admin_password.py
-    executable: python3
-  environment:
-    ADGUARD_USER: "{{ adguard_admin_username }}"
-    ADGUARD_PW: "{{ adguard_admin_password }}"
-  changed_when: true
-  tags:
-    - never
-    - rotate-password
-
-- name: Start AdGuardHome after rotating admin password
-  ansible.builtin.systemd:
-    name: AdGuardHome
-    state: started
-  tags:
-    - never
-    - rotate-password
+    - name: Rotate and verify admin password in AdGuardHome.yaml
+      ansible.builtin.script:
+        cmd: rotate_admin_password.py
+        executable: python3
+      environment:
+        ADGUARD_USER: "{{ adguard_admin_username }}"
+        ADGUARD_PW: "{{ adguard_admin_password }}"
+      changed_when: true
+  always:
+    - name: Start AdGuardHome after rotation attempt
+      ansible.builtin.systemd:
+        name: AdGuardHome
+        state: started


### PR DESCRIPTION
## Summary

- Adds `python3-yaml` to the rotation deps step (the script needs `import yaml`; previous run failed with `ModuleNotFoundError: No module named 'yaml'`).
- Wraps stop + rotate in a `block` with `always: start` so an exception in the script doesn't leave AdGuardHome down.

## Test plan

- [ ] Trigger `ansible-adguard` with `site=hawkfield`, `tags=rotate-password`; run goes green and login API returns 200 for the Bitwarden password.

## Context

Hawkfield AdGuardHome is currently stopped after the failed rotation attempt in run 25637887849 — this PR is required to recover.