### PR TITLE
CI: validate Kubernetes manifests on PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -29,6 +29,17 @@ These run automatically on pull requests to validate changes before merge.
 |----------|------|----------|-------|-------------|
 | **Ansible Lint** | `ansible-lint.yaml` | PR (paths: `Ansible/**`), manual | N/A | Lints all Ansible code with `ansible-lint --strict` |
 | **Terraform Plan (PR)** | `terraform-plan.yaml` | PR (paths: `terraform/**`) | Hawkfield, London | Runs `terraform plan` for both sites and posts results as a PR comment |
+| **Kubernetes Validate** | `k8s-validate.yaml` | PR (paths: `kubernetes/**`), manual | N/A | `kubectl kustomize` + `kubeconform` over every overlay, plus `yamllint` on changed YAML |
+
+`k8s-validate` builds all 62 kustomization directories under `kubernetes/flux/` and
+schema-checks the output. `-ignore-missing-schemas` lets the Flux CRs through and
+`-skip Secret` lets the SOPS blobs through — `-strict` would otherwise reject their
+`sops` key as an extra property.
+
+The `yamllint` job lints only the YAML a PR changed, against the repo `.yamllint`.
+A whole-tree run currently reports ~2,900 errors (the bulk in the generated
+`gotk-components.yaml`), so gating on the full repo would fail every PR regardless of
+its contents.
 
 ### Deploy on Merge
 

--- a/.github/workflows/k8s-validate.yaml
+++ b/.github/workflows/k8s-validate.yaml
@@ -1,0 +1,78 @@
+name: Kubernetes validate
+permissions:
+  contents: read
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'kubernetes/**'
+      - '.github/workflows/k8s-validate.yaml'
+  workflow_dispatch:
+jobs:
+  kustomize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install kubeconform
+        env:
+          VERSION: v0.7.0
+        run: |
+          base=https://github.com/yannh/kubeconform/releases/download
+          curl -sSL "$base/$VERSION/kubeconform-linux-amd64.tar.gz" \
+            | sudo tar xz -C /usr/local/bin kubeconform
+
+      # -ignore-missing-schemas passes over the Flux CRs; -skip Secret passes
+      # over the SOPS blobs, whose `sops` key -strict rejects as an extra
+      # property.
+      - name: Build and validate every overlay
+        run: |
+          failed=0
+          total=0
+          while read -r manifest; do
+            dir=$(dirname "$manifest")
+            total=$((total + 1))
+            if ! output=$(kubectl kustomize "$dir" 2>&1 \
+                | kubeconform -strict -ignore-missing-schemas \
+                    -skip Secret -summary -); then
+              echo "::error file=$manifest::$dir failed validation"
+              echo "$output"
+              failed=$((failed + 1))
+            fi
+          done < <(find kubernetes/flux -name 'kustomization.y*ml' | sort)
+          echo "$((total - failed))/$total overlays valid"
+          exit $((failed > 0))
+
+  yamllint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install yamllint
+        run: pip install yamllint
+
+      # Changed files only — the tree has a pre-existing backlog of lint
+      # errors, so a whole-repo run would fail every PR on contents it did
+      # not touch.
+      - name: Lint changed YAML
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only --diff-filter=d "$BASE...HEAD" \
+            | grep -E '\.ya?ml$' || true)
+          if [ -z "$changed" ]; then
+            echo "No YAML changed"
+            exit 0
+          fi
+          echo "$changed"
+          yamllint -c .yamllint -f github $changed

--- a/kubernetes/flux/applications/base/factorio/deployment.yml
+++ b/kubernetes/flux/applications/base/factorio/deployment.yml
@@ -19,7 +19,7 @@ spec:
       initContainers:
         - name: copy-server-settings
           image: busybox
-          command: [ "sh", "-c", "cp /settings/*.json /config" ]
+          command: ["sh", "-c", "cp /settings/*.json /config"]
           volumeMounts:
             - name: config
               mountPath: /config
@@ -47,7 +47,7 @@ spec:
               name: saves
       volumes:
         - name: config
-          emptyDir: { }
+          emptyDir: {}
         - name: saves
           nfs:
             path: /mnt/data/factorio/2026

--- a/kubernetes/flux/infrastructure/base/monitoring/truenas-api-exporter.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/truenas-api-exporter.yml
@@ -29,9 +29,9 @@ spec:
               value: "10.1.2.10"
             - name: LISTEN_PORT
               value: "9113"
-            # API key for the least-privilege `nasexporter` TrueNAS user (read-only
-            # roles). REST rejects non-admin keys, so the exporter uses the JSON-RPC
-            # WebSocket API.
+            # API key for the least-privilege `nasexporter` TrueNAS user
+            # (read-only roles). REST rejects non-admin keys, so the exporter
+            # uses the JSON-RPC WebSocket API.
             - name: TRUENAS_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
+++ b/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
@@ -33,9 +33,10 @@ spec:
       - name: storage
         mountPath: /app/data
     # extra/entrypoint.sh chowns /app/data and then drops to PUID:PGID with
-    # `setpriv --clear-groups`, which needs CAP_SETGID. Set root explicitly rather
-    # than by omission: helm leaves a previously-rendered securityContext in place
-    # when the key disappears from values, so the old non-root one would persist.
+    # `setpriv --clear-groups`, which needs CAP_SETGID. Set root explicitly
+    # rather than by omission: helm leaves a previously-rendered
+    # securityContext in place when the key disappears from values, so the old
+    # non-root one would persist.
     podSecurityContext:
       runAsUser: 0
       runAsGroup: 0


### PR DESCRIPTION
Adds a PR check for `kubernetes/**`, so bot-raised dependency PRs have something to validate them before merge reconciles to the cluster.

## What it does

**`kustomize` job** — builds all 62 kustomization directories under `kubernetes/flux/` and schema-checks each with `kubeconform -strict`. Verified locally: 62/62 pass today, and injecting a `ports:` → `portz:` typo correctly fails 4 overlays and the job.

`-ignore-missing-schemas` lets the Flux CRs through; `-skip Secret` lets the SOPS blobs through, since `-strict` rejects their `sops` key as an extra property.

**`yamllint` job** — lints only the YAML a PR changed, against the existing (until now unused) `.yamllint`.

## Why yamllint is scoped to changed files

A whole-tree run reports ~2,900 errors — 2,560 in the generated `gotk-components.yaml` alone, and ~370 elsewhere. Gating on the full repo would fail every PR regardless of contents. Changed-files-only gives real signal now; the backlog can be worked separately.

## The three manifest edits

Whitespace and comment reflow only, no semantic change:

- `factorio/deployment.yml` — `[ "sh", … ]` → `["sh", …]`, `{ }` → `{}`
- `truenas-api-exporter.yml`, `uptime-kuma/helm-release.yml` — rewrapped over-long comments

These are pre-existing lint errors in files a dependency bot would touch. Without fixing them the new job would fail bot PRs on lines the bot did not write.

## Checks that should *not* run here

`ansible-lint` and `terraform-plan` are path-filtered to `Ansible/**` and `terraform/**`; this PR touches neither.

First of three steps toward Renovate-managed image and chart updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)