### PR TITLE
CI: add ansible-monitoring workflow to deploy the Alloy host role

### DIFF
--- a/.github/workflows/ansible-monitoring.yaml
+++ b/.github/workflows/ansible-monitoring.yaml
@@ -1,0 +1,76 @@
+name: Ansible host monitoring
+permissions:
+  contents: read
+on:
+  push:
+    branches:
+      - "master"
+    paths:
+      - '.github/workflows/ansible-monitoring.yaml'
+      - 'Ansible/**'
+  workflow_dispatch:
+    inputs:
+      site:
+        description: 'Target site (default: both)'
+        type: choice
+        options:
+          - all
+          - hawkfield
+          - london
+        default: all
+concurrency:
+  group: "monitoring-${{ github.event.inputs.site || 'all' }}"
+jobs:
+  monitoring:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        site: ${{ fromJSON(inputs.site == 'hawkfield' && '["hawkfield"]' || inputs.site == 'london' && '["london"]' || '["hawkfield","london"]') }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Set up Ansible
+        working-directory: Ansible
+        run: |
+          pip install -r requirements.txt
+
+      - name: Install Ansible collections
+        working-directory: Ansible
+        run: |
+          ansible-galaxy collection install -r galaxy-requirements.yml
+
+      - name: Setup vault password
+        working-directory: Ansible
+        run: |
+          echo "${{ secrets.ANSIBLE_VAULT_PASSWORD }}" > vault
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "${{ secrets.ANSIBLE_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          eval `ssh-agent -s`
+          ssh-add ~/.ssh/id_ed25519
+
+      - name: Run host monitoring playbook
+        working-directory: Ansible
+        env:
+          PROXMOX_TOKEN_SECRET: ${{ matrix.site == 'hawkfield' && secrets.PROXMOX_TOKEN_HAWKFIELD_ANSIBLE || secrets.PROXMOX_TOKEN_LONDON_ANSIBLE }}
+        run: |
+          ansible-playbook monitoring.yml \
+            --inventory inventory/${{ matrix.site }}.proxmox.yml \
+            --vault-password-file vault


### PR DESCRIPTION
## Why

Follow-up to #302. That PR added `Ansible/monitoring.yml` + the `monitoring` role, but **no GitHub Actions workflow** — and the deploy model in this repo is *one workflow per playbook*, triggered on push to `master` touching `Ansible/**`. So the Alloy host role has never run on any host.

## Verification that surfaced this (post-merge of #302)

- ✅ **Loki ingress live**: `loki.clinch-home.com` → `10.1.2.205`, cert issued (`loki-certificate` READY), `POST /loki/api/v1/push` returns HTTP 400 over TLS (reachable, not ClusterIP-dead).
- ✅ **AdGuard DNS rewrite live**: the `ansible-adguard` workflow ran on the #302 merge and deployed it — AdGuard resolves `loki.clinch-home.com` → `10.1.2.205` (no wildcard; explicit rewrite).
- ❌ **No host metrics/logs**: Prometheus has `node_load1` only for `k8s-hawk-1/2/3` with **no `site` label**; nothing from `proxmox_nodes`/`base`/`adguard`/`claude`. Root cause: no workflow runs `monitoring.yml`.

## What this does

Adds `.github/workflows/ansible-monitoring.yaml`, mirroring `ansible-adguard.yaml` (the multi-site template):

- `["hawkfield","london"]` matrix + `workflow_dispatch` site selector.
- Tailscale (`tag:ci`) for cross-site reach to London hosts.
- Per-site `PROXMOX_TOKEN_SECRET` (`PROXMOX_TOKEN_HAWKFIELD_ANSIBLE` / `..._LONDON_ANSIBLE`), vault password + SSH key from Actions secrets.
- Runs `monitoring.yml --inventory inventory/<site>.proxmox.yml --vault-password-file vault`.
- Drops the AdGuard-specific `ADGUARD_ADMIN_PASSWORD` / `tags` inputs.

## Merging this triggers the rollout

On merge, the `Ansible/**` path filter fires the matrix immediately and installs Alloy on **every non-k8s host in both sites**. After it's green, verify:
- Prometheus: `node_load1{instance="<host>", site="hawkfield"}` and `site="london"`.
- Loki: `{node="<host>", site="hawkfield"}` journald lines.

## ⚠️ Known runtime caveat (separate, not fixed here)

The Dave/`claude` host (`claude-hawk-1`, 10.1.2.122) resolves DNS via the UDM (10.1.2.1) + Tailscale MagicDNS, **not** AdGuard — so it currently returns NXDOMAIN for `prometheus`/`loki.clinch-home.com` and Alloy there won't reach the endpoints until its resolver points at AdGuard (or an `/etc/hosts`/`hosts.j2` entry is added). Other host classes use AdGuard and are unaffected. Flagging for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)