### PR TITLE
Stop proxmox_vm_qemu replanning the same change every run

### DIFF
--- a/terraform/modules/ubuntu-server/main.tf
+++ b/terraform/modules/ubuntu-server/main.tf
@@ -37,10 +37,19 @@ resource "proxmox_vm_qemu" "ubuntu_server" {
   os_type            = "ubuntu"
   ipconfig0          = "ip=${var.ip_address}/24,gw=${var.gateway}"
   start_at_node_boot = true
+  vm_state           = "running"
 
   tags = var.tags
 
   scsihw = "virtio-scsi-single"
+
+  # Telmate marks these Optional without Computed, so leaving them unset diffs
+  # against what the provider reads back from PVE on every plan.
+  startup_shutdown {
+    order            = -1
+    shutdown_timeout = -1
+    startup_delay    = -1
+  }
 
   disk {
     type    = "cloudinit"
@@ -52,6 +61,7 @@ resource "proxmox_vm_qemu" "ubuntu_server" {
     size     = var.boot_disk_size
     storage  = var.data_boot_storage
     type     = "disk"
+    format   = "raw"
     iothread = true
     slot     = "virtio0"
   }
@@ -60,6 +70,7 @@ resource "proxmox_vm_qemu" "ubuntu_server" {
     size     = var.data_disk_size
     storage  = var.data_disk_storage
     type     = "disk"
+    format   = "raw"
     iothread = true
     slot     = "virtio1"
   }

--- a/terraform/modules/ubuntu-server/main.tf
+++ b/terraform/modules/ubuntu-server/main.tf
@@ -37,7 +37,7 @@ resource "proxmox_vm_qemu" "ubuntu_server" {
   os_type            = "ubuntu"
   ipconfig0          = "ip=${var.ip_address}/24,gw=${var.gateway}"
   start_at_node_boot = true
-  vm_state           = "running"
+  power_state        = "running"
 
   tags = var.tags
 


### PR DESCRIPTION
Every plan reports all five VMs as `update in-place` with the same four items, and applying never converges — see the plan comment on #387, which was already running rc08.

## Cause

Telmate declares `vm_state`/`power_state`, `disk.format` and the `startup_shutdown` block as `Optional` **without** `Computed`, then populates them during Read. An unset config therefore reads as "remove this", the apply is a no-op against PVE, and the next refresh re-reads the values from Proxmox. Repeat forever.

`default_ipv4_address`, `ssh_host` and `ssh_port` are computed-only and were collateral — they went `(known after apply)` because the resource was being updated at all, and settle once it isn't.

## Fix

Declare what's already true on the guests, in `modules/ubuntu-server`:

- `power_state = "running"`
- `startup_shutdown { order = -1, shutdown_timeout = -1, startup_delay = -1 }` — these are the provider's own defaults (`startupshutdown/schema.go`)
- `format = "raw"` on the two data disks — the flat `disk` block's `format` has no default, unlike the newer `disks` block which defaults it to `raw`

`proxmox_lxc` is unaffected, so the DNS containers need no change.

## Expect one migration apply on merge

`vm_state` is deprecated as of rc08, so this uses `power_state`. That costs a single non-converged apply, deliberately accepted.

`powerstate.Terraform` checks `d.GetOk("power_state")` during **Read**, where `ResourceData` holds the *prior state* rather than the config. Existing state has `vm_state` and no `power_state`, so that branch is false and the legacy path keeps writing `vm_state`. The first plan therefore shows `+ power_state = "running"` / `- vm_state = "running" -> null` on all five guests. Only once that apply writes `power_state` into state does Read take the non-legacy branch and settle at `No changes`.

**The migration is state-only and does not reboot anything.** Cloud-init is unchanged so `resourceVmQemuUpdate` takes the `config.State = desiredState` branch rather than the forced-shutdown one; no hardware attribute differs, so the SDK finds nothing requiring a reboot; and the `Guest.Start` call is skipped because the guests are already running.

Intermediate state was verified along the way: with `vm_state` instead, all three workspaces reported `No changes. Your infrastructure matches the configuration.`, confirming the other three fixes are correct and isolating this diff to the deprecation migration alone.

## Notes

- **This makes CI authoritative over power state.** A VM stopped by hand gets started on the next apply. That's right for these five, but it is a behaviour change. `lifecycle { ignore_changes = [power_state] }` is the alternative if you'd rather it not.
- Bumping the RC does not fix the perpetual diff on its own. Comparing the rc06/rc07/rc08 schemas, all four attributes carry identical flags in every version; the only `proxmox_vm_qemu` additions are `efidisk.format` and `power_state`. Master was already on rc08 via #380 before this branch.

## Verification caveat

I could not run a local plan — the `Proxmox - terraform` token in the vault 401s against the hawkfield API, having drifted from the `PROXMOX_TOKEN_HAWKFIELD_TERRAFORM` GitHub secret. Worth fixing separately. The plan job on this PR is the real check.

Unrelated: `terraform/london/main.tf` fails `terraform fmt -check` on master already. CI doesn't gate on fmt, so I've left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)