### PR TITLE
chore(monitoring): trim verbose alloy comment to one line

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/config.alloy
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/config.alloy
@@ -145,11 +145,7 @@ prometheus.relabel "cluster" {
     }
 }
 
-// This is a DaemonSet: every scrape below is filtered to the LOCAL node
-// (NODE_NAME keep), so each Alloy writes each series exactly once. Without
-// this, all 3 replicas scrape every target and remote_write collides
-// (out-of-order samples).
-
+// DaemonSet: keep only local-node targets, else every replica double-writes.
 discovery.kubernetes "nodes" {
     role = "node"
 }


### PR DESCRIPTION
Per review feedback — the 4-line DaemonSet comment from #309 was too verbose. Reduced to a single line (the node-local decision still warrants one concise callout). No behaviour change.