### PR TITLE
monitoring: fix yamllint line-length in kube-state-metrics

### DIFF
--- a/kubernetes/flux/infrastructure/base/monitoring/kube-state-metrics.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/kube-state-metrics.yml
@@ -1,7 +1,7 @@
 # kube-state-metrics — object/state metrics (kube_*), scraped by the Alloy
 # DaemonSet (no ServiceMonitor). Vendored from the upstream "standard" example
-# manifests, pinned to v2.19.0, namespaced to monitoring.
-# Source: https://github.com/kubernetes/kube-state-metrics/tree/v2.19.0/examples/standard
+# manifests, namespaced to monitoring.
+# Source: github.com/kubernetes/kube-state-metrics (examples/standard)
 ---
 apiVersion: v1
 automountServiceAccountToken: false


### PR DESCRIPTION
## Problem

#346 (kube-state-metrics v2.19.0 → v2.19.1) **merged with a red `yamllint` check**:

```
kubernetes/flux/infrastructure/base/monitoring/kube-state-metrics.yml
##[error]4:81 [line-length] line too long (89 > 80 characters)
```

The offending line is a pre-existing 89-char source URL, not something Renovate wrote. It only started failing because the new `yamllint` job lints *changed files*, and the image bump made this file changed. The deployment itself is healthy and live on v2.19.1 — this is purely a CI gate problem, but it recurs on **every** future bump to this file.

## Fix

Shortens the source comment under 80 chars, and drops the pinned version from the comment entirely so it can't drift out of sync with the image tag on the next Renovate bump.

## Two related landmines not fixed here

The same changed-files lint will fire on other files as the Renovate backlog drains:

- `kubernetes/flux/clusters/hawkfield/infrastructure/certificate-manager.yml` — 2 long lines (81 and 84 chars). Relevant because **cert-manager v1.21.0 is queued** in the rate-limited backlog.
- `kubernetes/flux/clusters/hawkfield/flux-system/gotk-components.yaml` — 1 long line plus ~40 indentation errors. This one is Flux-generated and marked `DO NOT EDIT`, so it can never be fixed by hand; it needs a `.yamllint` `ignore:` entry before the next Flux upgrade PR.

## Also worth noting

Renovate bumped the image tag but left `app.kubernetes.io/version: 2.19.0` on all five objects in this file, so KSM now reports a version label that disagrees with the running image. Not fixed here to keep this PR to the CI failure.