### PR TITLE
claude: automate gogcli credentials restoration

### DIFF
--- a/.github/workflows/ansible-claude.yaml
+++ b/.github/workflows/ansible-claude.yaml
@@ -62,6 +62,9 @@ jobs:
           BW_CLIENT_SECRET: ${{ secrets.BW_CLIENT_SECRET }}
           BW_MASTER_PASSWORD: ${{ secrets.BW_MASTER_PASSWORD }}
           GH_PAT: ${{ secrets.GH_PAT }}
+          GOG_CREDENTIALS_JSON: ${{ secrets.GOG_CREDENTIALS_JSON }}
+          GOG_KEYRING_PASSWORD: ${{ secrets.GOG_KEYRING_PASSWORD }}
+          GOG_TOKEN_STORE: ${{ secrets.GOG_TOKEN_STORE }}
         run: |
           ansible-playbook claude.yml \
             --inventory inventory/hawkfield.proxmox.yml \

--- a/Ansible/roles/claude/defaults/main.yml
+++ b/Ansible/roles/claude/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+claude_gogcli_version: "0.33.0"

--- a/Ansible/roles/claude/tasks/main.yml
+++ b/Ansible/roles/claude/tasks/main.yml
@@ -212,6 +212,88 @@
     group: claude
     mode: "0755"
 
+# gogcli (Google Gmail + Calendar). Restore after the dave clone so the reset
+# can't disturb ~/.config/gogcli. Tokens are password-derived (PBES2) and thus
+# portable, so restoring the keyring store is enough — no manual gog auth login.
+- name: "Download gogcli release tarball"
+  ansible.builtin.get_url:
+    # yamllint disable-line rule:line-length
+    url: "https://github.com/steipete/gogcli/releases/download/v{{ claude_gogcli_version }}/gogcli_{{ claude_gogcli_version }}_linux_amd64.tar.gz"
+    dest: "/home/claude/.cache/gogcli-{{ claude_gogcli_version }}.tar.gz"
+    owner: claude
+    group: claude
+    mode: "0644"
+
+- name: "Install gogcli binary"
+  ansible.builtin.unarchive:
+    src: "/home/claude/.cache/gogcli-{{ claude_gogcli_version }}.tar.gz"
+    dest: /usr/local/bin
+    remote_src: true
+    include:
+      - gog
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: "Ensure gogcli config directory exists"
+  ansible.builtin.file:
+    path: /home/claude/.config/gogcli
+    state: directory
+    owner: claude
+    group: claude
+    mode: "0700"
+
+- name: "Configure gogcli file keyring backend"
+  ansible.builtin.copy:
+    content: |
+      {
+        "keyring_backend": "file"
+      }
+    dest: /home/claude/.config/gogcli/config.json
+    owner: claude
+    group: claude
+    mode: "0600"
+
+- name: "Restore gogcli OAuth client credentials"
+  ansible.builtin.copy:
+    content: "{{ lookup('env', 'GOG_CREDENTIALS_JSON') }}"
+    dest: /home/claude/.config/gogcli/credentials.json
+    owner: claude
+    group: claude
+    mode: "0600"
+  no_log: true
+
+- name: "Restore gogcli keyring password"
+  ansible.builtin.copy:
+    content: "{{ lookup('env', 'GOG_KEYRING_PASSWORD') }}"
+    dest: /home/claude/.config/gogcli/.keyring-password
+    owner: claude
+    group: claude
+    mode: "0600"
+  no_log: true
+
+- name: "Ensure gogcli keyring directory exists"
+  ansible.builtin.file:
+    path: /home/claude/.config/gogcli/keyring
+    state: directory
+    owner: claude
+    group: claude
+    mode: "0700"
+
+- name: "Restore gogcli keyring OAuth token store"
+  ansible.builtin.copy:
+    content: "{{ item.value }}"
+    dest: "/home/claude/.config/gogcli/keyring/{{ item.key }}"
+    owner: claude
+    group: claude
+    mode: "0600"
+  loop: >-
+    {{ (lookup('env', 'GOG_TOKEN_STORE') | default('{}', true))
+       | from_json | dict2items }}
+  loop_control:
+    label: "{{ item.key }}"
+  no_log: true
+
 - name: "Download Claude Code installer"
   ansible.builtin.get_url:
     url: "https://claude.ai/install.sh"

--- a/Ansible/roles/claude/templates/bw-api.sh.j2
+++ b/Ansible/roles/claude/templates/bw-api.sh.j2
@@ -1,2 +1,3 @@
 export BW_CLIENTID="{{ bw_client_id }}"
 export BW_CLIENTSECRET="{{ bw_client_secret }}"
+export GOG_KEYRING_PASSWORD="$(cat /home/claude/.config/gogcli/.keyring-password)"


### PR DESCRIPTION
## What & why

The `claude` Ansible role provisioned everything for Dave except gogcli (Google Gmail + Calendar), leaving `gog auth list` empty on a fresh deploy. This extends the role to fully restore gogcli headlessly, mirroring the existing env-var-injection pattern used for the SSH key, `.bw-master`, and GH PAT.

Changes:
- Install a pinned gogcli release binary (`claude_gogcli_version`, `0.33.0`) via `get_url` + `unarchive` into `/usr/local/bin`.
- Restore `~/.config/gogcli/` — `config.json` (`file` keyring backend), `credentials.json`, `.keyring-password`, and every keyring OAuth token file. Tokens are password-derived (PBES2/JWE) so the store is portable; no manual `gog auth login` fallback is needed.
- Restore tasks run **after** the dave repo clone so the `reset --hard` can't disturb `~/.config/gogcli`.
- Export `GOG_KEYRING_PASSWORD` from `bw-api.sh.j2` by reading the restored file (avoids duplicating the secret in the template).
- Wire three new repo secrets into the workflow: `GOG_CREDENTIALS_JSON`, `GOG_KEYRING_PASSWORD`, `GOG_TOKEN_STORE`.

## Required before next deploy

The three secrets above must be created (repo secrets, matching the existing `BW_*`/`GH_PAT` pattern). Until they exist the restore tasks write empty files and `gog auth list` shows nothing — the playbook itself does not error.

## Review

Verified independently: the release URL resolves (HTTP 200) and the tarball contains a top-level `gog` binary, so the `include: [gog]` extraction is correct. Confirmed graceful degradation when `GOG_TOKEN_STORE` is unset (`default('{}', true) | from_json | dict2items` → empty loop, no error), `no_log` on all secret-bearing tasks, correct task ordering relative to the clone, and that `bw-api.sh` is sourced via the same runtime mechanism as the existing exports. ansible-lint (production/strict) passes clean; no code changes were required.

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)