### PR TITLE
monitoring: install Alloy unpinned so it stops fighting the update play

### DIFF
--- a/Ansible/roles/monitoring/defaults/main.yml
+++ b/Ansible/roles/monitoring/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-monitoring_alloy_version: "1.16.2-1"
 monitoring_scrape_interval: "15s"
 monitoring_disabled_collectors:
   - wifi

--- a/Ansible/roles/monitoring/tasks/install.yml
+++ b/Ansible/roles/monitoring/tasks/install.yml
@@ -23,5 +23,5 @@
 
 - name: Install Grafana Alloy
   ansible.builtin.apt:
-    name: "alloy={{ monitoring_alloy_version }}"
+    name: alloy
     state: present


### PR DESCRIPTION
## Problem

The **Ansible host monitoring** workflow has failed 3/3 over the last 7 days (hawk01/02/03 + lon01).

## Root cause

The monitoring role pinned Alloy via `monitoring_alloy_version` (`1.16.2-1`) and installed `alloy=<version>`. Meanwhile the scheduled update play (`update-proxmox.yml`, `apt state=latest`) moves Alloy **forward** to the newer build. So the next monitoring run tried to pull it **back down** to the pin, and apt refuses a downgrade without `--allow-downgrades` → the play fails. The two plays were fighting over the version.

## Fix

Per review feedback: stop pinning in the install role and let the update play own upgrades.

- Install `alloy` with `state: present` (ensure-installed, no version).
- Drop the now-unused `monitoring_alloy_version` default.

Fresh hosts get the current package; existing hosts keep whatever the scheduled update play installed. No downgrade, no fight.

(Supersedes the earlier `allow_downgrade: true` approach, which would have kept the pin and re-broken on every Alloy release.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)