### PR TITLE
Block ECH HTTPS records for split-horizon domains in AdGuard

### DIFF
--- a/Ansible/group_vars/adguard.yml
+++ b/Ansible/group_vars/adguard.yml
@@ -2,6 +2,14 @@
 ansible_user: root
 ansible_ssh_pass: null
 
+# Cloudflare publishes ECH configs (DNS type 65) for proxied hostnames. Local A
+# records come from /etc/hosts, which cannot answer type 65, so LAN browsers get
+# Cloudflare's ECH config and fail TLS against the internal ingress with
+# ERR_ECH_FALLBACK_CERTIFICATE_INVALID.
+adguard_user_rules:
+  - "||clinch-home.com^$dnstype=HTTPS"
+  - "||clincha.co.uk^$dnstype=HTTPS"
+
 adguard_local_dns_entries:
   # Proxmox hosts
   - domain: "hawk01.clinch-home.com"

--- a/Ansible/roles/adguard/defaults/main.yml
+++ b/Ansible/roles/adguard/defaults/main.yml
@@ -7,3 +7,4 @@ adguard_upstream_dns:
 adguard_admin_username: "admin"
 adguard_admin_password: "{{ lookup('env', 'ADGUARD_ADMIN_PASSWORD') }}"
 adguard_local_dns_entries: []
+adguard_user_rules: []

--- a/Ansible/roles/adguard/tasks/configure.yml
+++ b/Ansible/roles/adguard/tasks/configure.yml
@@ -44,3 +44,36 @@
       ansible.builtin.systemd:
         name: AdGuardHome
         state: started
+
+- name: Re-read AdGuard Home configuration before applying filtering rules
+  ansible.builtin.slurp:
+    src: /opt/AdGuardHome/AdGuardHome.yaml
+  register: adguard_config_before_rules
+
+- name: Apply user filtering rules to AdGuard config (stop → edit → start)
+  vars:
+    adguard_config: >-
+      {{ adguard_config_before_rules.content | b64decode | from_yaml }}
+  when: adguard_config.user_rules | default([], true) != adguard_user_rules
+  block:
+    - name: Stop AdGuardHome before editing its filtering rules
+      ansible.builtin.systemd:
+        name: AdGuardHome
+        state: stopped
+
+    - name: Write user filtering rules into AdGuard config
+      ansible.builtin.copy:
+        content: >-
+          {{ adguard_config
+             | combine({'user_rules': adguard_user_rules})
+             | to_nice_yaml(indent=2) }}
+        dest: /opt/AdGuardHome/AdGuardHome.yaml
+        owner: root
+        group: root
+        mode: "0600"
+        backup: true
+  always:
+    - name: Start AdGuardHome after editing its filtering rules
+      ansible.builtin.systemd:
+        name: AdGuardHome
+        state: started

--- a/Ansible/roles/adguard/templates/AdGuardHome.yaml.j2
+++ b/Ansible/roles/adguard/templates/AdGuardHome.yaml.j2
@@ -39,6 +39,7 @@ filters:
     url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_2.txt
     name: AdAway Default Blocklist
     id: 2
+user_rules: {{ adguard_user_rules | to_json }}
 querylog:
   enabled: true
   file_enabled: true


### PR DESCRIPTION
## Problem

Clients on the LAN hit `ERR_ECH_FALLBACK_CERTIFICATE_INVALID` when loading
`immich.clinch-home.com` / `photos.clinch-home.com`. The connection dies during
the TLS handshake, so nothing appears in ingress-nginx or application logs.

Cloudflare publishes a DNS `HTTPS` record (type 65) carrying an **Encrypted
Client Hello** config for every *proxied* hostname. `immich` and `photos` are the
only two names in the zone behind the orange cloud — everything else is DNS-only
or internal:

| Host | Public A | Proxied | ECH published |
|---|---|---|---|
| `immich.clinch-home.com` | 104.21.35.27 / 172.67.212.72 | yes | **yes** |
| `photos.clinch-home.com` | 104.21.35.27 / 172.67.212.72 | yes | **yes** |
| `plex.clinch-home.com` | 185.23.254.226 | no | no |

`adguard_local_dns_entries` is served from `/etc/hosts` (`hostsfile_enabled:
true`), which can **only answer A/AAAA**. Type 65 falls through to upstream, so a
LAN client gets a split answer:

```
A     → 10.1.2.205                      (internal ingress, from /etc/hosts)
HTTPS → ech=…  public_name=cloudflare-ech.com,
        ipv4hint=104.21.35.27           (Cloudflare, straight from upstream)
```

Verified — the local resolver returns a byte-identical `ech=` blob to `1.1.1.1`
while the A record is rewritten.

The browser then connects to the internal ingress but attempts Cloudflare's ECH:

1. ClientHello carries outer SNI `cloudflare-ech.com`, real host encrypted inside.
2. ingress-nginx ignores the ECH extension, has no ingress for that SNI, serves
   its default cert.
3. ECH was not accepted, so per spec the client validates the fallback cert
   against the **public name** — and gets:
   ```
   subject=O = Acme Co, CN = Kubernetes Ingress Controller Fake Certificate
   ```
4. Hard failure. No click-through, no HTTP request.

## Fix

Add `adguard_user_rules` and block type-65 for both split-horizon zones:

```
||clinch-home.com^$dnstype=HTTPS
||clincha.co.uk^$dnstype=HTTPS
```

Zone-wide rather than per-host so this doesn't recur the next time a hostname is
put behind the proxy. `clincha.co.uk` publishes no ECH today; included pre-emptively.

Only LAN clients are affected — external visitors still get ECH.

`AdGuardHome.yaml` is templated with `force: false` (bootstrap only), so the
template change alone would never reach the existing servers. The new task
applies rules to the live config with the same stop → edit → start pattern
already used for `hostsfile_enabled`, guarded by a comparison so it's a no-op
once converged.

## Trade-off

Blocking type 65 also suppresses DNS-based HTTP/3 advertisement for these zones
on the LAN. h3 still negotiates via `Alt-Svc`, so the practical cost is one
extra round trip on first connection.

## Testing

- `yamllint` and `ansible-lint` clean (`production` profile, 0 failures).
- Round-trip verified against a representative config containing the keys
  AdGuard writes itself. `user_rules` is the **only** semantic change — bcrypt
  admin hash preserved byte-for-byte, `schema_version` stays an `int`, nested
  `clients`/`filters` structures intact.
- PyYAML quotes the rules correctly, so the leading `||` is not misparsed as a
  YAML block scalar:
  ```yaml
  user_rules:
  - '||clinch-home.com^$dnstype=HTTPS'
  - '||clincha.co.uk^$dnstype=HTTPS'
  ```
- Second run skips the block — idempotent.
- Bootstrap template renders to a valid list, and to `user_rules: []` when empty.
- `copy` uses `backup: true`, and the restart is in `always:` so a failed write
  can't leave the house without DNS.

Suggest running via `workflow_dispatch` against `london` first, then `hawkfield`.

## Not addressed

Two separate issues with serving Immich through the Cloudflare proxy, worth
deciding on independently:

- Free plan caps request bodies at **100 MB** — large uploads will fail from
  outside the LAN regardless of this fix (the ingress sets `proxy-body-size: 0`).
- Cloudflare's ToS restricts proxying bulk non-HTML media, which a photo/video
  library squarely is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
