### PR TITLE
Enable nesting feature on LXC containers to fix logind

### DIFF
--- a/terraform/modules/lxc-container/main.tf
+++ b/terraform/modules/lxc-container/main.tf
@@ -20,6 +20,10 @@ resource "proxmox_lxc" "container" {
   start        = true
   onboot       = true
 
+  features {
+    nesting = true
+  }
+
   password = var.password
 
   rootfs {


### PR DESCRIPTION
Fixes #281

## Root cause

`systemd-logind` on Debian 12 uses `ProtectProc=`/`ProcSubset=`, which mount a private `/proc`. In an unprivileged LXC without the `nesting` feature, the user-namespace blocks that mount, so logind fails with `status=226/NAMESPACE` and is restarted 5 times before systemd gives up. PAM then blocks for the full 25s `org.freedesktop.login1` dbus activation timeout on every SSH login.

## Change

Add `features { nesting = true }` to `terraform/modules/lxc-container/main.tf`. All LXC containers in this repo are unprivileged Debian 12 and hit the same logind failure, so it's hardcoded in the module rather than threaded through `variables.tf`.

`dns-lon-1` and `dns-hawk-1` pick up the fix automatically.

## Post-merge

DNS containers need a reboot to pick up the feature flag. Telmate's `proxmox_lxc` applies `features` in place; if Terraform doesn't trigger a reboot itself, run `pct reboot <vmid>` on the relevant Proxmox node.