### PR TITLE
Point Dependabot at the terraform directories that exist

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,7 +18,9 @@ updates:
       interval: "weekly"
   - package-ecosystem: terraform
     directories:
-      - "/terraform/kubernetes"
-      - "/terraform/kubernetes/master"
+      - "/terraform/hawkfield"
+      - "/terraform/hawkfield-kubernetes"
+      - "/terraform/london"
+      - "/terraform/minio"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Problem

The weekly Dependabot **terraform** job has been failing on every run — most recently [job #1489391961](https://github.com/clincha-org/clincha/actions/runs/30333119587) (2026-07-28) and the run before it on 2026-07-25:

```
ERROR <job_1489391961> Error during file fetching; aborting:
  /terraform/kubernetes, /terraform/kubernetes/master not found

| dependency_file_not_found | { "message": "/terraform/kubernetes, /terraform/kubernetes/master not found" } |
```

`terraform/kubernetes/` was split into `hawkfield`, `hawkfield-kubernetes`, `london` and `minio` (commits `220214d`, `1d138dc`), but `.github/dependabot.yaml` still pointed at the old paths. Dependabot aborts during file fetching, so it has never read a single `.tf` file in this repo.

The `pip` and `github-actions` ecosystems are unaffected — both pass on the same runs.

## Fix

Replace the two dead paths with the four root modules that actually declare pinned providers:

| Directory | Provider | Pin |
|---|---|---|
| `terraform/hawkfield` | `Telmate/proxmox` | `3.0.2-rc06` |
| `terraform/hawkfield-kubernetes` | `Telmate/proxmox` | `3.0.2-rc06` |
| `terraform/london` | `Telmate/proxmox` | `3.0.2-rc06` |
| `terraform/minio` | `aminueza/minio` | `3.5.2` |

`terraform/modules/*` is deliberately excluded — those declare `required_providers` without a version constraint, so there is nothing for Dependabot to bump.

## Verification

Every `directory`/`directories` entry in the config now resolves to a real directory on `master`:

```
OK  pip             /Ansible
OK  github-actions  /.github/workflows
OK  github-actions  /.github/actions/ansible-setup
OK  github-actions  /.github/actions/terraform-setup
OK  terraform       /terraform/hawkfield
OK  terraform       /terraform/hawkfield-kubernetes
OK  terraform       /terraform/london
OK  terraform       /terraform/minio
```

`yamllint -c .yamllint` is clean apart from the pre-existing `document-start` warning on line 1.

## Follow-ups

- Expect a first flush of terraform PRs once this merges. `Telmate/proxmox` is pinned to a release candidate (`3.0.2-rc06`), so the first bump may be a large jump — worth reviewing rather than auto-merging.
- Explicit paths mean a new root module has to be added here by hand. `directories: ["/terraform/*"]` would be drift-proof, but I kept the explicit list so each entry is verifiable; happy to switch if you'd prefer the glob.
- Renovate is scoped to `enabledManagers: ["kubernetes", "flux"]`, so there is no overlap with these terraform updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)