### PR TITLE
monitoring: raise client-body-buffer-size on prometheus/grafana ingress

### DIFF
--- a/kubernetes/flux/infrastructure/base/monitoring/ingress.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/ingress.yml
@@ -4,6 +4,8 @@ kind: Ingress
 metadata:
   name: prometheus
   namespace: monitoring
+  annotations:
+    nginx.ingress.kubernetes.io/client-body-buffer-size: "64k"
 spec:
   ingressClassName: nginx
   tls:
@@ -35,6 +37,8 @@ kind: Ingress
 metadata:
   name: grafana
   namespace: monitoring
+  annotations:
+    nginx.ingress.kubernetes.io/client-body-buffer-size: "64k"
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
## What changed

Adds `nginx.ingress.kubernetes.io/client-body-buffer-size: "64k"` to the `prometheus` and `grafana` Ingress objects in the shared base monitoring manifests.

## Why

ingress-nginx logs `[warn] ... a client request body is buffered to a temporary file` ~300×/hour on the `server: prometheus` path. These are Grafana Prometheus-datasource `POST /api/ds/query` bodies exceeding nginx's default 16k `client-body-buffer-size`, spilling to disk on the ingress pod. Scoping the buffer bump to the two affected Ingresses (rather than raising the global ConfigMap default) keeps the blast radius minimal and stays fully declarative through Flux. 64k comfortably covers typical query POSTs while staying small per-connection.

Closes #327

## Review

Verified `kubectl kustomize` renders clean for both `hawkfield/monitoring` and `london/monitoring`, with the annotation surviving on both Ingresses including the london grafana host patch; yamllint passes. No global ConfigMap or `proxy-buffer-size` change needed since this is a request-body buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)