### PR TITLE
feat(elastic-finance): auto-restore Kibana dashboards on rebuild

### DIFF
--- a/kubernetes/flux/applications/base/elastic-finance/README.md
+++ b/kubernetes/flux/applications/base/elastic-finance/README.md
@@ -38,4 +38,3 @@ curl -sf -u "$USER:$PASS" \
 Commit the updated `dashboards/dashboards.ndjson`. On the next reconcile the
 import Job restores it; after a cluster rebuild the dashboards come back with no
 manual steps.
-

--- a/kubernetes/flux/applications/base/elastic-finance/README.md
+++ b/kubernetes/flux/applications/base/elastic-finance/README.md
@@ -6,3 +6,36 @@ Helm chart: https://github.com/elastic/cloud-on-k8s/tree/main/deploy/eck-stack
 
 Available roles for users: https://www.elastic.co/docs/reference/elasticsearch/roles
 
+## Dashboard backup and restore
+
+Kibana dashboards are saved objects held in the `.kibana` indices, so a full
+cluster rebuild destroys them even though the Longhorn volumes survive pod
+restarts. To make dashboards reproducible from the build, they are exported to
+NDJSON, committed under `dashboards/`, and re-imported automatically on every
+deploy by the `kibana-dashboard-import` Job.
+
+The Job waits for Kibana to be ready, then imports every `dashboards/*.ndjson`
+file via the Saved Objects `_import` API with `overwrite=true`, so it is
+idempotent and safe to re-run. Empty files are skipped, so committing dashboards
+is optional until you have some.
+
+### Export (run whenever dashboards change, then commit)
+
+Port-forward Kibana and export the saved objects you want to keep. Credentials
+come from the `secret-basic-auth` secret.
+
+```bash
+kubectl -n elastic-finance port-forward svc/kibana-kb-http 5601:5601 &
+
+curl -sf -u "$USER:$PASS" \
+  -H "kbn-xsrf: true" \
+  -X POST "http://localhost:5601/api/saved_objects/_export" \
+  -H "Content-Type: application/json" \
+  -d '{"type":["dashboard"],"includeReferencesDeep":true}' \
+  -o dashboards/dashboards.ndjson
+```
+
+Commit the updated `dashboards/dashboards.ndjson`. On the next reconcile the
+import Job restores it; after a cluster rebuild the dashboards come back with no
+manual steps.
+

--- a/kubernetes/flux/applications/base/elastic-finance/dashboard-import-job.yml
+++ b/kubernetes/flux/applications/base/elastic-finance/dashboard-import-job.yml
@@ -1,0 +1,66 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kibana-dashboard-import
+  namespace: elastic-finance
+spec:
+  backoffLimit: 10
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: import
+          image: curlimages/curl:8.11.1
+          env:
+            - name: KIBANA_URL
+              value: http://kibana-kb-http.elastic-finance:5601
+            - name: KIBANA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: secret-basic-auth
+                  key: username
+            - name: KIBANA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: secret-basic-auth
+                  key: password
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              auth="$KIBANA_USERNAME:$KIBANA_PASSWORD"
+              echo "Waiting for Kibana to be available..."
+              until curl -sf -u "$auth" \
+                "$KIBANA_URL/api/status" >/dev/null; do
+                sleep 5
+              done
+              echo "Kibana is up. Importing dashboards..."
+              imported=0
+              for file in /dashboards/*.ndjson; do
+                if [ ! -s "$file" ]; then
+                  echo "Skipping empty $file"
+                  continue
+                fi
+                echo "Importing $file"
+                curl -sf -u "$auth" \
+                  -H "kbn-xsrf: true" \
+                  -X POST \
+                  "$KIBANA_URL/api/saved_objects/_import?overwrite=true" \
+                  --form file=@"$file"
+                echo
+                imported=$((imported + 1))
+              done
+              if [ "$imported" -eq 0 ]; then
+                echo "No dashboards to import."
+              fi
+          volumeMounts:
+            - name: dashboards
+              mountPath: /dashboards
+              readOnly: true
+      volumes:
+        - name: dashboards
+          configMap:
+            name: kibana-dashboards

--- a/kubernetes/flux/applications/base/elastic-finance/dashboard-import-job.yml
+++ b/kubernetes/flux/applications/base/elastic-finance/dashboard-import-job.yml
@@ -45,12 +45,16 @@ spec:
                   continue
                 fi
                 echo "Importing $file"
-                curl -sf -u "$auth" \
+                response=$(curl -s -u "$auth" \
                   -H "kbn-xsrf: true" \
                   -X POST \
                   "$KIBANA_URL/api/saved_objects/_import?overwrite=true" \
-                  --form file=@"$file"
-                echo
+                  --form file=@"$file")
+                echo "$response"
+                echo "$response" | grep -q '"success":true' || {
+                  echo "Import of $file failed"
+                  exit 1
+                }
                 imported=$((imported + 1))
               done
               if [ "$imported" -eq 0 ]; then

--- a/kubernetes/flux/applications/base/elastic-finance/kustomization.yml
+++ b/kubernetes/flux/applications/base/elastic-finance/kustomization.yml
@@ -5,3 +5,11 @@ resources:
   - helm-release.yml
   - elastic-certificate.yml
   - kibana-certificate.yml
+  - dashboard-import-job.yml
+configMapGenerator:
+  - name: kibana-dashboards
+    namespace: elastic-finance
+    files:
+      - dashboards/dashboards.ndjson
+generatorOptions:
+  disableNameSuffixHash: true


### PR DESCRIPTION
## What changed

Adds an automated Kibana dashboard restore path for `elastic-finance` so dashboards survive a full Kubernetes cluster rebuild (not just pod restarts, which Longhorn already covers).

- **`dashboard-import-job.yml`** — a Flux-managed Job that waits for Kibana `/api/status`, then imports every `dashboards/*.ndjson` file via the Saved Objects `_import?overwrite=true` API. Idempotent and safe to re-run; empty files are skipped.
- **`kustomization.yml`** — registers the Job and a `configMapGenerator` (`kibana-dashboards`, no name-suffix hash) mounting the committed NDJSON.
- **`dashboards/dashboards.ndjson`** — placeholder for the committed export.
- **`README.md`** — documents the export (`curl` `_export`) / auto-import workflow.

Dashboards become declarative, git-versioned, and auto-restored on every rebuild.

## Review findings addressed

- Kibana's `_import` API returns HTTP 200 even when an import fails (`"success":false` in the body), so `curl -sf` would have treated a failed restore as success and silently no-op'd. The Job now inspects the response for `"success":true` and exits non-zero otherwise, so a genuine failure surfaces and the Job retries (`backoffLimit`/`OnFailure`).
- Verified both `dev` and `london` overlays render with `kubectl kustomize`, yamllint passes, and the embedded shell script parses.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)
