### PR TITLE
factorio: use Recreate strategy so the deployment can roll

### DIFF
--- a/kubernetes/flux/applications/base/factorio/deployment.yml
+++ b/kubernetes/flux/applications/base/factorio/deployment.yml
@@ -8,6 +8,9 @@ metadata:
     name: factorio
 spec:
   replicas: 1
+  # RollingUpdate deadlocks: no node can double-book the 4-CPU request
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       name: factorio


### PR DESCRIPTION
## Problem

The factorio image bump in #350 (2.0.73 → 2.1.12) merged and Flux applied it, but it never rolled. The Flux `factorio` Kustomization has been stuck on *"Running health checks for revision master@sha1:3d4fadc8"* since 19:07:47, and the cluster is still serving the old image:

```
factorio-5c9bb9689b-8tdx7   1/1   Running   113d   factoriotools/factorio:2.0.73
factorio-67475b8fd8-2hbmq   0/1   Pending     3m   <none>

FailedScheduling: 0/3 nodes are available: 3 Insufficient cpu.
```

With `replicas: 1` and the default `RollingUpdate` 25%/25%, `maxUnavailable` rounds *down* to 0 — so Kubernetes must schedule a second pod before terminating the old one. The container requests **4 CPU**, and every node is already 85–93% CPU-requested out of 9400m:

| Node | CPU requested |
| --- | --- |
| k8s-hawk-1 | 8288m (88%) |
| k8s-hawk-2 | 8033m (85%) |
| k8s-hawk-3 | 8788m (93%) |

Nothing frees up on its own, so this deadlocks permanently.

## Fix

`strategy: Recreate` — the old pod terminates first, freeing its 4 CPU for the replacement. Brief downtime on each bump, which is correct for a single-replica game server backed by one NFS save volume (two concurrent factorio processes writing the same saves directory would be worse than a restart).

## Verification after merge

```
flux reconcile kustomization factorio --with-source
kubectl -n factorio get pods -w
```