### PR TITLE
Add AdGuard DNS records for Immich

### DIFF
--- a/Ansible/group_vars/adguard.yml
+++ b/Ansible/group_vars/adguard.yml
@@ -58,6 +58,10 @@ adguard_local_dns_entries:
     answer: "10.1.2.205"
   - domain: "tdarr.clinch-home.com"
     answer: "10.1.2.205"
+  - domain: "immich.clinch-home.com"
+    answer: "10.1.2.205"
+  - domain: "photos.clinch-home.com"
+    answer: "10.1.2.205"
 
   # Kubernetes ingress — clincha.co.uk
   - domain: "clincha.co.uk"
@@ -93,6 +97,10 @@ adguard_local_dns_entries:
   - domain: "ombi.clincha.co.uk"
     answer: "10.1.2.205"
   - domain: "tdarr.clincha.co.uk"
+    answer: "10.1.2.205"
+  - domain: "immich.clincha.co.uk"
+    answer: "10.1.2.205"
+  - domain: "photos.clincha.co.uk"
     answer: "10.1.2.205"
 
   # Claude server (Dave)


### PR DESCRIPTION
Immich went live in `clincha/media` today (PRs #4 → #6) but none of its hostnames
resolve, so the only way in is the ingress IP.

Adds four rewrites to `adguard_local_dns_entries`, pointing at the ingress VIP
`10.1.2.205` like every other cluster service:

| domain | answer |
|---|---|
| `immich.clinch-home.com` | 10.1.2.205 |
| `photos.clinch-home.com` | 10.1.2.205 |
| `immich.clincha.co.uk` | 10.1.2.205 |
| `photos.clincha.co.uk` | 10.1.2.205 |

`photos.*` is the friendly alias; both are already in the Immich Ingress and on the
issued certificate, which is `Ready` for all four names.

## Verified
- `yamllint` clean, file parses, no duplicate domains (49 entries total)
- Immich answers through the ingress today when the name is forced past DNS:
  `curl --resolve immich.clinch-home.com:443:10.1.2.205` → `{"res":"pong"}` with a
  valid certificate, so these records are the only thing missing

Merging deploys straight away — the AdGuard workflow triggers on pushes to `master`
touching `Ansible/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)