### PR TITLE
terraform/minio: adopt existing buckets, policies, users & svcacct (drift)

### DIFF
--- a/terraform/minio/imports.tf
+++ b/terraform/minio/imports.tf
@@ -1,0 +1,65 @@
+# Import blocks adopt objects that already exist in the live MinIO server so
+# that `terraform plan` reconciles state without destroying or recreating them.
+# The "kubeconfigs" bucket and the read-write "kubeconfig" service account are
+# already tracked in state, so they are intentionally not imported here.
+#
+# Import ID formats (aminueza/minio v3.5.2, all passthrough except attachments):
+#   minio_s3_bucket               -> bucket name
+#   minio_iam_policy              -> policy name
+#   minio_iam_user                -> user name
+#   minio_iam_user_policy_attachment -> "<user-name>/<policy-name>"
+#   minio_iam_service_account     -> access key
+
+import {
+  to = minio_s3_bucket.loki_data
+  id = "loki-data"
+}
+
+import {
+  to = minio_s3_bucket.terraform
+  id = "terraform"
+}
+
+import {
+  to = minio_iam_policy.kubeconfig_ro
+  id = "kubeconfig-ro"
+}
+
+import {
+  to = minio_iam_policy.loki_rw
+  id = "loki-rw"
+}
+
+import {
+  to = minio_iam_policy.terraform_state
+  id = "terraform-state"
+}
+
+import {
+  to = minio_iam_user.loki
+  id = "loki"
+}
+
+import {
+  to = minio_iam_user.terraform
+  id = "terraform"
+}
+
+import {
+  to = minio_iam_user_policy_attachment.loki
+  id = "loki/loki-rw"
+}
+
+import {
+  to = minio_iam_user_policy_attachment.terraform
+  id = "terraform/terraform-state"
+}
+
+# Read-only "Dave" kubeconfig service account. Access key CJX4INKLQUXY9IKZHC5A
+# is the read-only account (s3:ListBucket/GetBucketLocation/GetObject); the
+# read-write account ALCRY0NI68NAE0CK8PHZ is already managed as
+# minio_iam_service_account.kubeconfig and is therefore not imported.
+import {
+  to = minio_iam_service_account.kubeconfig_ro
+  id = "CJX4INKLQUXY9IKZHC5A"
+}

--- a/terraform/minio/main.tf
+++ b/terraform/minio/main.tf
@@ -1,9 +1,27 @@
+# Buckets ---------------------------------------------------------------------
+
 resource "minio_s3_bucket" "kubeconfigs" {
   bucket = "kubeconfigs"
 }
 
+resource "minio_s3_bucket" "loki_data" {
+  bucket = "loki-data"
+}
+
+# This is the bucket backing the Terraform S3 state backend (providers.tf).
+# It is managed here so it is not orphaned, but must never be destroyed.
+resource "minio_s3_bucket" "terraform" {
+  bucket = "terraform"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Policies --------------------------------------------------------------------
+
 resource "minio_iam_policy" "kubeconfig_rw" {
-  name   = "kubeconfig-rw"
+  name = "kubeconfig-rw"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -21,7 +39,133 @@ resource "minio_iam_policy" "kubeconfig_rw" {
   })
 }
 
+resource "minio_iam_policy" "kubeconfig_ro" {
+  name = "kubeconfig-ro"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          "arn:aws:s3:::${minio_s3_bucket.kubeconfigs.bucket}",
+          "arn:aws:s3:::${minio_s3_bucket.kubeconfigs.bucket}/*",
+        ]
+      }
+    ]
+  })
+}
+
+resource "minio_iam_policy" "loki_rw" {
+  name = "loki-rw"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          "arn:aws:s3:::${minio_s3_bucket.loki_data.bucket}",
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:PutObject",
+        ]
+        Resource = [
+          "arn:aws:s3:::${minio_s3_bucket.loki_data.bucket}/*",
+        ]
+      }
+    ]
+  })
+}
+
+resource "minio_iam_policy" "terraform_state" {
+  name = "terraform-state"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        # Action order mirrors the live policy to avoid a cosmetic diff.
+        Action = [
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          "arn:aws:s3:::${minio_s3_bucket.terraform.bucket}",
+          "arn:aws:s3:::${minio_s3_bucket.terraform.bucket}/*",
+        ]
+      }
+    ]
+  })
+}
+
+# Users -----------------------------------------------------------------------
+
+# Existing user secrets cannot be read back from MinIO. The secret is supplied
+# out-of-band via TF_VAR_* and ignored after import so it is never rotated.
+variable "loki_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "terraform_user_secret" {
+  type      = string
+  sensitive = true
+}
+
+resource "minio_iam_user" "loki" {
+  name   = "loki"
+  secret = var.loki_secret
+
+  lifecycle {
+    ignore_changes = [secret]
+  }
+}
+
+resource "minio_iam_user" "terraform" {
+  name   = "terraform"
+  secret = var.terraform_user_secret
+
+  lifecycle {
+    ignore_changes = [secret]
+  }
+}
+
+resource "minio_iam_user_policy_attachment" "loki" {
+  user_name   = minio_iam_user.loki.name
+  policy_name = minio_iam_policy.loki_rw.name
+}
+
+resource "minio_iam_user_policy_attachment" "terraform" {
+  user_name   = minio_iam_user.terraform.name
+  policy_name = minio_iam_policy.terraform_state.name
+}
+
+# Service accounts ------------------------------------------------------------
+
+# Read-write kubeconfig service account on the clincha parent user.
 resource "minio_iam_service_account" "kubeconfig" {
   target_user = var.minio_user
   policy      = minio_iam_policy.kubeconfig_rw.policy
+}
+
+# Read-only ("Dave") kubeconfig service account on the clincha parent user.
+resource "minio_iam_service_account" "kubeconfig_ro" {
+  target_user = var.minio_user
+  policy      = minio_iam_policy.kubeconfig_ro.policy
 }

