### PR TITLE
claude: guard gogcli restore and fix stale gog symlink

### DIFF
--- a/Ansible/roles/claude/tasks/main.yml
+++ b/Ansible/roles/claude/tasks/main.yml
@@ -224,6 +224,21 @@
     group: claude
     mode: "0644"
 
+- name: "Check for a pre-existing gog symlink"
+  ansible.builtin.stat:
+    path: /usr/local/bin/gog
+    follow: false
+  register: claude_gog_binary
+
+# An earlier hand-rolled "go install" left /usr/local/bin/gog symlinked into
+# ~/go/bin. unarchive reports "ok" against the link target and silently skips,
+# pinning the host to whatever that stale build was.
+- name: "Remove stale gog symlink so the pinned release can install"
+  ansible.builtin.file:
+    path: /usr/local/bin/gog
+    state: absent
+  when: claude_gog_binary.stat.islnk | default(false)
+
 - name: "Install gogcli binary"
   ansible.builtin.unarchive:
     src: "/home/claude/.cache/gogcli-{{ claude_gogcli_version }}.tar.gz"
@@ -262,6 +277,9 @@
     group: claude
     mode: "0600"
   no_log: true
+  # Unguarded, a missing secret truncates the live file to 0 bytes and breaks
+  # gog while the play still reports success.
+  when: lookup('env', 'GOG_CREDENTIALS_JSON') | length > 0
 
 - name: "Restore gogcli keyring password"
   ansible.builtin.copy:
@@ -271,6 +289,7 @@
     group: claude
     mode: "0600"
   no_log: true
+  when: lookup('env', 'GOG_KEYRING_PASSWORD') | length > 0
 
 - name: "Ensure gogcli keyring directory exists"
   ansible.builtin.file:


### PR DESCRIPTION
## What & why

Two silent-failure modes found verifying #332 on its first post-merge deploy ([run 30607749129](https://github.com/clincha-org/clincha/actions/runs/30607749129) — green, but broken).

**1. Missing secrets truncate live credentials.** The `GOG_*` repo secrets did not exist yet, and the two restore `copy` tasks are unconditional. They wrote `credentials.json` and `.keyring-password` as **0 bytes**, killing `gog` on the live host while the play reported success. Only the keyring token store degraded gracefully — `GOG_TOKEN_STORE` unset → `dict2items` over `{}` → empty loop — which is why the OAuth tokens survived.

Both tasks now skip when their secret is empty, so a missing secret leaves the existing file alone instead of destroying it. The token-store loop is already safe and is left as-is.

**2. The pinned binary never installed.** `/usr/local/bin/gog` was a symlink into `~/go/bin` from an earlier hand-rolled `go install`. `unarchive` compared against the link target, returned `ok`, and wrote nothing — so the host stayed on that stale build (`0.13.0-dev`) rather than the pinned `0.33.0`. A fresh VM has no symlink and *would* get `0.33.0`, meaning reprovisioning silently changed the runtime version. A `stat` + conditional `file: state=absent` removes the link before extraction.

## Verification

- The three secrets (`GOG_CREDENTIALS_JSON`, `GOG_KEYRING_PASSWORD`, `GOG_TOKEN_STORE`) have now been created, so the guards are a safety net rather than the fix for the immediate outage.
- Live host recovered from a pre-deploy backup; `gog auth list` and a live Gmail query both pass.
- `ansible-playbook claude.yml --syntax-check` passes; `yamllint` reports no new violations (the two on `tasks/main.yml:157,179` pre-exist on master, unchanged by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)