### PR TITLE
Flux: deploy Deliver on hawkfield

### DIFF
--- a/Ansible/group_vars/adguard.yml
+++ b/Ansible/group_vars/adguard.yml
@@ -50,6 +50,8 @@ adguard_local_dns_entries:
     answer: "10.1.2.205"
   - domain: "tdarr.clinch-home.com"
     answer: "10.1.2.205"
+  - domain: "deliver.clinch-home.com"
+    answer: "10.1.2.205"
 
   # Kubernetes ingress — clincha.co.uk
   - domain: "clincha.co.uk"

--- a/kubernetes/flux/applications/base/deliver/configuration/deliver-kustomization.yml
+++ b/kubernetes/flux/applications/base/deliver/configuration/deliver-kustomization.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: deliver
+  namespace: flux-system
+spec:
+  interval: 5m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: deliver
+  path: ./deploy
+  prune: true
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg

--- a/kubernetes/flux/applications/base/deliver/configuration/kustomization.yml
+++ b/kubernetes/flux/applications/base/deliver/configuration/kustomization.yml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deliver-kustomization.yml

--- a/kubernetes/flux/applications/base/deliver/controller/git-repository.yml
+++ b/kubernetes/flux/applications/base/deliver/controller/git-repository.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: deliver
+  namespace: flux-system
+spec:
+  interval: 5m
+  ref:
+    branch: master
+  secretRef:
+    name: deliver-ssh-key
+  url: ssh://git@github.com/clincha/Deliver.git

--- a/kubernetes/flux/applications/base/deliver/controller/kustomization.yml
+++ b/kubernetes/flux/applications/base/deliver/controller/kustomization.yml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secret.yml
+  - git-repository.yml

