### PR TITLE
proxmox: retry Ubuntu fetches to ride out London egress stalls

### DIFF
--- a/Ansible/proxmox.yml
+++ b/Ansible/proxmox.yml
@@ -134,7 +134,11 @@
         url: >-
           https://releases.ubuntu.com/noble/SHA256SUMS
         return_content: true
+        timeout: 30
       register: sha256sums
+      until: sha256sums is succeeded
+      retries: 5
+      delay: 15
 
     - name: "Parse latest live-server ISO entry"
       vars:
@@ -164,6 +168,11 @@
         owner: root
         group: root
         mode: "0644"
+        timeout: 30
+      register: ubuntu_iso
+      until: ubuntu_iso is succeeded
+      retries: 5
+      delay: 15
 
     - name: "Update LXC template catalogue"
       ansible.builtin.command:


### PR DESCRIPTION
## What changed and why

The `Ansible Proxmox` scheduled workflow fails on the London job ~60% of runs, always on `Fetch Ubuntu SHA256SUMS` on `lon01` — a 30s TLS handshake timeout to `releases.ubuntu.com`. The task had no retry, so a single transient egress stall (likely a dead London IPv6 route the resolver hands back via AAAA) fails the whole run. Hawkfield's egress is clean and never stalls.

Both Ubuntu fetches in `Ansible/proxmox.yml` are idempotent GETs, so this makes them resilient to the transient stall rather than chasing the (unproven, on-box) IPv6 root cause:

- `Fetch Ubuntu SHA256SUMS` (`ansible.builtin.uri`): explicit `timeout: 30`, `retries: 5`, `delay: 15`, `until: sha256sums is succeeded`.
- `Download Ubuntu ISO` (`ansible.builtin.get_url`): same retry/backoff, plus a `register: ubuntu_iso` so `until` has a result to test. The checksum guard still skips the download when the ISO is already present.

Hawkfield behaviour is unchanged when the path is clean (first attempt succeeds). Worst case adds ~2.5 min if London is fully down.

Closes #315

## Review

Verified the retry keys are valid task keywords for both `uri` and `get_url`, confirmed the `get_url` `register` is required for `until`; `ansible-lint` (production/strict) and `yamllint` both pass. No changes needed to the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)