### PR TITLE
ci: bump actions/setup-python to v7 in k8s-validate

### DIFF
--- a/.github/workflows/k8s-validate.yaml
+++ b/.github/workflows/k8s-validate.yaml
@@ -54,7 +54,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 


### PR DESCRIPTION
## What changed

`.github/workflows/k8s-validate.yaml` pins `actions/setup-python@v6`. Every other workflow is on v7 — k8s-validate was added (#343) after dependabot's v7 bump (#338) merged, so it was written against the then-current pin and missed the sweep. v7.0.0 is still the latest release.

## Why a separate PR

This started as a one-line commit on #331, but touching `k8s-validate.yaml` matches that workflow's own `paths:` trigger, so its changed-files yamllint job starts running on whatever PR carries the change. On #331 that meant linting all 15 workflow files the composite-actions refactor touches, which failed on ~25 pre-existing long lines the PR never wrote. Landing the bump alone keeps the linted set to this one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)