### PR TITLE
CI: run Renovate daily

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -3,7 +3,7 @@ permissions:
   contents: read
 on:
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       dryRun:


### PR DESCRIPTION
Changes the schedule from Mondays 06:00 to daily 06:00.

```diff
-    - cron: '0 6 * * 1'
+    - cron: '0 6 * * *'
```

`prHourlyLimit: 2` is the binding cap, not `prConcurrentLimit: 3`, so each run opens at most 2 PRs. Weekly therefore meant 2 PRs a week — the dependency dashboard currently has **14 rate-limited updates** queued, which would take about seven weeks to drain. Daily brings that to roughly a week.

The limits themselves are unchanged, so this raises throughput without changing batch size: still a maximum of 2 new PRs at a time, 3 open concurrently.