### PR TITLE
Move loki and uptime-kuma off Longhorn onto NFS

### DIFF
--- a/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
+++ b/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
@@ -16,7 +16,25 @@ spec:
         name: uptime-kuma
         namespace: uptime-kuma
       interval: 1m
-#  valuesFrom:
-#    - kind: ConfigMap
-#      name: uptime-kuma-values
-#      valuesKey: values.yml
+  # Values are inline rather than valuesFrom: helm-controller does not watch the
+  # referenced ConfigMap, so an edit there needs a manual --force reconcile.
+  values:
+    # /app/data is the SQLite database. Mounted from hawkstore NFS rather than a
+    # PVC — a Longhorn journal abort silently wedged two volumes with EIO for 18
+    # days on 2026-07-08.
+    volume:
+      enabled: false
+    additionalVolumes:
+      - name: storage
+        nfs:
+          server: 10.1.2.10
+          path: /mnt/data/uptime-kuma
+    additionalVolumeMounts:
+      - name: storage
+        mountPath: /app/data
+    # The export is root_squash and the image defaults to root.
+    podSecurityContext:
+      runAsUser: 3019
+      runAsGroup: 3021
+      fsGroup: 3021
+      runAsNonRoot: true

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/loki-values.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/loki-values.yml
@@ -7,6 +7,14 @@ global:
 
 loki:
   auth_enabled: false
+  # The export is root_squash, so run as the hawkstore loki user rather than the
+  # chart default 10001. fsGroupChangePolicy is dropped: recursive chown of the
+  # mount is pointless on NFS and the dataset is already owned 3018:3020.
+  podSecurityContext:
+    runAsUser: 3018
+    runAsGroup: 3020
+    fsGroup: 3020
+    runAsNonRoot: true
   commonConfig:
     replication_factor: 1
   schemaConfig:
@@ -48,10 +56,19 @@ singleBinary:
   extraEnvFrom:
     - secretRef:
         name: loki-minio-creds
+  # /var/loki is WAL + tsdb-shipper index cache only; the durable chunks live in
+  # MinIO. Mounted from hawkstore NFS rather than a PVC — a Longhorn journal abort
+  # silently wedged this volume with EIO for 18 days on 2026-07-08.
   persistence:
-    enabled: true
-    size: 10Gi
-    storageClass: longhorn
+    enabled: false
+  extraVolumes:
+    - name: storage
+      nfs:
+        server: 10.1.2.10
+        path: /mnt/data/loki
+  extraVolumeMounts:
+    - name: storage
+      mountPath: /var/loki
 
 backend: { replicas: 0 }
 read: { replicas: 0 }


### PR DESCRIPTION
The last two Longhorn volumes in the cluster. Both now mount hawkstore NFS inline with no PVC, matching the shape the media repo already uses. After this, nothing in the cluster is on Longhorn.

## Loki

`/var/loki` holds the WAL and the tsdb-shipper index cache — the durable chunks are already in MinIO. This is the volume that took an ext4 journal abort on 2026-07-08 and has been returning `input/output error` on every write since, which is why Grafana has had no logs for 18 days. Moving it is the fix.

- `singleBinary.persistence.enabled: false`, with `extraVolumes`/`extraVolumeMounts` supplying `storage` at `/var/loki`. The chart renders both into the StatefulSet, so no PVC is involved.
- `loki.podSecurityContext` runs it as `3018:3020` instead of the chart default `10001`, because the export is `root_squash`. Note this key lives under `loki:`, not `singleBinary:`.

## uptime-kuma

`/app/data` is its SQLite database. Same treatment via `volume.enabled: false` plus `additionalVolumes`/`additionalVolumeMounts`, running as `3019:3021`.

Values move **inline** into the HelmRelease rather than `valuesFrom`. helm-controller does not watch ConfigMaps referenced that way, so an edit there sits silently until someone runs a manual `--force` reconcile. That bit us on this repo before.

### Data preserved

I did a cold copy of uptime-kuma's 45 MB `kuma.db` to `/mnt/data/uptime-kuma` with the deployment scaled to 0, and verified it byte-for-byte:

```
old: d886796802ace50fe955b52119358690  /old/kuma.db
new: d886796802ace50fe955b52119358690  /new/kuma.db
IDENTICAL
```

So the monitors survive rather than needing to be rebuilt. uptime-kuma is running again on the old PVC in the meantime, so **anything configured between that copy and the merge will be lost** — say the word and I'll re-run the copy immediately before you merge if there's been a gap.

Loki has nothing worth preserving: its filesystem is corrupt and the chunks are in MinIO.

## hawkstore prep — done

Created users `loki` (3018) and `uptimekuma` (3019), datasets `data/loki` and `data/uptime-kuma`, `root_squash` exports, ownership set. Verified by writing and fsyncing to both as the target uids.

## ⚠️ Cutover needs a manual step

**A StatefulSet's `volumeClaimTemplates` are immutable.** Removing Loki's will make the Helm upgrade fail with `updates to statefulset spec for fields other than 'replicas' ... are forbidden`, and helm-controller will just retry and keep failing.

After merge, the StatefulSet has to be deleted once so Helm recreates it:

```bash
kubectl delete statefulset loki -n monitoring
kubectl delete pvc storage-loki-0 -n monitoring
flux reconcile helmrelease loki -n monitoring --force
```

Also note `loki-values.yml` is a `disableNameSuffixHash` ConfigMap, so helm-controller won't notice the change on its own — the `--force` above covers both problems at once.

uptime-kuma is a Deployment, so it cuts over cleanly with no intervention. Helm will delete its old PVC as part of the upgrade.

I'll run the Loki steps and verify logs start flowing once this is merged.

## Alternative worth noting

Loki's local directory is genuinely disposable — an `emptyDir` would also work and would keep the hottest path off the network, at the cost of losing unflushed WAL on reschedule. I went with NFS because that's the stated direction, but it's a reasonable thing to revisit if the WAL turns out to be latency-sensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)