### PR TITLE
Strip control-plane exclude label so MetalLB can L2-announce

### DIFF
--- a/Ansible/kubernetes.yml
+++ b/Ansible/kubernetes.yml
@@ -163,6 +163,40 @@
         KUBECONFIG: /etc/kubernetes/admin.conf
       changed_when: true
 
+- name: "Allow LoadBalancer announcement from control-plane nodes"
+  hosts: kube_control_plane
+  become: true
+  run_once: true
+  tasks:
+    - name: "Install Kubernetes Python"
+      ansible.builtin.package:
+        name: python3-kubernetes
+        state: present
+
+    - name: "Get control-plane nodes"
+      kubernetes.core.k8s_info:
+        kind: Node
+        label_selectors:
+          - "node-role.kubernetes.io/control-plane"
+      environment:
+        KUBECONFIG: /etc/kubernetes/admin.conf
+      register: cp_nodes
+
+    - name: "Remove exclude-from-external-load-balancers label for MetalLB L2"
+      kubernetes.core.k8s:
+        state: patched
+        merge_type: merge
+        definition:
+          apiVersion: v1
+          kind: Node
+          metadata:
+            name: "{{ item }}"
+            labels:
+              node.kubernetes.io/exclude-from-external-load-balancers: null
+      loop: "{{ cp_nodes.resources | map(attribute='metadata.name') | list }}"
+      environment:
+        KUBECONFIG: /etc/kubernetes/admin.conf
+
 - name: "Bootstrap Flux"
   hosts: kube_control_plane
   become: true

--- a/kubernetes/flux/infrastructure/base/metallb/README.md
+++ b/kubernetes/flux/infrastructure/base/metallb/README.md
@@ -12,6 +12,16 @@ Do the following from a kubernetes master as the user `kubernetes`
    sed -e "s/strictARP: false/strictARP: true/" | \
    kubectl apply -f - -n kube-system
    ```
+
+   > **All-control-plane clusters:** MetalLB v0.15+ will not L2-announce a VIP
+   > from any node carrying the `node.kubernetes.io/exclude-from-external-load-balancers`
+   > label, which kubeadm adds to every control-plane node. On a cluster where
+   > all nodes are control-plane (Hawkfield, London), this leaves no eligible
+   > speaker and every LoadBalancer VIP goes dark. The label is stripped
+   > automatically by the **"Allow LoadBalancer announcement from control-plane
+   > nodes"** play in `Ansible/kubernetes.yml`, which re-runs on every cluster
+   > rebuild / Kubespray upgrade. See [clincha-org/clincha#294](https://github.com/clincha-org/clincha/issues/294).
+
 2. Install using Helm
     ```bash
     helm repo add metallb https://metallb.github.io/metallb


### PR DESCRIPTION
## Problem

On 2026-05-31 all three Hawkfield nodes rebooted simultaneously and **every LoadBalancer VIP went dark** (`10.1.2.200/.201/.205` — longhorn, homepage, ingress-nginx). Root cause (confirmed, #294):

- Hawkfield/London are **all-control-plane** clusters. Kubeadm labels every control-plane node with `node.kubernetes.io/exclude-from-external-load-balancers`.
- **MetalLB v0.15+ honours that label and refuses to L2-announce from a labelled node.** With every node excluded there is no eligible speaker → no `ServiceL2Status`, no ARP responder → VIPs unreachable. MetalLB had effectively never been announcing; the VIPs survived only on an `arp_ignore` kernel leak on hawk-1 until the reboot reset `strictARP=1` everywhere and exposed it.
- There is **no MetalLB/Helm option** to ignore the label — the speaker reads it directly. The only fix is removing the label from the nodes.

A live hotfix (`kubectl label node … exclude-…-`) restored service, but it isn't in IaC, so a cluster rebuild or Kubeadm upgrade would silently re-add the label and re-break L2.

## Change

- **`Ansible/kubernetes.yml`** — new play **"Allow LoadBalancer announcement from control-plane nodes"**, placed between the kube-proxy strictARP step and the Flux bootstrap (so nodes are eligible before Flux deploys MetalLB). It discovers control-plane nodes at runtime via `k8s_info` and removes the label with an idempotent RFC 7386 merge patch (key set to `null`) — a no-op when the label is already absent. Mirrors the existing `kubernetes.core.k8s` + `python3-kubernetes` + `run_once` patterns already in the file.
- **`kubernetes/flux/infrastructure/base/metallb/README.md`** — documents the all-control-plane requirement and cross-references #294.

Generic by design: targets `kube_control_plane` and discovers node names at runtime, so the single play protects both Hawkfield and London, and re-applies on every `cluster-rebuild` `configure` job and every Kubespray re-run / version bump — exactly the events that re-add the label.

## Verification

- `yamllint -c .yamllint Ansible/kubernetes.yml` and `ansible-lint Ansible/kubernetes.yml`: the new play adds **zero** new violations (remaining reports are pre-existing on `master`, all outside the inserted lines).
- Live cluster (post-hotfix) read-only confirmation:
  - exclude label `ABSENT` on all three nodes.
  - `servicel2status`: exactly one announcer per VIP (homepage→hawk-2, ingress-nginx→hawk-1, longhorn→hawk-3).

## Out of scope

- Why all three hawks rebooted within ~1s (suspected power event).
- Pre-existing hardcoded `kube_version`/`cluster_name: hawkfield` in `kubernetes.yml`.

Closes #294