### PR TITLE
longhorn: prepare for removal

### DIFF
--- a/kubernetes/flux/infrastructure/base/longhorn/controller/nodes.yml
+++ b/kubernetes/flux/infrastructure/base/longhorn/controller/nodes.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     node.longhorn.io/create-default-disk: "config"
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     node.longhorn.io/default-disks-config: |-
       [
         {
@@ -25,6 +26,7 @@ metadata:
   labels:
     node.longhorn.io/create-default-disk: "config"
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     node.longhorn.io/default-disks-config: |-
       [
         {
@@ -44,6 +46,7 @@ metadata:
   labels:
     node.longhorn.io/create-default-disk: "config"
   annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
     node.longhorn.io/default-disks-config: |-
       [
         {

--- a/kubernetes/flux/infrastructure/hawkfield/longhorn/controller/values.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/longhorn/controller/values.yml
@@ -7,5 +7,7 @@ persistence:
 defaultSettings:
   createDefaultDiskLabeledNodes: true
   storageReservedPercentageForDefaultDisk: 0
+  # the chart's pre-delete hook refuses to uninstall without this
+  deletingConfirmationFlag: true
 defaultBackupStore:
   backupTarget: "nfs://10.1.2.10:/mnt/data/backups/longhorn"


### PR DESCRIPTION
Prerequisite for #(removal PR, linked below). **Merge this first and let it reconcile** — the removal is unsafe until both guards below are live.

## Guard 1: the Node objects are in the prune inventory

`base/longhorn/controller/nodes.yml` declares three `kind: Node` resources to label the hawk nodes with their `fast` disk config. Flux tracks them:

```
$ kubectl -n flux-system get kustomization longhorn-controller \
    -o jsonpath='{range .status.inventory.entries[*]}{.id}{"\n"}{end}'
_longhorn__Namespace
longhorn_longhorn-values__ConfigMap
_k8s-hawk-1__Node          ← these three
_k8s-hawk-2__Node
_k8s-hawk-3__Node
longhorn_longhorn-certificate_cert-manager.io_Certificate
longhorn_longhorn_helm.toolkit.fluxcd.io_HelmRelease
longhorn_longhorn_networking.k8s.io_Ingress
longhorn_longhorn_source.toolkit.fluxcd.io_HelmRepository

$ kubectl -n flux-system get kustomization longhorn-controller -o jsonpath='{.spec.prune}'
true
```

Deleting the `longhorn-controller` Kustomization — or just dropping `nodes.yml` from its resources — makes Flux's garbage collector delete the **Node objects for all three control-plane nodes**. This adds `kustomize.toolkit.fluxcd.io/prune: disabled` to each so they're excluded from GC and survive the removal. The labels and annotations they carry are inert once Longhorn is gone and can be cleaned off by hand later.

## Guard 2: the chart refuses to uninstall

```
$ kubectl -n longhorn get settings.longhorn.io deleting-confirmation-flag -o jsonpath='{.value}'
false
```

Longhorn's `pre-delete` hook aborts the uninstall while this is false, which would strand the HelmRelease and leave the `longhorn` namespace stuck `Terminating`. This sets `defaultSettings.deletingConfirmationFlag: true`.

It has to be a separate, earlier apply: the flag lives *inside* the HelmRelease the removal deletes, so a single combined PR would tear down the release before the setting ever reached the cluster.

## Validation

`kubectl kustomize` builds clean, yamllint clean. No behaviour change — Longhorn keeps running exactly as now; this only changes how it can be taken down.

## After merging

```
flux reconcile kustomization longhorn-controller --with-source
kubectl -n longhorn get settings.longhorn.io deleting-confirmation-flag -o jsonpath='{.value}'   # expect: true
kubectl -n flux-system get kustomization longhorn-controller \
  -o jsonpath='{range .status.inventory.entries[*]}{.id}{"\n"}{end}' | grep Node   # expect: no output
```

Both must be satisfied before the removal PR goes in.