### PR TITLE
fix(monitoring): hostNetwork on Alloy DaemonSet for real node net + NFS metrics

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alloy-values.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alloy-values.yml
@@ -3,6 +3,9 @@ namespaceOverride: monitoring
 controller:
   type: daemonset
   hostPID: true
+  # hostNetwork: unix exporter needs the node netns for network/NFS stats; dnsPolicy keeps cluster DNS.
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   volumes:
     extra:
       - name: host-root

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/config.alloy
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/config.alloy
@@ -17,10 +17,10 @@ prometheus.exporter.unix "host" {
         mount_points_exclude = "^/(dev|proc|sys|run/k3s/containerd/.+|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)"
     }
     netclass {
-        ignored_devices = "^(veth.*|[a-f0-9]{15})$"
+        ignored_devices = "^(veth.*|cali.*|vxlan\\.calico|kube-ipvs0|nodelocaldns|dummy.*|lxc.*|tap.*|[a-f0-9]{15})$"
     }
     netdev {
-        device_exclude = "^(veth.*|[a-f0-9]{15})$"
+        device_exclude = "^(veth.*|cali.*|vxlan\\.calico|kube-ipvs0|nodelocaldns|dummy.*|lxc.*|tap.*|[a-f0-9]{15})$"
     }
 }
 


### PR DESCRIPTION
## Problem
The Alloy DaemonSet's `prometheus.exporter.unix` runs in the **pod** network namespace. `/proc/net/*` is a symlink to `/proc/self/net`, which is bound to the calling process's netns — so even though we bind-mount host `/proc` via `/host/root`, the network views resolve to the pod:

- `node_network_*` → pod-veth/Calico interfaces (~0.01 MB/s during an HD stream)
- `node_nfs_*` RPC counters → **zero**, despite the node's `/proc/net/rpc/nfs` showing real traffic (`rpc 11077563`)

CPU/disk/load already worked because those `/proc` files (`/proc/stat`, `/proc/loadavg`, disk stats) are **not** netns-scoped.

The kubelet-managed `kubernetes.io~nfs` mounts (Plex media, Grafana, Prometheus on `10.1.2.10`) and their RPC traffic live in the **node's** netns — invisible to the pod-scoped exporter.

## Fix
- `controller.hostNetwork: true` — exporter now reads the node's real network namespace.
- `controller.dnsPolicy: ClusterFirstWithHostNet` — keeps cluster DNS so `remote_write` (`prometheus.monitoring.svc`) and `loki.write` (`loki-gateway.monitoring.svc`) still resolve. ClusterIP routing works from host netns via kube-proxy.
- Extended `netdev`/`netclass` excludes to drop the now-visible Calico/k8s virtual interfaces (`cali*`, `vxlan.calico`, `kube-ipvs0`, `nodelocaldns`), keeping real NICs (`eth0`).

## Safety checks
- `nfs`/`netdev` collectors already enabled (metrics existed, just empty) — no collector changes needed.
- Port `12345` confirmed free on the nodes.
- `hostPID` already true; instance label still set from `NODE_NAME` env (identity unchanged → existing dashboards keep working).
- Only affects the k8s DaemonSet; Proxmox hosts use the separate Ansible Alloy config.
- Chart `1.8.2` confirmed to wire `controller.hostNetwork`/`dnsPolicy` in `_pod.yaml`.

## Post-merge (valuesFrom/config CMs aren't watched)
```
flux reconcile kustomization monitoring --with-source
flux reconcile helmrelease alloy -n monitoring
kubectl -n monitoring rollout status ds/alloy
```
Verify: `rate(node_network_receive_bytes_total{instance="k8s-hawk-3",device="eth0"}[5m])` > 0 and `rate(node_nfs_rpcs_total{instance="k8s-hawk-3"}[5m])` > 0.

Found while debugging Plex buffering (node iowait/load high with no visible NIC or NFS load). Closes the gaps tracked in the observability-gaps note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)