### PR TITLE
monitoring: fix yamllint line-length in certificate-manager

### DIFF
--- a/kubernetes/flux/clusters/hawkfield/infrastructure/certificate-manager.yml
+++ b/kubernetes/flux/clusters/hawkfield/infrastructure/certificate-manager.yml
@@ -10,7 +10,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  path: ./kubernetes/flux/infrastructure/hawkfield/certificate-manager/controller
+  path: >-
+    ./kubernetes/flux/infrastructure/hawkfield/certificate-manager/controller
   prune: true
   wait: true
   decryption:
@@ -28,7 +29,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  path: ./kubernetes/flux/infrastructure/hawkfield/certificate-manager/configuration
+  path: >-
+    ./kubernetes/flux/infrastructure/hawkfield/certificate-manager/configuration
   dependsOn:
     - name: certificate-manager-controller
   prune: true


### PR DESCRIPTION
Clears the two `line-length` errors in `clusters/hawkfield/infrastructure/certificate-manager.yml`:

```
13:81  error  line too long (81 > 80 characters)
31:81  error  line too long (84 > 80 characters)
```

Both are Flux Kustomization `path:` values that are simply one or four characters too long. Folded onto their own lines with `>-`, which yields the identical scalar:

```yaml
  path: >-
    ./kubernetes/flux/infrastructure/hawkfield/certificate-manager/controller
```

Verified the parsed documents are unchanged, not just the paths:

```
$ python3 -c "compare yaml.safe_load_all(HEAD) vs working tree"
semantically identical: True

'./kubernetes/flux/infrastructure/hawkfield/certificate-manager/controller'
'./kubernetes/flux/infrastructure/hawkfield/certificate-manager/configuration'
```

## Correction to what I said on #353

I claimed this file would make the queued cert-manager v1.21.0 bump merge red. **That was wrong** — the version is pinned in `infrastructure/base/certificate-manager/controller/helm-release.yml`, which is lint-clean. Renovate never edits this file, so no bump was ever at risk from it.

Checking properly, Renovate does not currently touch *any* file that fails yamllint, so #346 merging red was a one-off rather than the start of a pattern. This fix is still worth having — it's a live landmine for any hand-written PR touching this file — but not for the reason I gave.

## The real state of the lint gate

15 files under `kubernetes/` currently fail yamllint. They fall into three groups:

| Group | Files | Fixable? |
| --- | --- | --- |
| SOPS-encrypted secrets — long base64 lines | `cloudflare-secret.yml`, both `github-actions-runner` secrets, both `grafana-admin-credentials.yaml`, `loki-minio-creds.sops.yaml`, `truenas-api-key.sops.yaml`, `authentication-secrets.yml` | No — needs a `line-length: ignore` entry, as `base/media/controller/secret.yml` already has |
| Flux-generated, `DO NOT EDIT` | `gotk-components.yaml`, `flux-system/kustomization.yaml` | No — needs a top-level `ignore` entry before the next Flux upgrade PR |
| Genuinely fixable | this file, `issuers.yml`, `alloy-values.yml`, `loki-values.yml`, `prometheus.yml` | Yes |

Deliberately scoped to the one file that was asked for. The other two groups are a call about suppressing vs fixing that's worth making explicitly rather than folding in here.