### PR TITLE
fix(proxmox): retry Ubuntu fetch/download to survive London egress stalls (#315)

### DIFF
--- a/Ansible/proxmox.yml
+++ b/Ansible/proxmox.yml
@@ -129,12 +129,17 @@
         filename: ceph-no-subscription
         state: present
 
+    # London egress to releases.ubuntu.com stalls the TLS handshake intermittently; retry through it.
     - name: "Fetch Ubuntu SHA256SUMS"
       ansible.builtin.uri:
         url: >-
           https://releases.ubuntu.com/noble/SHA256SUMS
         return_content: true
+        timeout: 30
       register: sha256sums
+      until: sha256sums is succeeded
+      retries: 5
+      delay: 15
 
     - name: "Parse latest live-server ISO entry"
       vars:
@@ -164,6 +169,11 @@
         owner: root
         group: root
         mode: "0644"
+        timeout: 30
+      register: ubuntu_iso
+      until: ubuntu_iso is succeeded
+      retries: 5
+      delay: 15
 
     - name: "Update LXC template catalogue"
       ansible.builtin.command:


### PR DESCRIPTION
Fixes #315

## Problem

The **Ansible Proxmox** scheduled workflow fails on the **London** job ~daily (≈60% of recent runs; 9 of the last 15). The Hawkfield/Bristol job never fails. Every failure is the `Fetch Ubuntu SHA256SUMS` task on `lon01`:

```
Status code was -1 ... <urlopen error _ssl.c:1012: The handshake operation timed out>
url: https://releases.ubuntu.com/noble/SHA256SUMS  (elapsed: 30)
```

`lon01` intermittently can't complete a TLS handshake to `releases.ubuntu.com` inside the 30s default. London (`10.2.2.0/24`) and Bristol (`10.1.2.0/24`) are separate sites with independent WAN egress; DNS config is effectively identical (both via per-site AdGuard → Cloudflare upstream), so this is an L3 egress stall on London's path, not name resolution. Most likely an IPv6 (AAAA) address tried first over a dead route until the 30s timeout, with no IPv4 fallback in time — see #315 for the full analysis. The task had **no retry**, so one transient stall failed the whole run.

## Change

`Ansible/proxmox.yml`: add retry-with-backoff (`retries: 5`, `delay: 15`, `until: ... is succeeded`) and an explicit `timeout: 30` to:

- `Fetch Ubuntu SHA256SUMS`
- `Download Ubuntu ISO` (same host, same egress risk)

Both are idempotent GETs, so this is safe for both sites and leaves Bristol behaviour unchanged — it just rides through the transient London stalls instead of failing on the first one.

## Notes / follow-ups

- Smallest robust change; doesn't attempt to fix London IPv6 egress itself.
- If retries don't fully settle it: confirm the IPv6 root cause on `lon01` and either fix London IPv6 egress, force IPv4, or point London at a UK Ubuntu mirror via a `group_vars/london.yml` var.
- `ansible-lint` (production profile) passes.
