### PR TITLE
Point fleet resolvers at AdGuard so host Alloy can ship

### DIFF
--- a/Ansible/group_vars/hawkfield.yml
+++ b/Ansible/group_vars/hawkfield.yml
@@ -1,6 +1,11 @@
 k8s_cluster_name: "hawkfield"
 site_dns_domain: "hawkfield.clinch-home.com"
 
+# AdGuard resolvers: own-site first, other-site fallback (no SPOF).
+resolver_nameservers:
+  - "10.1.2.131"
+  - "10.2.2.131"
+
 ansible_ssh_pass: !vault |
   $ANSIBLE_VAULT;1.1;AES256
   32363733313266333133353239313039393237373930653538343637356366396436616237353935

--- a/Ansible/group_vars/london.yml
+++ b/Ansible/group_vars/london.yml
@@ -1,6 +1,11 @@
 k8s_cluster_name: "london"
 site_dns_domain: "london.clinch-home.com"
 
+# AdGuard resolvers: own-site first, other-site fallback (no SPOF).
+resolver_nameservers:
+  - "10.2.2.131"
+  - "10.1.2.131"
+
 user_list:
   - {
     name: "ansible",

--- a/Ansible/monitoring.yml
+++ b/Ansible/monitoring.yml
@@ -1,4 +1,13 @@
 ---
+# Point fleet resolvers at AdGuard first, so Alloy can resolve the
+# prometheus/loki ingress hostnames. AdGuard hosts are excluded — they
+# resolve via themselves.
+- name: Point fleet resolvers at AdGuard
+  hosts: proxmox_nodes:base:claude
+  become: true
+  roles:
+    - role: resolver
+
 - name: Install host metrics & logs collector
   hosts: proxmox_nodes:base:adguard:claude
   become: true

--- a/Ansible/roles/resolver/defaults/main.yml
+++ b/Ansible/roles/resolver/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+resolver_search_domain: "clinch-home.com"
+# resolver_nameservers is set per site in group_vars/{hawkfield,london}.yml

--- a/Ansible/roles/resolver/handlers/main.yml
+++ b/Ansible/roles/resolver/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Apply netplan
+  ansible.builtin.command:
+    cmd: netplan apply
+  changed_when: false

--- a/Ansible/roles/resolver/tasks/main.yml
+++ b/Ansible/roles/resolver/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Point /etc/resolv.conf at the AdGuard resolvers (Debian / Proxmox)
+  ansible.builtin.template:
+    src: resolv.conf.j2
+    dest: /etc/resolv.conf
+    owner: root
+    group: root
+    mode: "0644"
+  when: ansible_facts['distribution'] != 'Ubuntu'
+
+- name: Point netplan at the AdGuard resolvers (Ubuntu)
+  vars:
+    addrs: "{% for n in resolver_nameservers %}        - {{ n }}\n{% endfor %}"
+  ansible.builtin.replace:
+    path: /etc/netplan/50-cloud-init.yaml
+    after: 'nameservers:'
+    before: 'set-name:'
+    regexp: '(addresses:\n)(?:\s*-\s*[0-9.]+\n)+'
+    replace: '\g<1>{{ addrs }}'
+  notify: Apply netplan
+  when: ansible_facts['distribution'] == 'Ubuntu'

--- a/Ansible/roles/resolver/templates/resolv.conf.j2
+++ b/Ansible/roles/resolver/templates/resolv.conf.j2
@@ -1,0 +1,5 @@
+# Managed by Ansible (roles/resolver) — do not edit on the host.
+search {{ resolver_search_domain }}
+{% for ns in resolver_nameservers %}
+nameserver {{ ns }}
+{% endfor %}


### PR DESCRIPTION
## Why

Follow-up to #302/#303. After the host monitoring rollout, validation showed Alloy was installed fleet-wide but **only the two AdGuard LXCs (`dns-hawk-1`, `dns-lon-1`) actually shipped data**. Every other host — PVE nodes, base VMs, the `claude` server — resolves DNS via upstream resolvers (UDM `10.1.2.1` / Tailscale MagicDNS) that don't know the internal `prometheus`/`loki.clinch-home.com` ingress names. So `remote_write` / `loki.write` failed with `no such host` and backed up the WAL. The AdGuard hosts worked only because they answer the rewrite themselves.

Confirmed on real hosts:
- `claude-hawk-1` (Ubuntu): `dial tcp: lookup prometheus.clinch-home.com on 127.0.0.53:53: no such host`
- `hawk01` (PVE): same, via `10.1.2.1:53`

## What

A `resolver` role pointing each host at the AdGuard servers — **own-site primary, other-site secondary over Tailscale (no SPOF)** — OS-aware because the two host classes differ:

| Class | Mechanism | Fix |
|---|---|---|
| `proxmox_nodes` (PVE, Debian 12) | static `/etc/resolv.conf`, no systemd-resolved/resolvconf | template `/etc/resolv.conf` |
| `base`, `claude` (Ubuntu) | netplan + systemd-resolved, per-link DNS | rewrite nameservers in `50-cloud-init.yaml` + `netplan apply` |

The Ubuntu path edits the per-link nameservers (a global resolved setting can't override the per-link `clinch-home.com` routing domain). The **default route and search domain are preserved**, and the **Tailscale link is untouched** so MagicDNS keeps working.

Wired into `monitoring.yml` as a prerequisite play over `proxmox_nodes:base:claude` (AdGuard excluded — it resolves via itself). `resolver_nameservers` is set per site in `group_vars/{hawkfield,london}.yml`.

## Validation

Ran the actual role against one host of each class:
- **hawk01 (PVE):** check-mode diff → real run; `resolv.conf` rewritten, then `node_load1{instance="hawk01", site="hawkfield"}` + journald land in the hawkfield stack, no send errors.
- **claude-hawk-1 (Ubuntu + Tailscale):** netplan path applied; resolves the ingress names, `node_load1{instance="claude-hawk-1", site="hawkfield"}` + logs land, **`ts.net` MagicDNS still resolves**; re-run reports no change (idempotent).
- `ansible-lint --strict` (CI gate) and `yamllint` both clean.

> Note: I hand-applied the equivalent change to `hawk01` and `claude-hawk-1` during validation, so those two are already live. The remaining hosts (`hawk02/03`, `london01`, base VMs) get fixed by CI on merge — both sites' AdGuard already hold the rewrites.

## Assumption to flag

The Ubuntu path targets `/etc/netplan/50-cloud-init.yaml` (the cloud-init filename, consistent with how these VMs are provisioned). If a base VM uses a different netplan filename the `replace` task will no-op/error — worth a glance at the first `base`-host run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)