### PR TITLE
CI: run Renovate weekly

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -106,7 +106,13 @@ All secrets are stored in GitHub repository settings.
 | `PACKER_SSH_PASSWORD` | SSH password for Packer VM provisioning | packer |
 | `PROXMOX_ROOT_PASSWORD` | Root password for bootstrap | ansible-proxmox-bootstrap |
 | `GH_PAT` | GitHub Personal Access Token | ansible-proxmox-bootstrap |
-| `RENOVATE_TOKEN` | Fine-grained PAT, this repo only, Contents + Pull requests read/write | renovate |
+| `RENOVATE_TOKEN` | Fine-grained PAT, this repo only, Contents + Pull requests + Issues read/write | renovate |
+
+All three permissions are required. **Issues** is the non-obvious one: Renovate's
+repo-init GraphQL query reads `repository.issues` unconditionally, so without it the
+run dies at startup with an opaque `platform-unknown-error` — the underlying
+`FORBIDDEN` on the `issues` field is only visible at debug log level. Write, not just
+read, because `dependencyDashboard` needs to open and update its issue.
 
 `RENOVATE_TOKEN` is deliberately not `GH_PAT`: that one is a classic token carrying
 `admin:org`, `delete_repo` and `workflow`, far beyond what Renovate needs. It also

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -46,6 +46,23 @@ These run when changes are pushed to `master` (i.e. a PR is merged).
 | Workflow | File | Schedule | Sites | What it does |
 |----------|------|----------|-------|-------------|
 | **Update Proxmox** | `ansible-update-proxmox.yaml` | Daily 03:00 UTC, manual | Hawkfield, London (parallel) | Runs `update-proxmox.yml` — apt upgrades on Proxmox hosts (independent per site) |
+| **Renovate** | `renovate.yaml` | Weekly Monday 06:00 UTC, manual | N/A | Proposes container image and Helm chart updates under `kubernetes/flux/` as PRs |
+
+Renovate is configured by `/renovate.json` at the repo root. Only the `kubernetes`
+and `flux` managers are enabled, so it cannot open a `terraform/**`, `Ansible/**` or
+`.github/**` PR — which matters because `terraform-plan.yaml` guards on
+`github.actor != 'dependabot[bot]'`, a check Renovate would not match. Dependabot
+still owns pip, github-actions and terraform; the two do not overlap.
+
+Nothing auto-merges. Merging a Renovate PR deploys it — Flux reconciles within 1–2
+minutes.
+
+`clincha/media` runs its own copy of this workflow against its own `renovate.json`.
+The two are separate because a fine-grained PAT has a single resource owner and
+cannot span an org-owned and a user-owned repo.
+
+Run manually with **dryRun: true** to see what it would propose without opening
+anything.
 
 ### Manual Operations
 
@@ -89,6 +106,11 @@ All secrets are stored in GitHub repository settings.
 | `PACKER_SSH_PASSWORD` | SSH password for Packer VM provisioning | packer |
 | `PROXMOX_ROOT_PASSWORD` | Root password for bootstrap | ansible-proxmox-bootstrap |
 | `GH_PAT` | GitHub Personal Access Token | ansible-proxmox-bootstrap |
+| `RENOVATE_TOKEN` | Fine-grained PAT, this repo only, Contents + Pull requests read/write | renovate |
+
+`RENOVATE_TOKEN` is deliberately not `GH_PAT`: that one is a classic token carrying
+`admin:org`, `delete_repo` and `workflow`, far beyond what Renovate needs. It also
+omits `workflow` scope, so Renovate cannot write under `.github/workflows/`.
 
 ## Known Gaps
 

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,34 @@
+name: Renovate
+permissions:
+  contents: read
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Dry run (log only, opens no PRs)'
+        type: boolean
+        default: false
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      # A PAT rather than GITHUB_TOKEN: PRs opened by GITHUB_TOKEN do not
+      # trigger workflows, so k8s-validate would never run on a bot PR.
+      - name: Run Renovate
+        uses: renovatebot/github-action@v46.1.20
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_AUTODISCOVER: 'false'
+          RENOVATE_REPOSITORIES: '["clincha-org/clincha"]'
+          RENOVATE_ONBOARDING: 'false'
+          RENOVATE_REQUIRE_CONFIG: 'required'
+          RENOVATE_DRY_RUN: ${{ inputs.dryRun && 'full' || 'null' }}


### PR DESCRIPTION
The scheduled runner. Third and last of the Renovate PRs.

**Requires `RENOVATE_TOKEN` to exist before merge** — see below.

## Two runners, not one

The plan called for a single fine-grained PAT covering both repos. That is not possible: a fine-grained PAT has exactly one resource owner, and `clincha-org` is an **Organization** while `clincha/media` is **User**-owned. No single fine-grained token reaches both.

Rather than fall back to a classic `repo`-scoped PAT, each repo runs its own copy of this workflow with its own token. Tokens stay minimally scoped and either can be revoked without affecting the other. `clincha/media` PR is separate.

## Token to create

A **fine-grained PAT**, resource owner `clincha-org`, **this repository only**:

| Permission | Access |
| --- | --- |
| Contents | Read and write |
| Pull requests | Read and write |

Store as the `RENOVATE_TOKEN` repository secret. Nothing else — notably **not** `Workflows`, so Renovate cannot write under `.github/workflows/`.

Deliberately not `GH_PAT`: that is a classic token carrying `admin:org`, `delete_repo` and `workflow`, far wider than Renovate needs, and shared with three other jobs so it could not be revoked independently.

A PAT is needed rather than `GITHUB_TOKEN` because PRs opened by `GITHUB_TOKEN` do not trigger workflows — `k8s-validate` would never run on a bot PR, which defeats the point of landing it first.

## Rollout

1. Create the PAT, add `RENOVATE_TOKEN`.
2. Merge this.
3. Run manually with **dryRun: true** and read the log.
4. Re-run with dryRun off.

I already ran the equivalent dry run locally against the `renovate.json` from #344 — the expected 16 updates, nothing under `terraform/**`, `Ansible/**` or `.github/**`, and no write to `gotk-components.yaml`. Step 3 is confirmation on the real runner rather than a discovery step.

Weekly Monday 06:00 UTC matches Dependabot's cadence. `prConcurrentLimit: 3` throttles the ~16-item backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)