### PR TITLE
ansible: bump kubespray to v2.29.1 for hostendpoints watch RBAC

### DIFF
--- a/Ansible/galaxy-requirements.yml
+++ b/Ansible/galaxy-requirements.yml
@@ -16,7 +16,7 @@ collections:
 
   - name: "https://github.com/kubernetes-sigs/kubespray"
     type: git
-    version: v2.29.0
+    version: v2.29.1  # adds hostendpoints "watch" RBAC (kubespray#11076)
 
   - name: "ansible.netcommon"
     version: "8.1.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ packer build packer/ubuntu2404/main.pkr.hcl
 - **Roles**: `base/`, `users/`, `sudoers/`, `helm/`
 - **Inventory**: Dynamic Proxmox-based (`inventory/hawkfield.proxmox.yml`, `inventory/london.proxmox.yml`)
 - **Group vars**: `group_vars/all.yml`, `group_vars/hawkfield.yml`, `group_vars/london.yml`
-- Kubespray v2.29.0 (installed via Galaxy as a collection)
+- Kubespray v2.29.1 (installed via Galaxy as a collection)
 
 ### Kubernetes (`kubernetes/flux/`)
 


### PR DESCRIPTION
## What changed

Bumps the Kubespray git pin in `Ansible/galaxy-requirements.yml` from `v2.29.0` to `v2.29.1`, and updates the matching version reference in `CLAUDE.md`.

## Why

`calico-kube-controllers` cannot `watch` the `hostendpoints` CRD under `v2.29.0`, so it retries in a tight loop, logging ~180k `Failed to create watcher` WARN lines/day — the largest single log source in the hawkfield estate. It is functionally harmless (host endpoints are unused) but drowns the logs and inflates Loki ingest.

`v2.29.1` is a bugfix-only patch release (same Calico/Kubernetes versions) that contains the upstream fix adding the `watch` verb (kubespray#11076). Verified against the tag: `roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2` at `v2.29.1` renders `verbs: [get, list, create, update, delete, watch]` on the `hostendpoints` rule. Kubespray re-applies the corrected ClusterRole on the next `kubernetes.yml` run, so no full rebuild is required.

## Review findings addressed

The implementation was a correct single-line bump. Added a follow-up commit updating the stale `Kubespray v2.29.0` reference in `CLAUDE.md` to keep docs consistent with the pin. yamllint passes; confirmed the fix is present in the `v2.29.1` tag.

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)