### PR TITLE
Run uptime-kuma as root; its entrypoint chowns /app/data

### DIFF
--- a/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
+++ b/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
@@ -32,9 +32,11 @@ spec:
     additionalVolumeMounts:
       - name: storage
         mountPath: /app/data
-    # The export is root_squash and the image defaults to root.
-    podSecurityContext:
-      runAsUser: 3019
-      runAsGroup: 3021
-      fsGroup: 3021
-      runAsNonRoot: true
+    # extra/entrypoint.sh chowns /app/data under `set -e` before dropping to PUID:PGID
+    # with setpriv, so this has to start as root — the chown fails over NFS otherwise
+    # and the container exits. Its export is maproot=root rather than root_squash.
+    podEnv:
+      - name: PUID
+        value: "3019"
+      - name: PGID
+        value: "3021"


### PR DESCRIPTION
Follow-up to #340. Loki cut over cleanly and logs are flowing again, but uptime-kuma's new pod crash-looped.

## Problem

`extra/entrypoint.sh` in `louislam/uptime-kuma`:

```sh
set -e
PUID=${PUID=0}
PGID=${PGID=0}

files_ownership () {
    chown -hRc "$PUID":"$PGID" /app/data
}

echo "==> Performing startup jobs and maintenance tasks"
files_ownership
...
exec setpriv --reuid "$PUID" --regid "$PGID" --clear-groups "$@"
```

It chowns `/app/data` **before** dropping privileges, under `set -e`. Running as a non-root pod on a `root_squash` export, every chown returns `Operation not permitted` and the script exits:

```
==> Performing startup jobs and maintenance tasks
chown: changing ownership of '/app/data/kuma.db': Operation not permitted
chown: changing ownership of '/app/data': Operation not permitted
```

The files were already owned `3019:3021`, so the chown was a no-op — but NFS rejects a SETATTR of owner from a non-root client regardless, and `set -e` doesn't care that nothing needed changing.

No outage: the rolling update kept the old pod serving because the new one never became ready.

## Fix

The image already takes `PUID`/`PGID` and drops privileges itself via `setpriv`, so the right shape is to start as root and let it. Same arrangement as ombi and plex:

- `podEnv` sets `PUID=3019` / `PGID=3021`, replacing `podSecurityContext`
- the export moves from `root_squash` to `maproot=root` (applied on hawkstore already)

Files still land as `3019:3021`, so the copied `kuma.db` and the dataset layout are unchanged.

## Note

That's now three images in this cluster whose entrypoints need root to chown a config directory before dropping privileges — ombi, plex and uptime-kuma. Only the ones with a genuine non-root path (the other four lscr images, loki, prometheus, grafana, immich) can use `root_squash`. Worth checking the entrypoint before assuming a new app can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)