### PR TITLE
feat(monitoring): TrueNAS (hawkstore) metrics + logs into Grafana

### DIFF
--- a/kubernetes/flux/infrastructure/base/monitoring/alloy-syslog.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/alloy-syslog.yml
@@ -1,0 +1,93 @@
+---
+# Separate single-replica Deployment, not the Alloy DaemonSet, so the syslog
+# listener has one owner rather than one per node.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alloy-syslog
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: alloy-syslog
+    app.kubernetes.io/component: syslog
+    app.kubernetes.io/part-of: kube-prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-syslog
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: alloy-syslog
+        app.kubernetes.io/component: syslog
+        app.kubernetes.io/part-of: kube-prometheus
+    spec:
+      containers:
+        - name: alloy
+          image: grafana/alloy:v1.16.1
+          args:
+            - run
+            - /etc/alloy/config-syslog.alloy
+            - --storage.path=/tmp/alloy
+            - --server.http.listen-addr=0.0.0.0:12345
+          ports:
+            - name: syslog-tcp
+              containerPort: 1514
+              protocol: TCP
+            - name: http
+              containerPort: 12345
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+          volumeMounts:
+            - mountPath: /etc/alloy
+              name: config
+              readOnly: true
+            - mountPath: /tmp
+              name: data
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: config
+          configMap:
+            name: alloy-syslog-config
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alloy-syslog
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: alloy-syslog
+    app.kubernetes.io/component: syslog
+    app.kubernetes.io/part-of: kube-prometheus
+  annotations:
+    metallb.io/loadBalancerIPs: 10.1.2.210
+    metallb.io/allow-shared-ip: truenas-ingest
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+  selector:
+    app.kubernetes.io/name: alloy-syslog
+  ports:
+    - name: syslog-tcp
+      port: 514
+      targetPort: syslog-tcp
+      protocol: TCP

--- a/kubernetes/flux/infrastructure/base/monitoring/graphite-exporter.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/graphite-exporter.yml
@@ -1,0 +1,114 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: graphite-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: graphite-exporter
+    app.kubernetes.io/component: graphite-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: graphite-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: graphite-exporter
+        app.kubernetes.io/component: graphite-exporter
+        app.kubernetes.io/part-of: kube-prometheus
+    spec:
+      containers:
+        - name: graphite-exporter
+          image: prom/graphite-exporter:v0.16.0
+          args:
+            - --graphite.mapping-config=/etc/graphite/mapping.conf
+            - --web.listen-address=:9108
+            - --graphite.listen-address=:9109
+          ports:
+            - name: metrics
+              containerPort: 9108
+              protocol: TCP
+            - name: graphite-tcp
+              containerPort: 9109
+              protocol: TCP
+            - name: graphite-udp
+              containerPort: 9109
+              protocol: UDP
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+          volumeMounts:
+            - mountPath: /etc/graphite
+              name: mapping
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: mapping
+          configMap:
+            name: graphite-mapping
+            items:
+              - key: graphite_mapping.conf
+                path: mapping.conf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: graphite-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: graphite-exporter
+    app.kubernetes.io/component: graphite-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+spec:
+  selector:
+    app.kubernetes.io/name: graphite-exporter
+  ports:
+    - name: metrics
+      port: 9108
+      targetPort: metrics
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: graphite-exporter-ingest
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: graphite-exporter
+    app.kubernetes.io/component: graphite-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+  annotations:
+    metallb.io/loadBalancerIPs: 10.1.2.210
+    metallb.io/allow-shared-ip: truenas-ingest
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+  selector:
+    app.kubernetes.io/name: graphite-exporter
+  ports:
+    - name: graphite-tcp
+      port: 9109
+      targetPort: graphite-tcp
+      protocol: TCP
+    - name: graphite-udp
+      port: 9109
+      targetPort: graphite-udp
+      protocol: UDP

--- a/kubernetes/flux/infrastructure/base/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/kustomization.yml
@@ -6,6 +6,8 @@ resources:
   - helm-release-loki.yml
   - helm-release-alloy.yml
   - kube-state-metrics.yml
