### PR TITLE
Set uptime-kuma to root explicitly, not by omission

### DIFF
--- a/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
+++ b/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
@@ -32,9 +32,14 @@ spec:
     additionalVolumeMounts:
       - name: storage
         mountPath: /app/data
-    # extra/entrypoint.sh chowns /app/data under `set -e` before dropping to PUID:PGID
-    # with setpriv, so this has to start as root — the chown fails over NFS otherwise
-    # and the container exits. Its export is maproot=root rather than root_squash.
+    # extra/entrypoint.sh chowns /app/data and then drops to PUID:PGID with
+    # `setpriv --clear-groups`, which needs CAP_SETGID. Set root explicitly rather
+    # than by omission: helm leaves a previously-rendered securityContext in place
+    # when the key disappears from values, so the old non-root one would persist.
+    podSecurityContext:
+      runAsUser: 0
+      runAsGroup: 0
+      runAsNonRoot: false
     podEnv:
       - name: PUID
         value: "3019"


### PR DESCRIPTION
Third and final piece of the uptime-kuma cutover. #341 was the right diagnosis but an incomplete fix.

## What happened

#341 removed `podSecurityContext` from values, expecting the pod to fall back to root. It didn't — **Helm leaves a previously-rendered `securityContext` on the Deployment when the key disappears from values.** The live pod kept `runAsUser: 3019` from the #340 release.

So the `PUID`/`PGID` change did take effect and got the entrypoint past the chown, but it then died one line later:

```
==> Performing startup jobs and maintenance tasks
==> Starting application with user 3019 group 3021
setpriv: setgroups failed: Operation not permitted
```

`setpriv --clear-groups` needs `CAP_SETGID`, which a non-root pod doesn't have.

Worth correcting something I said in #341: the original chown failure wasn't NFS rejecting a same-owner SETATTR. `PUID` defaults to **0** in that entrypoint, so with no env set it was doing `chown -hRc 0:0`, a real ownership change, which root_squash refused. With `PUID`/`PGID` set correctly the chown is a genuine no-op and succeeds.

## Fix

Set root explicitly rather than by omission, so it overrides the stale field instead of relying on Helm to clear it:

```yaml
podSecurityContext:
  runAsUser: 0
  runAsGroup: 0
  runAsNonRoot: false
```

## Verified before opening this

Standalone pod, same image, same NFS path, root + `PUID`/`PGID`:

```
[DB] INFO: Your database version: 10
[DB] INFO: Latest database version: 10
[DB] INFO: Database patch not needed
[SERVER] INFO: Listening on 3001
```

So it starts, and the cold-copied `kuma.db` is intact and recognised — the monitors are there.

## Status

No outage throughout: the old pod has stayed `Running` and `status.clinch-home.com` has served normally the whole time, because the new pod never passed readiness. The Helm upgrade is currently in a retry loop against the 5m timeout; merging this resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)