### PR TITLE
feat(monitoring): TrueNAS API exporter for ZFS pools/scrub + disk temps

### DIFF
--- a/kubernetes/flux/infrastructure/base/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/kustomization.yml
@@ -8,6 +8,7 @@ resources:
   - kube-state-metrics.yml
   - graphite-exporter.yml
   - alloy-syslog.yml
+  - truenas-api-exporter.yml
   - prometheus.yml
   - grafana.yml
   - certificate.yml

--- a/kubernetes/flux/infrastructure/base/monitoring/truenas-api-exporter.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/truenas-api-exporter.yml
@@ -1,0 +1,89 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: truenas-api-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: truenas-api-exporter
+    app.kubernetes.io/component: truenas-api-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: truenas-api-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: truenas-api-exporter
+        app.kubernetes.io/component: truenas-api-exporter
+        app.kubernetes.io/part-of: kube-prometheus
+    spec:
+      containers:
+        - name: exporter
+          image: python:3.12-slim
+          command: ["python3", "/app/truenas_exporter.py"]
+          env:
+            - name: TRUENAS_HOST
+              value: "10.1.2.10"
+            - name: LISTEN_PORT
+              value: "9113"
+            # API key for the least-privilege `nasexporter` TrueNAS user (read-only
+            # roles). REST rejects non-admin keys, so the exporter uses the JSON-RPC
+            # WebSocket API.
+            - name: TRUENAS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: truenas-api-credentials
+                  key: api-key
+          ports:
+            - name: metrics
+              containerPort: 9113
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+          volumeMounts:
+            - mountPath: /app
+              name: script
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: script
+          configMap:
+            name: truenas-exporter-script
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: truenas-api-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: truenas-api-exporter
+    app.kubernetes.io/component: truenas-api-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+spec:
+  selector:
+    app.kubernetes.io/name: truenas-api-exporter
+  ports:
+    - name: metrics
+      port: 9113
+      targetPort: metrics
+      protocol: TCP

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
@@ -4,6 +4,7 @@ metadata:
   name: monitoring
 resources:
   - ../../base/monitoring
+  - truenas-api-key.sops.yaml
 configMapGenerator:
   - name: prometheus.yml
     namespace: monitoring
@@ -39,5 +40,11 @@ configMapGenerator:
     namespace: monitoring
     files:
       - config-syslog.alloy
+    options:
+      disableNameSuffixHash: true
+  - name: truenas-exporter-script
+    namespace: monitoring
+    files:
+      - truenas_exporter.py
     options:
       disableNameSuffixHash: true

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
@@ -24,3 +24,9 @@ scrape_configs:
   - job_name: truenas-hawkstore
     static_configs:
       - targets: ['graphite-exporter.monitoring.svc:9108']