+  - graphite-exporter.yml
+  - alloy-syslog.yml
   - prometheus.yml
   - grafana.yml
   - certificate.yml

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/config-syslog.alloy
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/config-syslog.alloy
@@ -1,0 +1,23 @@
+logging {
+    level  = "info"
+    format = "logfmt"
+}
+
+loki.source.syslog "truenas" {
+    listener {
+        // 1514 not 514: unprivileged in-pod bind; the Service maps 514 -> 1514.
+        address  = "0.0.0.0:1514"
+        protocol = "tcp"
+        labels   = {
+            job  = "truenas-syslog",
+            node = "hawkstore",
+        }
+    }
+    forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+    endpoint {
+        url = "http://loki-gateway.monitoring.svc/loki/api/v1/push"
+    }
+}

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/graphite_mapping.conf
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/graphite_mapping.conf
@@ -1,0 +1,919 @@
+mappings:
+
+################################################
+# memory mapping
+################################################
+
+- match: 'truenas\.(.*)\.system\.ram\.(.*)'
+  match_type: "regex"
+  name: "physical_memory"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    kind: "${2}"
+
+- match: 'truenas\.(.*)\.mem\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "memory_${2}"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    kind: "${3}"
+
+- match: 'truenas\.(.*)\.system\.swap\.(.*)'
+  match_type: "regex"
+  name: "swap"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    kind: "${2}"
+
+################################################
+# service mapping
+################################################
+
+- match: 'truenas\.(.*)\.services\.cpu\.(.*)'
+  match_type: "regex"
+  name: "services_cpu"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    service: "${2}"
+
+- match: 'truenas\.(.*)\.services\.io_ops_read\.(.*)'
+  match_type: "regex"
+  name: "services_iops"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    op: "read"
+    service: "${2}"
+
+- match: 'truenas\.(.*)\.services\.io_ops_write\.(.*)'
+  match_type: "regex"
+  name: "services_iops"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    op: "write"
+    service: "${2}"
+
+- match: 'truenas\.(.*)\.services\.io_read\.(.*)'
+  match_type: "regex"
+  name: "services_io"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    op: "read"
+    service: "${2}"
+
+- match: 'truenas\.(.*)\.services\.io_write\.(.*)'
+  match_type: "regex"
+  name: "services_io"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    op: "write"
+    service: "${2}"
+
+- match: 'truenas\.(.*)\.services\.mem_usage\.(.*)'
+  match_type: "regex"
+  name: "services_mem"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    service: "${2}"
+
+################################################
+# disk smart metrics
+################################################
+
+- match: 'truenas\.(.*)\.smart\.log\.smart\.disktemp\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "disk_temperature"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    serial: "${2}"
+
+- match: 'truenas\.(.*)\.smart_log_smart\.disktemp\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "disk_temperature"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    serial: "${2}"
+
+################################################
+# disk operation mappings
+################################################
+
+- match: 'truenas\.(.*)\.disk\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "disk_io"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.disk_ops\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "disk_io_ops"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.disk_ext\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "disk_io"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.disk_ext_ops\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "disk_io_ops"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.disk_backlog\.(.*)\.backlog'
+  match_type: "regex"
+  name: "disk_io_backlog"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+
+- match: 'truenas\.(.*)\.disk_busy\.(.*)\.busy'
+  match_type: "regex"
+  name: "disk_busy"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+
+- match: 'truenas\.(.*)\.disk_util\.(.*)\.utilization'
+  match_type: "regex"
+  name: "disk_utilization"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+
+- match: 'truenas\.(.*)\.disk_mops\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "disk_io"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+    op: "merged_${3}"
+
+- match: 'truenas\.(.*)\.disk_ext_mops\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "disk_io"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+    op: "merged_${3}"
+
+- match: 'truenas\.(.*)\.disk_iotime\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "disk_iotime"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.disk_ext_iotime\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "disk_iotime"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.disk_qops\.(.*)\.operations'
+  match_type: "regex"
+  name: "disk_qops"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+
+- match: 'truenas\.(.*)\.disk_await\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "disk_await"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.disk_ext_await\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "disk_await"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.disk_avgsz\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "disk_io_size"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.disk_ext_avgsz\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "disk_io_size"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.disk_svctm\.(.*)\.svctm'
+  match_type: "regex"
+  name: "disk_svctm"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    disk: "${2}"
+
+- match: 'truenas\.(.*)\.system\.io\.(.*)'
+  match_type: "regex"
+  name: "system_io"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    op: "${2}"
+
+################################################
+# CPU mapping
+################################################
+
+- match: 'truenas\.(.*)\.system\.intr\.interrupts'
+  match_type: "regex"
+  name: "interrupts"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    kind: "hard"
+
+- match: 'truenas\.(.*)\.system\.cpu\.softirq'
+  match_type: "regex"
+  name: "interrupts"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    kind: "soft"
+
+- match: 'truenas\.(.*)\.cpu\.(.*)\.softirq'
+  match_type: "regex"
+  name: "cpu_softirq"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    cpu: "${2}"
+
+- match: 'truenas\.(.*)\.system\.ctxt\.switches'
+  match_type: "regex"
+  name: "context_switches"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+
+- match: 'truenas\.(.*)\.system\.cpu\.(.*)'
+  match_type: "regex"
+  name: "cpu_total"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    kind: "${2}"
+
+- match: 'truenas\.(.*)\.cputemp\.temperatures\.(.*)'
+  match_type: "regex"
+  name: "cpu_temperature"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    cpu: "cpu${2}"
+
+- match: 'truenas\.(.*)\.cpu\.core_throttling\.(.*)'
+  match_type: "regex"
+  name: "cpu_throttling"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    cpu: "${2}"
+
+- match: 'truenas\.(.*)\.cpu\.cpufreq\.(.*)'
+  match_type: "regex"
+  name: "cpu_frequency"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    cpu: "${2}"
+
+- match: 'truenas\.(.*)\.cpu\.(.*)_cpuidle\.(.*)'
+  match_type: "regex"
+  name: "cpu_idlestate"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    cpu: "${2}"
+    state: "${3}"
+
+- match: 'truenas\.(.*)\.cpu\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "cpu_usage"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    cpu: "${2}"
+    kind: "${3}"
+
+################################################
+# process mapping
+################################################
+
+- match: 'truenas\.(.*)\.system\.forks\.started'
+  match_type: "regex"
+  name: "processes_forks"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+
+- match: 'truenas\.(.*)\.system\.processes\.(.*)'
+  match_type: "regex"
+  name: "processes"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    kind: "${2}"
+
+- match: 'truenas\.(.*)\.system\.active_processes\.(.*)'
+  match_type: "regex"
+  name: "processes"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    kind: "${2}"
+
+################################################
+# uptime mapping
+################################################
+
+- match: 'truenas\.(.*)\.system\.uptime\.uptime'
+  match_type: "regex"
+  name: "uptime"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+
+- match: 'truenas\.(.*)\.system\.clock_sync_state\.state'
+  match_type: "regex"
+  name: "clock_synced"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+
+- match: 'truenas\.(.*)\.system\.clock_status\.(.*)'
+  match_type: "regex"
+  name: "clock_status"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    state: "${2}"
+
+- match: 'truenas\.(.*)\.system\.clock_sync_offset\.offset'
+  match_type: "regex"
+  name: "clock_offset"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+
+################################################
+# load mapping
+################################################
+
+- match: 'truenas\.(.*)\.system\.load\.(.*)'
+  match_type: "regex"
+  name: "system_load"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    kind: "${2}"
+
+################################################
+# nsfd mappings
+################################################
+
+- match: 'truenas\.(.*)\.nfsd\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "nfs_${2}"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    op: "${3}"
+
+################################################
+# zfs mappings
+################################################
+
+- match: 'truenas\.(.*)\.zfs\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "zfs_${2}"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.zfspool\.state_(.*)\.(.*)'
+  match_type: "regex"
+  name: "zfs_pool"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    pool: "${2}"
+    state: "${3}"
+
+################################################
+# network mappings
+################################################
+
+- match: 'truenas\.(.*)\.net\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "interface_io"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    interface: "${2}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.net_speed\.(.*)\.speed'
+  match_type: "regex"
+  name: "interface_speed"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    interface: "${2}"
+
+- match: 'truenas\.(.*)\.net_duplex\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "interface_duplex"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    interface: "${2}"
+    state: "${3}"
+
+- match: 'truenas\.(.*)\.net_operstate\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "interface_operationstate"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    interface: "${2}"
+    state: "${3}"
+
+- match: 'truenas\.(.*)\.net_carrier\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "interface_carrierstate"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    interface: "${2}"
+    state: "${3}"
+
+- match: 'truenas\.(.*)\.net_mtu\.(.*)\.mtu'
+  match_type: "regex"
+  name: "interface_mtu"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    interface: "${2}"
+
+- match: 'truenas\.(.*)\.net_packets\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "interface_packets"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    interface: "${2}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.net_errors\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "interface_errors"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    interface: "${2}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.net_drops\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "interface_drops"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    interface: "${2}"
+    op: "${3}"
+
+- match: 'truenas\.(.*)\.system\.net\.(.*)'
+  match_type: "regex"
+  name: "system_net_io"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    op: "${2}"
+
+################################################
+# k3s mappings
+################################################
+
+- match: 'truenas\.(.*)\.k3s_stats\.k3s_pod_stats\.(.*)\.cpu'
+  match_type: "regex"
+  name: "k3s_pod_cpu"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    pod: "${2}"
+
+- match: 'truenas\.(.*)\.k3s_stats\.k3s_pod_stats\.(.*)\.mem'
+  match_type: "regex"
+  name: "k3s_pod_mem"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    pod: "${2}"
+
+- match: 'truenas\.(.*)\.k3s_stats\.k3s_pod_stats\.(.*)\.net\.(.*)'
+  match_type: "regex"
+  name: "k3s_pod_net"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    pod: "${2}"
+    direction: "${3}"
+
+################################################
+# cgroup mappings
+################################################
+
+- match: 'truenas\.(.*)\.(.*)\.cpu_full_pressure\.(.*)'
+  match_type: "regex"
+  name: "cgroup_cpu_full_pressure"
+  labels:
+    job: "truenas"
+    dimension: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "percent"
+
+- match: 'truenas\.(.*)\.(.*)\.cpu_full_pressure_stall_time\.time'
+  match_type: "regex"
+  name: "cgroup_cpu_full_pressure_stall_time"
+  labels:
+    job: "truenas"
+    dimension: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "ms"
+
+- match: 'truenas\.(.*)\.(.*)\.cpu_limit\.used'
+  match_type: "regex"
+  name: "cgroup_cpu_limit"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "percent"
+
+- match: 'truenas\.(.*)\.(.*)\.cpu_some_pressure\.(.*)'
+  match_type: "regex"
+  name: "cgroup_cpu_some_pressure"
+  labels:
+    job: "truenas"
+    dimension: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "percent"
+
+- match: 'truenas\.(.*)\.(.*)\.cpu_some_pressure_stall_time\.time'
+  match_type: "regex"
+  name: "cgroup_cpu_some_pressure_stall_time"
+  labels:
+    job: "truenas"
+    dimension: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "ms"
+
+- match: 'truenas\.(.*)\.(.*)\.cpu\.(.*)'
+  match_type: "regex"
+  name: "cgroup_cpu_usage"
+  labels:
+    job: "truenas"
+    type: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "percent"
+
+- match: 'truenas\.(.*)\.(.*)\.io\.(.*)'
+  match_type: "regex"
+  name: "cgroup_io_usage"
+  labels:
+    job: "truenas"
+    type: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "KiB/s"
+
+- match: 'truenas\.(.*)\.(.*)\.io_full_pressure\.(.*)'
+  match_type: "regex"
+  name: "cgroup_io_full_pressure"
+  labels:
+    job: "truenas"
+    dimension: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "percent"
+
+- match: 'truenas\.(.*)\.(.*)\.io_full_pressure_stall_time\.time'
+  match_type: "regex"
+  name: "cgroup_io_full_pressure_stall_time"
+  labels:
+    job: "truenas"
+    dimension: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "ms"
+
+- match: 'truenas\.(.*)\.(.*)\.io_some_pressure\.(.*)'
+  match_type: "regex"
+  name: "cgroup_io_some_pressure"
+  labels:
+    job: "truenas"
+    dimension: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "percent"
+
+- match: 'truenas\.(.*)\.(.*)\.io_some_pressure_stall_time\.time'
+  match_type: "regex"
+  name: "cgroup_io_some_pressure_stall_time"
+  labels:
+    job: "truenas"
+    dimension: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "ms"
+
+- match: 'truenas\.(.*)\.(.*)\.mem\.(.*)'
+  match_type: "regex"
+  name: "cgroup_memory_detailed_usage"
+  labels:
+    job: "truenas"
+    type: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "MiB"
+
+- match: 'truenas\.(.*)\.(.*)\.mem_full_pressure\.(.*)'
+  match_type: "regex"
+  name: "cgroup_mem_full_pressure"
+  labels:
+    job: "truenas"
+    dimension: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "percent"
+
+- match: 'truenas\.(.*)\.(.*)\.memory_full_pressure_stall_time\.time'
+  match_type: "regex"
+  name: "cgroup_mem_full_pressure_stall_time"
+  labels:
+    job: "truenas"
+    dimension: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "ms"
+
+- match: 'truenas\.(.*)\.(.*)\.mem_some_pressure\.(.*)'
+  match_type: "regex"
+  name: "cgroup_mem_some_pressure"
+  labels:
+    job: "truenas"
+    dimension: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "percent"
+
+- match: 'truenas\.(.*)\.(.*)\.memory_some_pressure_stall_time\.time'
+  match_type: "regex"
+  name: "cgroup_mem_some_pressure_stall_time"
+  labels:
+    job: "truenas"
+    dimension: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "ms"
+
+- match: 'truenas\.(.*)\.(.*)\.mem_usage\.(.*)'
+  match_type: "regex"
+  name: "cgroup_mem_usage"
+  labels:
+    job: "truenas"
+    type: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "MiB"
+
+- match: 'truenas\.(.*)\.(.*)\.mem_usage_limit\.(.*)'
+  match_type: "regex"
+  name: "cgroup_mem_usage_limit"
+  labels:
+    job: "truenas"
+    type: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "MiB"
+
+- match: 'truenas\.(.*)\.(.*)\.mem_utilization'
+  match_type: "regex"
+  name: "cgroup_mem_utilization"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "percent"
+
+- match: 'truenas\.(.*)\.(.*)\.pgfaults\.(.*)'
+  match_type: "regex"
+  name: "cgroup_pgfaults"
+  labels:
+    job: "truenas"
+    type: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "MiB/s"
+
+- match: 'truenas\.(.*)\.(.*)\.throttled'
+  match_type: "regex"
+  name: "cgroup_cpu_throttled"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "percent"
+
+- match: 'truenas\.(.*)\.(.*)\.throttled_duration'
+  match_type: "regex"
+  name: "cgroup_cpu_throttled_duration"
+  labels:
+    job: "truenas"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "ms"
+
+- match: 'truenas\.(.*)\.(.*)\.writeback\.(.*)'
+  match_type: "regex"
+  name: "cgroup_writeback"
+  labels:
+    job: "truenas"
+    type: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "MiB"
+
+- match: 'truenas\.(.*)\.(.*)\.serviced_ops\.(.*)'
+  match_type: "regex"
+  name: "cgroup_serviced_ops"
+  labels:
+    job: "truenas"
+    type: "${3}"
+    instance: "${1}"
+    cgroup: "${2}"
+    unit: "op/s"
+
+################################################
+# arcstat mapping
+################################################
+
+- match: 'truenas\.(.*)\.truenas_arcstats\.(.*)\.(.*)'
+  match_type: "regex"
+  name: "truenas_arcstats"
+  labels:
+    job: "truenas"
+    type: "${2}"
+    subtype: "${3}"
+    instance: "${1}"
+
+################################################
+# disk by ID mapping
+################################################
+
+- match: 'truenas\.(.*)\.truenas_disk_stats\.(.*)\.(reads|writes)'
+  match_type: "regex"
+  name: "disk_io"
+  labels:
+    job: "truenas"
+    disk: "${2}"
+    instance: "${1}"
+    op: "${3}"
+    unit: "KiB/s"
+
+- match: 'truenas\.(.*)\.truenas_disk_stats\.ops\.(.*)\.(read_ops|write_ops)'
+  match_type: "regex"
+  name: "disk_io_ops"
+  labels:
+    job: "truenas"
+    disk: "${2}"
+    instance: "${1}"
+    op: "${3}"
+    unit: "op/s"
+
+- match: 'truenas\.(.*)\.truenas_disk_stats\.busy\.(.*)\.busy'
+  match_type: "regex"
+  name: "disk_busy"
+  labels:
+    job: "truenas"
+    disk: "${2}"
+    instance: "${1}"
+    unit: "ms"
+
+################################################
+# disk space and inodes
+################################################
+
+- match: 'truenas\.(.*)\.disk_space\.(.*)\.used'
+  match_type: "regex"
+  name: "disk_bytes_used"
+  labels:
+    job: "truenas"
+    mountpoint: "${2}"
+    instance: "${1}"
+    unit: "GiB"
+
+- match: 'truenas\.(.*)\.disk_space\.(.*)\.avail'
+  match_type: "regex"
+  name: "disk_bytes_avail"
+  labels:
+    job: "truenas"
+    mountpoint: "${2}"
+    instance: "${1}"
+    unit: "GiB"
+
+- match: 'truenas\.(.*)\.disk_space\.(.*)\.reserved_for_root'
+  match_type: "regex"
+  name: "disk_bytes_reserved_for_root"
+  labels:
+    job: "truenas"
+    mountpoint: "${2}"
+    instance: "${1}"
+    unit: "GiB"
+
+- match: 'truenas\.(.*)\.disk_inodes\.(.*)\.used'
+  match_type: "regex"
+  name: "disk_inodes_used"
+  labels:
+    job: "truenas"
+    mountpoint: "${2}"
+    instance: "${1}"
+    unit: "inodes"
+
+- match: 'truenas\.(.*)\.disk_inodes\.(.*)\.avail'
+  match_type: "regex"
+  name: "disk_inodes_avail"
+  labels:
+    job: "truenas"
+    mountpoint: "${2}"
+    instance: "${1}"
+    unit: "inodes"
+
+- match: 'truenas\.(.*)\.disk_inodes\.(.*)\.reserved_for_root'
+  match_type: "regex"
+  name: "disk_inodes_reserved_for_root"
+  labels:
+    job: "truenas"
+    mountpoint: "${2}"
+    instance: "${1}"
+    unit: "inodes"

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
@@ -29,3 +29,15 @@ configMapGenerator:
       - values.yml=loki-values.yml
     options:
       disableNameSuffixHash: true
