### PR TITLE
Point backend.conf.sample at a live state key

### DIFF
--- a/terraform/backend.conf.sample
+++ b/terraform/backend.conf.sample
@@ -2,6 +2,6 @@ bucket = "terraform"
 endpoints = {
   s3 = "http://10.1.2.10:30293"
 }
-key        = "clinch-home-kubernetes.tfstate"
+key        = "hawkfield.tfstate"
 access_key = "terraform"
 secret_key = "1234567890"


### PR DESCRIPTION
`clinch-home-kubernetes.tfstate` and `k8s-london.tfstate` were stale leftovers mirrored across from MinIO and have been removed from the `terraform` bucket.

Both were unreachable — no workspace backend referenced either key. `clinch-home-kubernetes` duplicated vmid 111 (`k8s-lon-1`), which `terraform/london` manages; `k8s-london` described a 3-node London cluster on the retired 10.2.0.x subnet whose vmids 112 and 113 no longer exist in Proxmox. Confirmed against the live PVE API before deleting.

The sample pointed at one of the deleted keys, so it now uses `hawkfield.tfstate`. All four workspaces re-init and read their state correctly.