--- a/terraform/minio/outputs.tf
+++ b/terraform/minio/outputs.tf
@@ -6,3 +6,10 @@ output "kubeconfig_secret_key" {
   value     = minio_iam_service_account.kubeconfig.secret_key
   sensitive = true
 }
+
+# Read-only ("Dave") kubeconfig service account access key. The secret key is
+# not retrievable for an imported service account, so it is not exported here.
+output "kubeconfig_ro_access_key" {
+  value     = minio_iam_service_account.kubeconfig_ro.access_key
+  sensitive = true
+}


### PR DESCRIPTION
## Summary

⚠️ **Draft — "have a go" for review in the morning.** Brings `terraform/minio/` into line with the live MinIO server (`http://10.1.2.10:9000`). Live state was re-verified with `mc admin`. Everything that exists in MinIO but was missing from config is now declared **and** adopted via `import {}` blocks so `terraform plan` reconciles state **without recreating any live infrastructure**.

## What had drifted (now added)

**Buckets**
- `loki-data`
- `terraform` — this is the bucket backing the TF S3 state backend itself. Managed here but guarded with `lifecycle { prevent_destroy = true }`.

**Policies**
- `kubeconfig-ro` — `GetBucketLocation`/`GetObject`/`ListBucket` on `kubeconfigs` (+`/*`)
- `loki-rw` — list on `loki-data`, RW objects on `loki-data/*`
- `terraform-state` — RW on `terraform` (+`/*`). Action order mirrors the live policy to avoid a cosmetic diff.

**Users** (policies attached directly in MinIO, modelled with `minio_iam_user_policy_attachment`)
- `loki` → `loki-rw`
- `terraform` → `terraform-state`

**Service account** (parent user `clincha`)
- Read-only "Dave" kubeconfig service account (`kubeconfig-ro` policy). The existing RW `kubeconfig` service account is already in state and untouched.

## Import blocks (all in `imports.tf`)

`kubeconfigs` bucket and the RW `kubeconfig` service account are already in state, so they are **not** imported. Import ID formats verified against aminueza/minio v3.5.2 source (all passthrough except attachments):

| Resource | Import ID |
|---|---|
| `minio_s3_bucket.loki_data` | `loki-data` |
| `minio_s3_bucket.terraform` | `terraform` |
| `minio_iam_policy.kubeconfig_ro` | `kubeconfig-ro` |
| `minio_iam_policy.loki_rw` | `loki-rw` |
| `minio_iam_policy.terraform_state` | `terraform-state` |
| `minio_iam_user.loki` | `loki` |
| `minio_iam_user.terraform` | `terraform` |
| `minio_iam_user_policy_attachment.loki` | `loki/loki-rw` |
| `minio_iam_user_policy_attachment.terraform` | `terraform/terraform-state` |
| `minio_iam_service_account.kubeconfig_ro` | `CJX4INKLQUXY9IKZHC5A` |

## Secrets — none committed

- No access **secret** key, user secret, or admin password appears in any tracked file. `providers.tfvars` still has **no** `minio_password` (CI injects `TF_VAR_minio_password`).
- The two service-account **access key IDs** appear in `imports.tf` — these are non-secret identifiers (needed to key the import), not credentials.
- Existing user secrets for `loki`/`terraform` **cannot be read back** from MinIO and must not be rotated. They are declared as `sensitive` variables with **no default** and `lifecycle { ignore_changes = [secret] }`, so import adopts the users without recreating or rotating them.

**Variables that need values supplied out-of-band (e.g. CI `TF_VAR_*`):**
- `TF_VAR_loki_secret`
- `TF_VAR_terraform_user_secret`

## Validation

- `terraform fmt` ✅ and `terraform validate` (`-backend=false`) ✅ — config is valid.
- `terraform plan` was **skipped**: the live `terraform` S3 user secret needed to init the backend isn't reliably available (the Bitwarden value produced a `SignatureDoesNotMatch`), and the task was explicit not to block on it. **No `terraform apply` was run.**

## Flags for review 🌅

1. **`plan` not run** — please run `terraform plan` with valid backend + `TF_VAR_*` creds to confirm all 10 imports resolve to a clean/no-op plan before applying. Watch for cosmetic JSON-policy diffs (provider should normalise, but worth a look).
2. **svcacct mapping** — confirmed live: `ALCRY0NI68NAE0CK8PHZ` = RW (`s3:*`, already managed); `CJX4INKLQUXY9IKZHC5A` = RO (the imported "Dave" account). Double-check this is the intended ro/rw split.
3. **Self-managing the state bucket** — `terraform` bucket is the state backend. It's adopted + `prevent_destroy`, but flagging in case you'd rather leave it out of config entirely.
4. **Default branch** — opened against `master` (the repo's actual default), not `main`.
5. **Commit credit** — per `CLAUDE.md` ("do not credit Claude in commits/PRs") I omitted the `Co-Authored-By` trailer, which differs from the task brief. Say the word and I'll add it.
