### PR TITLE
fix(monitoring): numeric runAsUser for graphite-exporter and alloy-syslog

### DIFF
--- a/kubernetes/flux/infrastructure/base/monitoring/alloy-syslog.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/alloy-syslog.yml
@@ -22,6 +22,8 @@ spec:
         app.kubernetes.io/component: syslog
         app.kubernetes.io/part-of: kube-prometheus
     spec:
+      securityContext:
+        fsGroup: 473
       containers:
         - name: alloy
           image: grafana/alloy:v1.16.1
@@ -57,6 +59,8 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            runAsUser: 473
+            runAsGroup: 473
             capabilities:
               drop:
                 - ALL

--- a/kubernetes/flux/infrastructure/base/monitoring/graphite-exporter.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/graphite-exporter.yml
@@ -55,6 +55,8 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
Follow-up to #311. Both new pods hit `CreateContainerConfigError` under `runAsNonRoot: true`:

- `graphite-exporter`: image declares a **non-numeric** user (`nobody`) the kubelet can't verify → pin `runAsUser/runAsGroup: 65534`.
- `alloy-syslog`: `grafana/alloy` image runs as **root** → pin `runAsUser/runAsGroup: 473` + pod `fsGroup: 473` so the `/tmp` emptyDir (`--storage.path`) is writable.

Verified `kubectl kustomize` renders clean. Both LoadBalancers were already correctly sharing `10.1.2.210` before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)