### PR TITLE
Exclude k8s_cluster from host monitoring (stop double-collection)

### DIFF
--- a/Ansible/monitoring.yml
+++ b/Ansible/monitoring.yml
@@ -1,15 +1,17 @@
 ---
 # Point fleet resolvers at AdGuard first, so Alloy can resolve the
-# prometheus/loki ingress hostnames. AdGuard hosts are excluded — they
-# resolve via themselves.
+# prometheus/loki ingress hostnames. AdGuard hosts are excluded (they
+# resolve via themselves); k8s_cluster is excluded everywhere — those
+# nodes already run the in-cluster Alloy DaemonSet and use cluster DNS,
+# so adding host-Alloy would double their metrics.
 - name: Point fleet resolvers at AdGuard
-  hosts: proxmox_nodes:base:claude
+  hosts: proxmox_nodes:base:claude:!k8s_cluster
   become: true
   roles:
     - role: resolver
 
 - name: Install host metrics & logs collector
-  hosts: proxmox_nodes:base:adguard:claude
+  hosts: proxmox_nodes:base:adguard:claude:!k8s_cluster
   become: true
   roles:
     - role: monitoring


### PR DESCRIPTION
## Why

The k8s nodes are also tagged `base`, so `monitoring.yml` (targeting `proxmox_nodes:base:adguard:claude`) was installing **host-Alloy on the k8s nodes** and the resolver play was **repointing their DNS** — even though they already run the in-cluster Alloy **DaemonSet**. It went unnoticed until the DNS fix (#305) let the host-Alloy actually ship; then each hawkfield k8s node reported `node_*` **twice**:

```
node_load1{instance="k8s-hawk-1"}                    # DaemonSet (no site)
node_load1{instance="k8s-hawk-1", site="hawkfield"}  # stray host-Alloy
```

(London's `k8s-lon-1` picked up a stray host-Alloy too — not strictly doubled, since london has no DaemonSet, but still unintended.)

## Fix

Add `:!k8s_cluster` to **both** plays so k8s nodes are left entirely to the DaemonSet + cluster DNS:

```yaml
hosts: proxmox_nodes:base:claude:!k8s_cluster              # resolver
hosts: proxmox_nodes:base:adguard:claude:!k8s_cluster      # monitoring
```

## Cleanup already done (out-of-band)

The four affected k8s nodes were remediated directly (DaemonSets untouched, cluster Ready throughout):
- `k8s-hawk-1/2/3`, `k8s-lon-1`: `alloy` package purged + service disabled; netplan DNS reverted to the node gateway (`10.1.2.1` / `10.2.2.1`).

`ansible-lint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)