### PR TITLE
Add hawkfield-kubernetes to terraform plan/apply matrices

### DIFF
--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        site: [hawkfield, london]
+        site: [hawkfield, hawkfield-kubernetes, london]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -58,7 +58,7 @@ jobs:
         run: |
           terraform plan -no-color \
             -var-file=providers.tfvars \
-            -var="pm_api_token_secret=${{ matrix.site == 'hawkfield' && secrets.PROXMOX_TOKEN_HAWKFIELD_TERRAFORM || secrets.PROXMOX_TOKEN_LONDON_TERRAFORM }}" \
+            -var="pm_api_token_secret=${{ startsWith(matrix.site, 'hawkfield') && secrets.PROXMOX_TOKEN_HAWKFIELD_TERRAFORM || secrets.PROXMOX_TOKEN_LONDON_TERRAFORM }}" \
             -out=tfplan 2>&1 | tee plan_output.txt
 
       - name: Save plan output
@@ -84,7 +84,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const sites = ['hawkfield', 'london'];
+            const sites = ['hawkfield', 'hawkfield-kubernetes', 'london'];
             let body = '## 🏗️ Terraform Plan Results\n\n';
 
             for (const site of sites) {

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        site: [hawkfield, london]
+        site: [hawkfield, hawkfield-kubernetes, london]
     concurrency:
       group: "cluster-${{ matrix.site }}"
     steps:
@@ -50,7 +50,7 @@ jobs:
       - name: Terraform Plan
         working-directory: terraform/${{ matrix.site }}
         run: |
-          terraform plan -out=tfplan -var-file=providers.tfvars -var="pm_api_token_secret=${{ matrix.site == 'hawkfield' && secrets.PROXMOX_TOKEN_HAWKFIELD_TERRAFORM || secrets.PROXMOX_TOKEN_LONDON_TERRAFORM }}"
+          terraform plan -out=tfplan -var-file=providers.tfvars -var="pm_api_token_secret=${{ startsWith(matrix.site, 'hawkfield') && secrets.PROXMOX_TOKEN_HAWKFIELD_TERRAFORM || secrets.PROXMOX_TOKEN_LONDON_TERRAFORM }}"
 
       - name: Artifact Upload
         uses: actions/upload-artifact@v7
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        site: [hawkfield, london]
+        site: [hawkfield, hawkfield-kubernetes, london]
     concurrency:
       group: "cluster-${{ matrix.site }}"
     steps:
@@ -108,4 +108,4 @@ jobs:
       - name: Terraform Apply
         working-directory: terraform/${{ matrix.site }}
         run: |
-          terraform apply -auto-approve -var-file=providers.tfvars -var="pm_api_token_secret=${{ matrix.site == 'hawkfield' && secrets.PROXMOX_TOKEN_HAWKFIELD_TERRAFORM || secrets.PROXMOX_TOKEN_LONDON_TERRAFORM }}" tfplan/tfplan
+          terraform apply -auto-approve -var-file=providers.tfvars -var="pm_api_token_secret=${{ startsWith(matrix.site, 'hawkfield') && secrets.PROXMOX_TOKEN_HAWKFIELD_TERRAFORM || secrets.PROXMOX_TOKEN_LONDON_TERRAFORM }}" tfplan/tfplan


### PR DESCRIPTION
## Summary

- Add `hawkfield-kubernetes` to the matrix in `terraform-plan.yaml` and `terraform.yaml` (both plan and apply jobs), plus the PR-comment `sites` array.
- Replace the inline `matrix.site == 'hawkfield'` ternary with `startsWith(matrix.site, 'hawkfield')` so both hawkfield roots use `PROXMOX_TOKEN_HAWKFIELD_TERRAFORM` (same token already used by `cluster-rebuild.yaml` for this directory).

## Why

Commit `1d138dc` (2026-04-05, "Split k8s VMs into terraform/hawkfield-kubernetes and scope cluster rebuild") moved `k8s-hawk-1/2/3` into a new Terraform root with its own state, but only updated `cluster-rebuild.yaml`. The day-to-day PR plan and master-apply workflows still iterated `[hawkfield, london]`, so any change to the k8s-hawk VMs has been silently skipped for the past six weeks.

Noticed via #296: the PR's plan comment showed only `claude-hawk-1` and `k8s-lon-1` being updated, even though the multi-queue change targets five VMs including all three k8s-hawk nodes.

## Test plan

- [ ] `terraform-plan.yaml` runs against three sites on this PR. Bot comment shows a `hawkfield-kubernetes` section with "No changes" (nothing in this branch touches that root).
- [ ] After merge, `terraform.yaml` plan + apply succeeds for all three sites with no diff.
- [ ] Rebase #296 onto master and confirm its bot comment now includes `hawkfield-kubernetes` with in-place `~ queues = 0 -> 10` on `k8s-hawk-1/2/3`.