+  # TrueNAS depth (ZFS pools/datasets/scrub + disk temps) polled from the NAS API
+  # by truenas-api-exporter. Each scrape is a full API roundtrip, so poll gently.
+  - job_name: truenas-api
+    scrape_interval: 60s
+    static_configs:
+      - targets: ['truenas-api-exporter.monitoring.svc:9113']

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/truenas-api-key.sops.yaml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/truenas-api-key.sops.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: truenas-api-credentials
+    namespace: monitoring
+type: Opaque
+stringData:
+    api-key: ENC[AES256_GCM,data:UXTVm821sAhlxxQUtReVyI1i/aeA9GBLUS2bPvxM+tfbeBD2+56IU5ePSXwKWPCcgsTwrte/PQdIVQFpONAzYpKq,iv:RBePWIp2/Jz6D40AqAyYaYU2qRA2yOoH5vJ1tjnPckQ=,tag:4wMfjQKwVBW7gEVYQXzhBw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-06-06T16:53:40Z"
+    mac: ENC[AES256_GCM,data:OkZ/vBn3vLKFjiTgnIxB4UUjl5P96Ri7/pYmEystMu8Nmvh7gFbrsc63om44NHp5OmfxEbFCZhFyK++DJLQbSk7xZHAS9q5RJyq7Xa216gjDr8g2NQzLOLIk4lfuSO5CKrpR8tRsdqGlPMXBPZ6ebf9UzNVtJ7ztHkgSTtsxTXY=,iv:5tE40Me2zdu6OGd9JVZ2KcZyr055zfqUjkuCQ9nni4M=,tag:p8Y01VptItNebtTbuafeUg==,type:str]
+    pgp:
+        - created_at: "2026-06-06T16:53:40Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA+iIV7UXPYO1ARAAjB5ju2txHTa8oNXiTkSriLk1VJ2nXq+lMr7jd8ylSA1Z
+            umCt8onvvsBGn4J8KkSawzLsy/KpV83RwnQP0YQFoVIMrTOGHdPzOw8N/DmegZFX
+            w3tzvnP+9ekHc4aUXtFyfwJNcGC9/gIwpCxvTESPCEfXa58mYAnbb/hBZEV0gAS8
+            Kqr+4aFT+X3bdYzP47nqrrrEXFQdIyMh3XQt5pArh7Pv67qKZTKvlvZCECa88PSP
+            c85EHEu1ZX/JMFuV7G1ZlUzwxexqe5p56ElBOMhIP2VVA1vKrhoQrK6l30NM325n
+            UJw8ao8R/40EWrf4ElJh75I5QiMT2XU0CJPyaW14MzQ1eMMAwUXAjwIFuwnqbl71
+            vnI7dQZIjday97kUBllhYh6mmkSFBhkhQ4eEMsekRDYRUkbC3y/nj2nYiRc5xdwX
+            OzVH+MZLRGCi6Ba2KlPR5qYIiV1ZrVV0VewELfGqDoQqK4eW5cZjYDN828BCppKT
+            3SEqMorCGABzodyOWpllg/IWKN+bdBeo6IcJxFehSBgjknYLq7974JhY4H3jTTyJ
+            iKEXNKg81CI7xxtWOVB+v4jH3ZlMXSMEloXVZdcwiVSKk9QqmpokfvmdUxxQ4tYP
+            1HytfkZAftruQzo7la8oCPhII+zTNRwCAQO0/M5k+5+7FDyHxwflgU9ZlqCZYXzS
+            XgFbybAArldCHX5roFzPc64I6ucU1wixWQNiCcP8JX/NyevnIRgVuKvf20uMQhCm
+            sNdCajpJVN9d+xs+E8D1jt2wnPoQIcKf06DAyVbWQb9qEHpiCIh3RKF+tL7q1GA=
+            =voup
+            -----END PGP MESSAGE-----
+          fp: 76AF39813C2297E8F98C542D42436A07A9BA1DE0
+    encrypted_regex: ^(data|stringData)$
+    version: 3.9.4

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/truenas_exporter.py
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/truenas_exporter.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# TrueNAS API -> Prometheus exporter. Talks the 25.10 JSON-RPC WebSocket API
+# (the REST API rejects non-admin keys). Stdlib only: a minimal WS client so the
+# script can run from a stock python image mounted via ConfigMap.
+import base64, hashlib, json, os, socket, ssl, struct, sys, time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+NAS_HOST = os.environ.get("TRUENAS_HOST", "10.1.2.10")
+NAS_PORT = int(os.environ.get("TRUENAS_PORT", "443"))
+API_KEY = os.environ["TRUENAS_API_KEY"]
+WS_PATH = os.environ.get("TRUENAS_WS_PATH", "/api/current")
+LISTEN = int(os.environ.get("LISTEN_PORT", "9113"))
+
+
+class WSError(Exception):
+    pass
+
+
+class WSClient:
+    """Minimal RFC6453 client: TLS, text frames, client masking, reassembly."""
+
+    def __init__(self, host, port, path, timeout=15):
+        raw = socket.create_connection((host, port), timeout=timeout)
+        ctx = ssl._create_unverified_context()
+        self.s = ctx.wrap_socket(raw, server_hostname=host)
+        key = base64.b64encode(os.urandom(16)).decode()
+        req = (
+            f"GET {path} HTTP/1.1\r\nHost: {host}:{port}\r\n"
+            "Upgrade: websocket\r\nConnection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n\r\n"
+        )
+        self.s.sendall(req.encode())
+        resp = self._read_until(b"\r\n\r\n")
+        if b" 101 " not in resp.split(b"\r\n", 1)[0]:
+            raise WSError("ws upgrade failed: " + resp.split(b"\r\n", 1)[0].decode("latin1"))
+
+    def _read_until(self, marker):
+        buf = b""
+        while marker not in buf:
+            chunk = self.s.recv(4096)
+            if not chunk:
+                raise WSError("eof during handshake")
+            buf += chunk
+        return buf
+
+    def _recv_exact(self, n):
+        buf = b""
+        while len(buf) < n:
+            chunk = self.s.recv(n - len(buf))
+            if not chunk:
+                raise WSError("eof during frame")
+            buf += chunk
+        return buf
+
+    def send(self, text):
+        payload = text.encode()
+        header = struct.pack("!B", 0x81)  # FIN + text
+        mask = os.urandom(4)
+        n = len(payload)
+        if n < 126:
+            header += struct.pack("!B", 0x80 | n)
+        elif n < 65536:
+            header += struct.pack("!BH", 0x80 | 126, n)
+        else:
+            header += struct.pack("!BQ", 0x80 | 127, n)
+        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+        self.s.sendall(header + mask + masked)
+
+    def recv(self):
+        data = b""
+        while True:
+            b0, b1 = self._recv_exact(2)
+            fin = b0 & 0x80
+            opcode = b0 & 0x0F
+            ln = b1 & 0x7F
+            if ln == 126:
+                ln = struct.unpack("!H", self._recv_exact(2))[0]
+            elif ln == 127:
+                ln = struct.unpack("!Q", self._recv_exact(8))[0]
+            payload = self._recv_exact(ln) if ln else b""
+            if opcode == 0x9:  # ping -> pong
+                self._send_control(0xA, payload)
+                continue
+            if opcode == 0x8:  # close
+                raise WSError("server closed")
+            data += payload
+            if fin:
+                return data
+
+    def _send_control(self, opcode, payload):
+        mask = os.urandom(4)
+        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+        self.s.sendall(struct.pack("!BB", 0x80 | opcode, 0x80 | len(payload)) + mask + masked)
+
+    def close(self):
+        try:
+            self._send_control(0x8, b"")
+            self.s.close()
+        except Exception:
+            pass
+
+
+def rpc(ws, method, params=None, _id=[0]):
+    _id[0] += 1
+    mid = _id[0]
+    ws.send(json.dumps({"jsonrpc": "2.0", "id": mid, "method": method, "params": params or []}))
+    while True:
+        msg = json.loads(ws.recv())
+        if msg.get("id") == mid:
+            if "error" in msg:
+                raise WSError(f"{method}: {msg['error'].get('message')}")
+            return msg.get("result")
+
+
+def collect():
+    ws = WSClient(NAS_HOST, NAS_PORT, WS_PATH)
+    try:
+        if not rpc(ws, "auth.login_with_api_key", [API_KEY]):
+            raise WSError("api key login rejected")
+        pools = rpc(ws, "pool.query")
+        datasets = rpc(ws, "pool.dataset.query")
+        temps = rpc(ws, "disk.temperatures", [[]])
+    finally:
+        ws.close()
+    return pools, datasets, temps
+
+
+def esc(v):
+    return str(v).replace("\\", "\\\\").replace('"', '\\"')
+
+
+SCRUB_STATES = ["FINISHED", "SCANNING", "CANCELED", "NONE"]
+
+
+def render(pools, datasets, temps):
+    out = []
+
+    def metric(name, mtype, help_):
+        out.append(f"# HELP {name} {help_}")
+        out.append(f"# TYPE {name} {mtype}")
+
+    metric("truenas_pool_size_bytes", "gauge", "Total pool size in bytes")
+    for p in pools:
+        out.append(f'truenas_pool_size_bytes{{pool="{esc(p["name"])}"}} {p["size"]}')
+    metric("truenas_pool_allocated_bytes", "gauge", "Allocated bytes in pool")
+    for p in pools:
+        out.append(f'truenas_pool_allocated_bytes{{pool="{esc(p["name"])}"}} {p["allocated"]}')
+    metric("truenas_pool_free_bytes", "gauge", "Free bytes in pool")
+    for p in pools:
+        out.append(f'truenas_pool_free_bytes{{pool="{esc(p["name"])}"}} {p["free"]}')
+    metric("truenas_pool_healthy", "gauge", "1 if pool healthy else 0")
+    for p in pools:
+        out.append(f'truenas_pool_healthy{{pool="{esc(p["name"])}",status="{esc(p["status"])}"}} {1 if p.get("healthy") else 0}')
+    metric("truenas_pool_fragmentation_ratio", "gauge", "Pool fragmentation percent")
+    for p in pools:
+        try:
+            out.append(f'truenas_pool_fragmentation_ratio{{pool="{esc(p["name"])}"}} {float(p.get("fragmentation") or 0)}')
+        except (TypeError, ValueError):
+            pass
+    metric("truenas_pool_scrub_state", "gauge", "Scrub/resilver: 1 for the current state label")
+    metric("truenas_pool_scrub_errors", "gauge", "Errors from last scrub")
+    metric("truenas_pool_scrub_percentage", "gauge", "Scrub progress percent")
+    metric("truenas_pool_scrub_end_timestamp_seconds", "gauge", "Unix time the last scrub ended")
+    for p in pools:
+        scan = p.get("scan") or {}
+        state = scan.get("state") or "NONE"
+        fn = scan.get("function") or "NONE"
+        pool = esc(p["name"])
+        for s in SCRUB_STATES:
+            out.append(f'truenas_pool_scrub_state{{pool="{pool}",function="{esc(fn)}",state="{s}"}} {1 if state == s else 0}')
+        out.append(f'truenas_pool_scrub_errors{{pool="{pool}"}} {scan.get("errors") or 0}')
+        out.append(f'truenas_pool_scrub_percentage{{pool="{pool}"}} {scan.get("percentage") or 0}')
+        end = scan.get("end_time") or {}
+        if isinstance(end, dict) and end.get("$date"):
+            out.append(f'truenas_pool_scrub_end_timestamp_seconds{{pool="{pool}"}} {int(end["$date"]) / 1000:.0f}')
+
+    metric("truenas_dataset_used_bytes", "gauge", "Dataset used bytes")
+    metric("truenas_dataset_available_bytes", "gauge", "Dataset available bytes")
+    for d in datasets:
+        if d.get("type") != "FILESYSTEM":
+            continue
+        name = esc(d["name"])
+        used = (d.get("used") or {}).get("parsed")
+        avail = (d.get("available") or {}).get("parsed")
+        if used is not None:
+            out.append(f'truenas_dataset_used_bytes{{dataset="{name}"}} {used}')
+        if avail is not None:
+            out.append(f'truenas_dataset_available_bytes{{dataset="{name}"}} {avail}')
+
+    metric("truenas_disk_temperature_celsius", "gauge", "Disk temperature in Celsius")
+    for disk, temp in (temps or {}).items():
+        if temp is not None:
+            out.append(f'truenas_disk_temperature_celsius{{disk="{esc(disk)}"}} {temp}')
+    return "\n".join(out) + "\n"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        if self.path != "/metrics":
+            self.send_response(404)
+            self.end_headers()
+            return
+        start = time.time()
+        try:
+            body = render(*collect())
+            ok = 1
+        except Exception as e:
+            body = ""
+            ok = 0
+            sys.stderr.write(f"scrape error: {e}\n")
+        body += (
+            "# HELP truenas_scrape_success 1 if the last scrape of the TrueNAS API succeeded\n"
+            "# TYPE truenas_scrape_success gauge\n"
+            f"truenas_scrape_success {ok}\n"
+            "# HELP truenas_scrape_duration_seconds Duration of the TrueNAS API scrape\n"
+            "# TYPE truenas_scrape_duration_seconds gauge\n"
+            f"truenas_scrape_duration_seconds {time.time() - start:.3f}\n"
+        )
+        data = body.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer(("0.0.0.0", LISTEN), Handler).serve_forever()


### PR DESCRIPTION
Closes the 'full NAS depth' gap left by #311. On TrueNAS 25.10 (Goldeye), netdata no longer pushes ZFS-pool / dataset / scrub / SMART series over Graphite, so the graphite_exporter pipeline only yields host/IO/ARC/NFS. This adds a small cluster-side exporter that polls the TrueNAS API for the missing depth.

## What it adds
- **`truenas_exporter.py`** — stdlib-only exporter (no pip deps; runs from a stock `python:3.12-slim` via ConfigMap, matching this repo's no-custom-image pattern). Speaks the 25.10 **JSON-RPC WebSocket API** (the REST API rejects non-admin keys) via a minimal inline RFC6455 client.
- **Dedicated least-privilege TrueNAS user `nasexporter`** — roles `POOL_READ, DATASET_READ, POOL_SCRUB_READ, DISK_READ, REPORTING_READ` (read-only; verified writes are denied). **Not a personal key.** Key stored as a **SOPS-encrypted** Secret (`truenas-api-credentials`).
- Deployment runs non-root + read-only rootfs; ClusterIP `:9113`.
- **`truenas-api`** Prometheus scrape job, 60s interval (each scrape is a full API roundtrip — gentle on the NAS).

## Metrics
`truenas_pool_{size,allocated,free,healthy,fragmentation_ratio}`, `truenas_pool_scrub_{state,errors,percentage,end_timestamp_seconds}`, `truenas_dataset_{used,available}_bytes`, `truenas_disk_temperature_celsius`, `truenas_scrape_{success,duration_seconds}`.

## Verified before commit
Ran the exporter locally against the live NAS with the scoped key: 118 metrics, `truenas_scrape_success 1`, 3 pools + 16 datasets + 20 disk temps rendering correctly. `kubectl kustomize` renders clean; SOPS secret round-trips.

## Note
Stable-named ConfigMap (`truenas-exporter-script`) → a manual `kubectl rollout restart deploy/truenas-api-exporter` is needed after a script edit (same trade-off as the rest of this stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)