### PR TITLE
Lowercase the level parsed from Sonarr and Radarr stdout

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/config.alloy
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/config.alloy
@@ -140,6 +140,12 @@ loki.process "pod_logs" {
         stage.regex {
             expression = "^\\[(?P<level>Trace|Debug|Info|Warn|Error|Fatal)\\] "
         }
+        // Canonical lowercase, matching what Loki's own detector emits for
+        // every other container so one level is a single series.
+        stage.template {
+            source   = "level"
+            template = "{{ ToLower .Value }}"
+        }
         stage.labels {
             values = { level = "" }
         }


### PR DESCRIPTION
Follow-up to #376. That PR extracted `Info` from `[Info]` and used it verbatim, which is Sonarr's own casing — but Loki's built-in detector emits lowercase for every other container, so `Info` and `info` sat side by side as separate series.

Lowercases it. Pairs with clincha/media#27, which normalises the four media file-log collectors the same way.

Validated with `loki.echo` in a real `grafana/alloy:v1.18.0` against 138 lines of live sonarr+radarr stdout: `info` ×54, `debug` ×2, no junk values, and the s6-overlay init lines still correctly left unlabelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)