--- a/kubernetes/flux/applications/base/deliver/controller/secret.yml
+++ b/kubernetes/flux/applications/base/deliver/controller/secret.yml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: deliver-ssh-key
+    namespace: flux-system
+type: Opaque
+stringData:
+    identity: ENC[AES256_GCM,data:J5WF3YsX9c9U+RUovxd7m8E9ssepU50h7JBD+Qo+uCcW9jWu49X6ka266LwMP4JgUOzzq3a51v0fSfLohZbjksaZJVrZf2tM3RH9XDC5kKg8nziIgoKk0BtaoiyK1MXHeIqyR2MaVx06IvL/QvHRPkvPIOXMI6mOfyq8zykw9ikXE1psbE33R9ASTZc/UksulxNtzfuXAv0Kjo4xnNrR2RvUHtwYVzr4ZLF/LHIDqsMmONTTdh6WUv6+N05Ojz+1LgbDcZTUS4Q8dUbNYrrpQq2mjdLEhy0/O1KVwfvwjRv7fUdWmuDTto/gH55eqIZByXI7JGIm5bVvZz+ttrKIIfLRGp5d+fVxDY+l9KIPxINa/CZXBvwzzlJSB7eeG540uA5uLsUrR1bA3RMwU3zAyO+UYi/dzQwb+azkdn6VEvPlt5sttdRZqRrw88fEq/LYCl91pjoFhTzwdklKaNqGdr5Yv6gPOwmDHmgClXbnQGtsshKkch/I8hPSRc95NZ2yemJ25rkFxFb9yoZXcuxkPQ167ZzD2q5+9BpTxBxAWjgMZrY=,iv:fqMyQnUOPZ2aCwn9IbWI64tC/KTxHu4dbnc4bcx2ABc=,tag:fLLYwHbCFc/IUaCOT8FlDg==,type:str]
+    known_hosts: ENC[AES256_GCM,data:RtSyQUV1i5pcj9IBtL2TV8Cu4pqYgNC8WVgOio6GKbWsog2Kb/qvOfwzErKZIrsuuvY51uei2U9ySvUIw6l4eyuT+iGGwRmeU2Zb79hkWQmQRg8QjhOJ+wGDD/dhW61V2hx8gCZvoDHy1JoyouoFhbIZDxIUq4kVOzQ7GP8Y5BQMiv34B2v70gdh6ZkVo6N9ohI9D2UkYFLFseahMm5tKkZDNoe4gxDaamQ+a2Auhgw8s02ZSfk6sCEuxUItV4Hlz59upAWCYQhyvKIIgNJCCiutYtKqPlyMIZ9JEXu987rkUJWZdNtHbfQrokwg63z8Q0cxD6V8EUrZaGFq1gYSzhjpKb7n4ENSe+VGBI7CEh5deWBluFX0SUWs8oVI8rqUSXWTPHJdfNZaCux0yQWZmXjqL7FQF1HskaDwTe70/W5WDKVopKsrjSnxgO6UO9sXvRtSPjprA6rVDMmIbWdNcUt0Vj3WbdihcHYMCInGj0r8KLviE1q6COhonEfiW2W757Ju1IuG2ciNeKReeds58DetBxlzx/H9dzuqb9eLUsJwfoCMOiSzRrVUQeY8oOkNbla0TOKhseVTiWEfmFUK9+sxZxsePlNRqzdPp81C52TJec/J5jWXM/FOIKDEPzN/97ERMOxcRoeo0fQU6BhlH3KTrRYl2rVOOF/mSbaPn9KiHuwxuZHYZgybJduDT5Kpn4Of3qHkZsI0oEFZZ9vNubnj7f5iLnZ2w32uRuL5PK+jwt2aP0hFdr8+N/efsj9LYck7Ouc0yjbXIslGWNfF7NKuQ/avLHHm5VVClTPM90tFj2VQk8dBvCniZBPPL0UZmMMMaybTmmNnCARgce2rLU+iTvbSiAHYVcu45abYM8y8SB0xiuhk7s1mB3X5GvvN6AL+v+zyffXLDHdZy9cv5Cnf7PrA6nPSdzq6TVFj9nIynOwUyqe/6PoTmZdIT4s2h9WpA3aKYd8X2XfmvMn0XtZP429uFW8wSlJl7Ryu2GLG9ngbEaKPOVudNbJDWy+1HQzUYWNwTA+vDufi6vrDkaVF0LAhigf/U59tstUHeDlk5KBo9m0RBnjOsOv0TQ2LFGd3lb5/8Yj/OjNj,iv:ox8vYR4CCwk5RJBZp37fI5v8WK+rhQfO4OpnQEAPMXM=,tag:mhgmKuN6paRbKNiBUnDe9A==,type:str]
+sops:
+    lastmodified: "2026-06-11T20:14:08Z"
+    mac: ENC[AES256_GCM,data:ry89jTsbJdLN2fY/kruILnrChU4UiFjFNmqly+BbLI4pyurzhpce5lAGdgLXTum8DriTTAfB4bSIpfYET313/SQl5yDCPpw/i3RAGDHBfaZCxfXeUtiiFwT1WESHvdegHdEIEqqIExDkdBlwS0A07VWWO9k1kwSySF7PC7sjgBY=,iv:2rOpazfxuWyohQwocw4vR76c3kxOupb91LnhmLvDJJI=,tag:VwZFh+enA++UQnJGH84Dpw==,type:str]
+    pgp:
+        - created_at: "2026-06-11T20:14:08Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA+iIV7UXPYO1AQ/+PhWu3RjjvgodkVHUR4iSr/H+K6DS1QBYa44IA5VjjG5L
+            r5GNqJc1C/EuB/CwkTO8VhZBXiFGCSvBWkZzadQ9MYIGlZ0PQfErcaJ9DczOExtI
+            PHPyyoxayvdRtkCXXXsdEzjuaFBH1FxmLTj01+urKVTED1WP3P2uwjYZvD5WbNXT
+            mA1Mp+6K/RAOfLZvhPHcDW8atwMoEgyM1SN8OeDnd5wlDyMjggRzfgiY7tLYmaJD
+            qohAWx0Sh/QK80pdakUwnuasHWDnlGleQ8SHFbIGWzT9Uk1xg33qsa8aDz7VMV3S
+            TTtUGoeLJGbEjNRER84oby2XTfFGtm7rD2I2lht5SZK9UmeoD+kQuH/3wxCT7iMB
+            h1xSlX2MZDQTeEFyZDBL8uLN+IvMcHeRceaK06ZA5ayuErVpTJ+WhhPDZewpGOZf
+            kSpdG5wcRE8EZ+To7aAQ0db8B0D6DwLYicU/zAEXYJcSIMU2tOnKELzrRHna6IVi
+            CLWqLf25PjbvBm+MSs8mJdR7von6KSiXa3t224vcyoXZwoxzeq+aMfzyFBJuA2EF
+            KD+JSO8XiqHHOUEud+kr3X8hPKECYujvbv3ZUUUR+YqYlG7Kd7KjNgQqVIP1s57H
+            fAUPbaWyVWhBBJe4GXES1xlwAZVdeXSc2LExnztYn1d5ZQ0No1aO62UGDHsQB37S
+            UQHGT+Kzi8jzCQfehmoFyyYlxg8G/OmHwXyuYIMBGElRT/5pUzEMZuh1dJ0rT32O
+            5nM26Cnc4PbUukKbzSxfLf/rclO6ru9B86X5e5Q/gto0sw==
+            =iuCq
+            -----END PGP MESSAGE-----
+          fp: 76AF39813C2297E8F98C542D42436A07A9BA1DE0
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/kubernetes/flux/applications/hawkfield/deliver/configuration/kustomization.yml
+++ b/kubernetes/flux/applications/hawkfield/deliver/configuration/kustomization.yml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/deliver/configuration

