### PR TITLE
Add multi-queue virtio NICs and irqbalance to ubuntu-server VMs

### DIFF
--- a/Ansible/roles/base/tasks/main.yml
+++ b/Ansible/roles/base/tasks/main.yml
@@ -9,3 +9,6 @@
 
     - name: "Tools"
       ansible.builtin.include_tasks: tools.yml
+
+    - name: "Network tuning"
+      ansible.builtin.include_tasks: network-tuning.yml

--- a/Ansible/roles/base/tasks/network-tuning.yml
+++ b/Ansible/roles/base/tasks/network-tuning.yml
@@ -1,0 +1,12 @@
+---
+- name: "Install irqbalance"
+  ansible.builtin.apt:
+    name: irqbalance
+    state: present
+    update_cache: true
+
+- name: "Enable and start irqbalance"
+  ansible.builtin.systemd_service:
+    name: irqbalance
+    enabled: true
+    state: started

--- a/terraform/modules/ubuntu-server/main.tf
+++ b/terraform/modules/ubuntu-server/main.tf
@@ -6,6 +6,10 @@ terraform {
   }
 }
 
+locals {
+  queues = var.queues != null ? var.queues : var.cores
+}
+
 resource "proxmox_vm_qemu" "ubuntu_server" {
   name        = var.name
   target_node = var.target_node
@@ -27,6 +31,7 @@ resource "proxmox_vm_qemu" "ubuntu_server" {
     bridge = var.network_bridge
     model  = "virtio"
     mtu    = 1 # Inherit from bridge
+    queues = local.queues
   }
 
   os_type            = "ubuntu"

--- a/terraform/modules/ubuntu-server/variables.tf
+++ b/terraform/modules/ubuntu-server/variables.tf
@@ -56,6 +56,11 @@ variable "network_bridge" {
   default     = "vmbr1"
   type        = string
 }
+variable "queues" {
+  description = "Number of virtio NIC queues; null means match `cores`"
+  default     = null
+  type        = number
+}
 
 # DISKS
 variable "boot_disk_size" {


### PR DESCRIPTION
Closes #293

## Summary

- `terraform/modules/ubuntu-server`: new optional `queues` variable (default `null` → matches `var.cores`) wired into the existing virtio `network` block. Module callers in `hawkfield-kubernetes/`, `hawkfield/`, and `london/` are unchanged.
- `Ansible/roles/base`: new `network-tuning.yml` installs `irqbalance` and enables/starts it via `systemd_service`, included after the existing Tools step.

Effective per-VM queue counts:

| VM | cores | queues |
| -- | ----- | ------ |
| k8s-hawk-1/2/3 | 10 | 10 |
| claude-hawk-1  |  4 |  4 |
| k8s-lon-1      |  4 |  4 |

LXC containers (`dns-hawk-1`, `dns-lon-1`) use a different module and are out of scope.

## Context

From the WS-1006 audit (2026-05-13): single-queue virtio NICs cap net softirq processing at one CPU per VM. This is hygiene from that investigation — not load-bearing for WS-1006 (Stage 5 cleared the host stack), so it can ship at a relaxed pace.

Telmate/proxmox v3.0.2-rc06 supports `queues` in the `network` block. PVE applies the new queue count on the next VM **start**, not live — Terraform apply will show in-place updates but actual queue count won't change until each VM is stopped and started.

## Rollout (after CI green)

1. `terraform.yaml` workflow plans + applies (expect in-place updates only — `queues = 0 -> N` on the five VMs).
2. `ansible-base.yaml` workflow installs `irqbalance` everywhere. Harmless on VMs that haven't restarted.
3. Manual rolling stop/start, one host at a time:
   - For each k8s-hawk: `kubectl drain <node> --ignore-daemonsets --delete-emptydir-data`, `qm stop <vmid>` on the hawk host, `qm start <vmid>`, wait for `kubectl get nodes` Ready, `kubectl uncordon <node>`.
   - For `claude-hawk-1` and `k8s-lon-1`: `qm stop` / `qm start` during a low-traffic window.

Note: must be a Proxmox-side stop/start, not a guest reboot — `queues=` is applied at VM start.

## Test plan

- [ ] CI: `terraform-plan.yaml` shows in-place `+ queues = N` updates only — no replacement/destroy.
- [ ] CI: `ansible-lint.yaml` passes.
- [ ] After merge + `terraform.yaml` apply: re-plan is clean.
- [ ] After merge + `ansible-base.yaml` run: `systemctl is-active irqbalance` reports `active` on every base host.
- [ ] After each VM stop/start: `ethtool -l <iface>` reports `Combined: N` matching `cores`; `cat /proc/interrupts | grep virtio` shows multiple per-queue lines pinned across different CPUs under load.
- [ ] Load check on a k8s-hawk: `iperf3 -c <peer> -P 8` + `mpstat -P ALL 1` — softirq% spreads across CPUs rather than pinning one.