### PR TITLE
fix(monitoring): scrape cluster metrics node-locally on the Alloy DaemonSet

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/config.alloy
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/config.alloy
@@ -145,12 +145,26 @@ prometheus.relabel "cluster" {
     }
 }
 
+// This is a DaemonSet: every scrape below is filtered to the LOCAL node
+// (NODE_NAME keep), so each Alloy writes each series exactly once. Without
+// this, all 3 replicas scrape every target and remote_write collides
+// (out-of-order samples).
+
 discovery.kubernetes "nodes" {
     role = "node"
 }
 
+discovery.relabel "kubelet" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+        source_labels = ["__meta_kubernetes_node_name"]
+        regex         = sys.env("NODE_NAME")
+        action        = "keep"
+    }
+}
+
 prometheus.scrape "kubelet" {
-    targets           = discovery.kubernetes.nodes.targets
+    targets           = discovery.relabel.kubelet.output
     forward_to        = [prometheus.relabel.cluster.receiver]
     job_name          = "kubelet"
     scheme            = "https"
@@ -163,7 +177,7 @@ prometheus.scrape "kubelet" {
 }
 
 prometheus.scrape "cadvisor" {
-    targets           = discovery.kubernetes.nodes.targets
+    targets           = discovery.relabel.kubelet.output
     forward_to        = [prometheus.relabel.cluster.receiver]
     job_name          = "cadvisor"
     scheme            = "https"
@@ -176,10 +190,34 @@ prometheus.scrape "cadvisor" {
     scrape_interval = "30s"
 }
 
+discovery.kubernetes "kube_state_metrics" {
+    role = "pod"
+    namespaces {
+        names = ["monitoring"]
+    }
+}
+
+discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+    rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "kube-state-metrics"
+        action        = "keep"
+    }
+    rule {
+        source_labels = ["__meta_kubernetes_pod_container_port_name"]
+        regex         = "http-metrics"
+        action        = "keep"
+    }
+    rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        regex         = sys.env("NODE_NAME")
+        action        = "keep"
+    }
+}
+
 prometheus.scrape "kube_state_metrics" {
-    targets = [
-        {"__address__" = "kube-state-metrics.monitoring.svc:8080"},
-    ]
+    targets         = discovery.relabel.kube_state_metrics.output
     forward_to      = [prometheus.relabel.cluster.receiver]
     job_name        = "kube-state-metrics"
     scrape_interval = "30s"
@@ -197,6 +235,11 @@ discovery.relabel "ingress_nginx" {
     rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         regex         = "metrics"
+        action        = "keep"
+    }
+    rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        regex         = sys.env("NODE_NAME")
         action        = "keep"
     }
     rule {


### PR DESCRIPTION
## Problem (found during apply/verify of #308)

After #308 merged and reconciled, all the new metrics flowed (`kube_*`, `container_*`, `kubelet_*`, `nginx_ingress_*`) **but** Prometheus logged a steady stream of:

```
level=ERROR source=write_handler.go:230 msg="Out of order sample from remote write" err="out of order sample"
```

…for the `kubelet`, `cadvisor`, `kube-state-metrics`, and `ingress-nginx` jobs (61 in 90s). Those samples are **rejected/dropped**.

## Root cause

Alloy runs as a **DaemonSet (3 replicas)**. The #308 scrapes discovered **cluster-wide** targets, so all 3 replicas scraped *every* kubelet, *every* ingress pod, and the *single* KSM, each `remote_write`-ing identical series. Multiple writers per series → interleaved timestamps → out-of-order rejection. The existing host-metrics and pod-logs pipelines avoid this by filtering to the local node (`NODE_NAME`); the new scrapes didn't.

## Fix

Filter every cluster scrape to the local node so each series has exactly one writer (same `NODE_NAME` keep pattern already used by `discovery.relabel "pod_logs"`):

- **kubelet + cAdvisor** — keep node-role target where `__meta_kubernetes_node_name == NODE_NAME`; each Alloy scrapes only its own kubelet.
- **kube-state-metrics** — switch from the cluster-wide Service target to pod-role discovery (ns `monitoring`), keeping `app=kube-state-metrics`, the `http-metrics` port, and the local node. Only the Alloy on KSM's node scrapes it (self-heals on reschedule).
- **ingress-nginx** — add a node-local keep alongside the existing metrics-port keep.

## Validation

- `alloy fmt` parses; `kubectl kustomize hawkfield/monitoring` builds clean.
- Post-deploy verification (each job's `up`, metric counts, and **zero** new out-of-order errors) in the PR thread once reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)