+  - name: graphite-mapping
+    namespace: monitoring
+    files:
+      - graphite_mapping.conf
+    options:
+      disableNameSuffixHash: true
+  - name: alloy-syslog-config
+    namespace: monitoring
+    files:
+      - config-syslog.alloy
+    options:
+      disableNameSuffixHash: true

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
@@ -19,3 +19,8 @@ scrape_configs:
         - '10.1.2.101:9100'
         - '10.1.2.102:9100'
         - '10.1.2.103:9100'
+  # TrueNAS (hawkstore) metrics: pushed via Graphite to the graphite_exporter,
+  # re-exposed in Prometheus format and scraped here. Single scrape point.
+  - job_name: truenas-hawkstore
+    static_configs:
+      - targets: ['graphite-exporter.monitoring.svc:9108']


### PR DESCRIPTION
## What

hawkstore (TrueNAS `10.1.2.10`) backs the Prometheus TSDB, Grafana DB and Loki chunks over NFS but is itself unmonitored. This adds cluster-side receivers so its metrics and system logs flow into the existing Grafana — light push from the NAS (built-in shippers only), all the heavy lifting cluster-side.

## Architecture

```
TrueNAS hawkstore (10.1.2.10)        hawkfield (monitoring ns)
netdata ─► Graphite Exporter ─9109─► graphite-exporter :9108 ─► Prometheus ─► Grafana
syslog-ng ─► Remote Syslog ──514───► alloy-syslog ─► Loki ──────────────────► Grafana
```

