### PR TITLE
monitoring: silence loki-gateway 2xx access logs

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/loki-values.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/loki-values.yml
@@ -64,3 +64,5 @@ test: { enabled: false }
 
 gateway:
   enabled: true
+  # Log only non-2xx/3xx responses so successful Alloy pushes stop flooding Loki
+  verboseLogging: false


### PR DESCRIPTION
## What & why

`loki-gateway` (the Loki chart's bundled nginx proxy) was logging an access-log line for every successful `204 POST /loki/api/v1/push` from Alloy — roughly 8,600 lines/hour, about a third of the `monitoring` namespace's pod-log volume and ~20% of total pod-log ingest. Loki was logging the act of shipping logs, then shipping those logs again, at zero diagnostic value.

Set `gateway.verboseLogging: false` in the Loki Helm values. In chart v7.0.0 this switches the gateway nginx config from unconditional `access_log` to `access_log ... if=$loggable` with a `map $status $loggable` block that drops 2xx/3xx — silencing successful pushes at the source while retaining error/non-2xx visibility. One-line values change, no custom nginx snippet to maintain.

Closes #326

## Review

Verified against the pinned `grafana/loki` chart v7.0.0 that `gateway.verboseLogging` exists and its `_helpers.tpl` renders the `map $status $loggable { ~^[23] 0; default 1; }` gate when false; confirmed no new yamllint issues introduced. Implementation matches the plan; no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)