--- a/kubernetes/flux/applications/hawkfield/deliver/controller/kustomization.yml
+++ b/kubernetes/flux/applications/hawkfield/deliver/controller/kustomization.yml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/deliver/controller

--- a/kubernetes/flux/clusters/hawkfield/applications/deliver.yml
+++ b/kubernetes/flux/clusters/hawkfield/applications/deliver.yml
@@ -1,0 +1,41 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: deliver-controller
+  namespace: flux-system
+spec:
+  interval: 1m
+  timeout: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/flux/applications/hawkfield/deliver/controller
+  prune: true
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: deliver-configuration
+  namespace: flux-system
+spec:
+  interval: 1m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/flux/applications/hawkfield/deliver/configuration
+  dependsOn:
+    - name: deliver-controller
+    - name: certificate-manager-configuration
+    - name: ingress-nginx
+  prune: true
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg


### PR DESCRIPTION
Wires [clincha/Deliver](https://github.com/clincha/Deliver) into hawkfield Flux, following the media controller/configuration pattern: the app's manifests live in its own repo (`deploy/`, added in clincha/Deliver#19), and this PR makes Flux reconcile them.

## What

- `applications/base/deliver/controller/` — `GitRepository` for `ssh://git@github.com/clincha/Deliver.git` (branch `master`) + SOPS-encrypted `deliver-ssh-key` Secret (fresh ed25519 deploy key, encrypted to the cluster GPG key `76AF...1DE0`)
- `applications/base/deliver/configuration/` — Flux `Kustomization` reconciling `./deploy` from that repo
- `applications/hawkfield/deliver/{controller,configuration}` overlays + `clusters/hawkfield/applications/deliver.yml` (`deliver-configuration` depends on `deliver-controller`, `certificate-manager-configuration`, `ingress-nginx`)

Image updates: CI tags images with the full commit SHA + `latest`; no Flux image-update automation objects exist in this repo (only the controllers), and SHA tags aren't orderable, so none added. Bump procedure: pin the new SHA in Deliver's `deploy/deployment.yml` and merge — Flux rolls it out. The Deployment starts on `latest` with `imagePullPolicy: Always` until the first pin.

## Before merging (manual steps, in order)

1. Merge clincha/Deliver#19 (manifests) — and clincha/Deliver#16 so an image exists on GHCR.
2. Add this **public** deploy key to clincha/Deliver (Settings → Deploy keys, read-only) — the encrypted private half is in this PR:

   ```
   ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE1dVzXont4xCtZh0I7GFLcLRyLSdaXJCS85PRx+AZUg flux deliver deploy key
   ```
3. Create the app Secret (values are only known to you — the Gmail app password can't be read back from Actions secrets):

   ```bash
   kubectl -n deliver create secret generic deliver-secrets \
     --from-literal=GMAIL_ADDRESS=... \
     --from-literal=GMAIL_APP_PASSWORD=... \
     --from-literal=ANTHROPIC_API_KEY=...
   ```
   (namespace exists once Flux applies the manifests; create the Secret right after, the Deployment waits on it)
4. Either make the `ghcr.io/clincha/deliver` package public, or create the pull secret:

   ```bash
   kubectl -n deliver create secret docker-registry ghcr-pull \
     --docker-server=ghcr.io --docker-username=<user> --docker-password=<PAT with read:packages>
   ```
5. Point DNS for `deliver.clinch-home.com` at the ingress (AdGuard rewrite, same as the other apps) if not covered by a wildcard.

## Verification

- `kubectl kustomize` builds both hawkfield overlays cleanly
- `kubectl apply --dry-run=client` passes on the rendered overlays and `clusters/hawkfield/applications/deliver.yml` (kubectl v1.35.4)
- `sops` metadata fingerprint matches `.sops.yaml` (`76AF39813C2297E8F98C542D42436A07A9BA1DE0`)

Part of clincha/Deliver#10

🤖 Generated with [Claude Code](https://claude.com/claude-code)