### PR TITLE
Fix resolver_nameservers undefined on proxmox_nodes

### DIFF
--- a/Ansible/group_vars/all.yml
+++ b/Ansible/group_vars/all.yml
@@ -4,3 +4,11 @@ ansible_python_interpreter: /usr/bin/python3
 
 metrics_remote_write_url: "https://prometheus.clinch-home.com/api/v1/write"
 logs_push_url: "https://loki.clinch-home.com/loki/api/v1/push"
+
+# AdGuard resolvers per site: own-site first, other-site fallback (no SPOF).
+# Keyed on `site` (set per host by the inventory) so it resolves for both
+# guests and the proxmox_nodes, which aren't in the per-site group.
+resolver_nameservers_by_site:
+  hawkfield: ["10.1.2.131", "10.2.2.131"]
+  london: ["10.2.2.131", "10.1.2.131"]
+resolver_nameservers: "{{ resolver_nameservers_by_site[site] }}"

--- a/Ansible/group_vars/hawkfield.yml
+++ b/Ansible/group_vars/hawkfield.yml
@@ -1,11 +1,6 @@
 k8s_cluster_name: "hawkfield"
 site_dns_domain: "hawkfield.clinch-home.com"
 
-# AdGuard resolvers: own-site first, other-site fallback (no SPOF).
-resolver_nameservers:
-  - "10.1.2.131"
-  - "10.2.2.131"
-
 ansible_ssh_pass: !vault |
   $ANSIBLE_VAULT;1.1;AES256
   32363733313266333133353239313039393237373930653538343637356366396436616237353935

--- a/Ansible/group_vars/london.yml
+++ b/Ansible/group_vars/london.yml
@@ -1,11 +1,6 @@
 k8s_cluster_name: "london"
 site_dns_domain: "london.clinch-home.com"
 
-# AdGuard resolvers: own-site first, other-site fallback (no SPOF).
-resolver_nameservers:
-  - "10.2.2.131"
-  - "10.1.2.131"
-
 user_list:
   - {
     name: "ansible",


### PR DESCRIPTION
## Why

The `ansible-monitoring` run after #304 **failed** on the PVE hosts (`hawk03`, `lon01`):

```
AnsibleUndefinedVariable: 'resolver_nameservers' is undefined
fatal: [hawk03]: FAILED!
```

The proxmox dynamic inventory sets `site` on every host via `compose`, but the `proxmox_nodes` are **not** members of the per-site group — so `group_vars/{hawkfield,london}.yml` (where I'd put `resolver_nameservers`) applied to the guests but never to the PVE nodes. Guests succeeded; PVE nodes errored.

## Fix

Move `resolver_nameservers` to `group_vars/all.yml`, keyed on `site` (which *is* defined on every host, confirmed: `hawk03`'s deployed Alloy config has `site = "hawkfield"`):

```yaml
resolver_nameservers_by_site:
  hawkfield: ["10.1.2.131", "10.2.2.131"]
  london: ["10.2.2.131", "10.1.2.131"]
resolver_nameservers: "{{ resolver_nameservers_by_site[site] }}"
```

Drop the per-site definitions. Lazy evaluation means this only resolves where the resolver role runs.

## Validation

Ran the role against `hawk02` with **only** `site=hawkfield` set (no explicit var) — `resolver_nameservers` resolved from the map and produced the correct `resolv.conf` diff (`10.1.2.1` → AdGuard). `ansible-lint --strict` clean.

Merging re-triggers `ansible-monitoring`; I'll confirm the full fleet ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)