### PR TITLE
monitoring: manage loki-minio-creds via SOPS

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
@@ -5,6 +5,7 @@ metadata:
 resources:
   - ../../base/monitoring
   - truenas-api-key.sops.yaml
+  - loki-minio-creds.sops.yaml
 configMapGenerator:
   - name: prometheus.yml
     namespace: monitoring

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/loki-minio-creds.sops.yaml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/loki-minio-creds.sops.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: loki-minio-creds
+    namespace: monitoring
+type: Opaque
+stringData:
+    S3_ACCESS_KEY_ID: ENC[AES256_GCM,data:9Cf5Gw==,iv:8b5G2gvzZZ670wjMH2hPbQYcwxz9FoqWX/FbicWh/44=,tag:huqAG8oQzX5YLPLhdSenCQ==,type:str]
+    S3_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:MMc3GiIpvA1Exx0khyRcIsqAzE7xyKHjYxYtp+lMv/THT9fjEpphuhzVjB3j1mLn,iv:lUkvK/XIUPEyiT02Ul05yVVBWHax9e6ylJfvuaCfreU=,tag:93HLxs4WGhuftKjcvYh7ww==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-16T20:48:05Z"
+    mac: ENC[AES256_GCM,data:VSTqNLb9g1wDUXhWmtrS5Yupvfhi8/rQVY8bQuxHugB0PMqW/ATGmSbLXjFyvu2jmq4Yk8H/cp0u94/yxuFRtfu/STscyn4hGbr2H+fWkT8faF+CbisKnjlqVqxiqeHbIHinC/bIBjj/qer8stKn/7QYKXgdS936IKWu1nut8Gs=,iv:qEtoYIdt39W9lCVWXJjCGhCnPe0+QX8byxzg3SFh1VQ=,tag:aXPNG5bztMQ92kM5CFqONg==,type:str]
+    pgp:
+        - created_at: "2026-06-16T20:48:05Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA+iIV7UXPYO1ARAAlb9M0V1/wTYGyQy5K8Z6fmmO2BeJJlQ9Nxf9p4FRqTjg
+            RCwvL7kPTpzbEITjvnfo0W9YQK5SQfZPGXNcKbAQb19lWYF+/cslAaWjTGQCEkwH
+            4df51ew5eMp/LDQzvfUrz4JkeLX8IwnCm3fS7eVAsP4OaC7jBIs2vuv96A22436s
+            wY3qQOgNOJgKokh7BdcbQD99DJNG+U4RZHxJ10Ord4OZTFitt44MDENunyWeQlMV
+            /72veiM5rvUqRjjK8H/nX21VUuwuIkXIz4GR+UlZxslySL40BbpoNao/DrbteshE
+            2T/Q/xWTcC1amjCy2uW3MAGGu25qgBBbWOSVRTXKB83ln9ePRootr0swX01C08tV
+            YiNH3XVDqN4yugQ7wkMkemLqsT1w6AAoIX0A8wUhH1iF+p/N4QLWffYM/tdj9yEj
+            Yame2wPMJ+YjkRVWBPV4wJeUBTVIGWGWs+SJ6goRF8W08v8yXtXzmppId9nN4SHz
+            ohx9DS8t1t00rVyKs3HCzbkxp4LdXFiOiaYucY1ccOqQSpJPbSggRBNjv9/8esuC
+            iQYDDdY/nlaA61YHSmJSQSE+s9f45o23e5ui7fuQFiaRbPCUYw95bea6cE/Lo+Mr
+            hRFR7oKhn8ofLK5ITbay842Jf3prqG/wNvZciDPVeRcFFBzV4WOhV7m2vB6Q0cLS
+            XAErimPy3NTYcBSrHcraA1wd3RGW+gTzy9emX5Edp9vwBJrb9ywrA83RA78114qG
+            aphQYGvF2y6NXh0+xT0/oXqbteXi4x4FJGR6e5VjabT1ODmdPpGXDgFvICKg
+            =42zX
+            -----END PGP MESSAGE-----
+          fp: 76AF39813C2297E8F98C542D42436A07A9BA1DE0
+    version: 3.13.1


### PR DESCRIPTION
## Problem

`monitoring/loki-minio-creds` (the S3 access key/secret for Loki's MinIO object-storage backend) was created by hand and only ever existed in the live cluster — it was **not in source control**. A clean cluster bootstrap would bring Loki up without its storage credentials.

Found during a sweep for live-only secrets (Secrets with no Flux/SOPS or Helm provenance).

## Change

- Add `loki-minio-creds.sops.yaml` — the Secret, SOPS-encrypted with the same PGP key as `truenas-api-credentials` (only `stringData` is encrypted).
- Reference it from the monitoring `kustomization.yml`.

The `monitoring` Flux Kustomization already has `decryption.provider: sops` (secretRef `sops-gpg`), so Flux decrypts it on reconcile. Values match the live Secret exactly, so this is a no-op for the running cluster and a safety net for rebuilds.

## Verification

`kubectl kustomize` builds the monitoring overlay successfully with the Secret included and still encrypted; `sops --decrypt` round-trips to the live values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)