### PR TITLE
Parse the log level from Sonarr and Radarr console output

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/config.alloy
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/config.alloy
@@ -127,6 +127,23 @@ loki.process "pod_logs" {
     stage.labels {
         values = { stream = "" }
     }
+
+    // Sonarr and Radarr prefix console output with [Level]. Loki's own level
+    // detector doesn't recognise that shape and stamps ~97% of their lines
+    // "unknown", which is what a service_name view renders. The casing here
+    // already matches what their file logs carry.
+    stage.match {
+        selector = "{namespace=\"media\", container=~\"sonarr|radarr\"}"
+
+        // Named levels only — the s6 init in these images also emits bracketed
+        // prefixes like "[migrations] started", which \w+ would turn into a level.
+        stage.regex {
+            expression = "^\\[(?P<level>Trace|Debug|Info|Warn|Error|Fatal)\\] "
+        }
+        stage.labels {
+            values = { level = "" }
+        }
+    }
 }
 
 loki.write "local" {


### PR DESCRIPTION
Sonarr and Radarr prefix their console output with `[Level]`. Loki's built-in level detector doesn't recognise that shape, so it falls back to `unknown` — and since `service_name="sonarr"` is what Explore and Logs Drilldown group by, that stream sits right alongside the correctly-levelled file logs from clincha/media#25 and makes the whole view look broken.

Measured over 24h before the fix:

| container | stdout lines | rendered `unknown` |
|---|---|---|
| sonarr | 1,393 | **1,364 (97.9%)** |
| radarr | 3,094 | 2,936 (94.9%) |

1,066 of sonarr's lines literally begin with `[Info]`, 5 with `[Warn]`, 3 with `[Error]`.

## Note on the regex

It matches the six named levels rather than `\w+`. The first version used `\w+` and validation caught it inventing `level="migrations"` from the LSIO s6 init's `[migrations] started` — precisely the kind of junk label this PR exists to remove.

The casing Sonarr emits (`[Info]`, `[Warn]`) already matches what its file logs carry, so no normalisation is needed and the two streams agree.

## Validation

`alloy fmt` clean. Ran the stage in a real `grafana/alloy:v1.18.0` against 138 lines of live sonarr+radarr stdout: 56 labelled (`Info` ×54, `Debug` ×2), 0 junk values, and the 82 s6-overlay init lines correctly left unlabelled since they carry no level at all.

## Out of scope

Same measurement flagged other media containers whose stdout is mostly `unknown` — tdarr (17,581 lines, 92.7%), immich, postgres, redis. Different formats; tdarr's needs ANSI-escape handling. Happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)