Both cluster Services share MetalLB IP **`10.1.2.210`** via `metallb.io/allow-shared-ip: truenas-ingest` (graphite TCP/UDP 9109, syslog TCP 514).

## Changes

- **`base/monitoring/graphite-exporter.yml`** — `prom/graphite-exporter:v0.16.0` Deployment; ClusterIP `:9108` (in-cluster scrape) + LoadBalancer `:9109` ingest. Mapping vendored from [Supporterino](https://github.com/Supporterino/truenas-graphite-to-prometheus) as the `graphite-mapping` ConfigMap (hawkfield overlay).
- **`base/monitoring/alloy-syslog.yml`** — single-replica `grafana/alloy:v1.16.1` (`loki.source.syslog` → Loki). Separate from the Alloy DaemonSet so the listener is a single owner. In-pod 1514, Service maps 514→1514 (no privileged bind, stays non-root).
- **`hawkfield/monitoring/`** — vendored `graphite_mapping.conf` + `config-syslog.alloy`, wired as stable-named `configMapGenerator`s.
- **`hawkfield/monitoring/prometheus.yml`** — `truenas-hawkstore` scrape job → `graphite-exporter.monitoring.svc:9108`.

## Notes

- Annotations use `metallb.io/` to match this cluster's existing ingress-nginx pin.
- Stable ConfigMap names → a manual rollout restart is needed after a config edit (same trade-off as the rest of this stack).

## Follow-ups (after merge + reconcile, when the LB IP is live)

- NAS-side: register the Graphite Reporting Exporter (`prefix=truenas`, `namespace=hawkstore` → `truenas.hawkstore.…`) and `syslogservers: ["10.1.2.210:514"]` via the TrueNAS API.
- Build the `hawkstore` Grafana dashboard (ZFS/ARC/SMART/scrub/host + syslog panel).
- Checkpoint: confirm ZFS/SMART series actually arrive — 25.04+ rewrote netdata plugins; patch the mapping if Goldeye changed metric paths.

## Verification

```
kubectl kustomize kubernetes/flux/infrastructure/hawkfield/monitoring/   # renders clean (32 docs)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)