### PR TITLE
claude role: provision the cron layer and its credentials

### DIFF
--- a/.github/workflows/ansible-claude.yaml
+++ b/.github/workflows/ansible-claude.yaml
@@ -43,6 +43,7 @@ jobs:
           GOG_CREDENTIALS_JSON: ${{ secrets.GOG_CREDENTIALS_JSON }}
           GOG_KEYRING_PASSWORD: ${{ secrets.GOG_KEYRING_PASSWORD }}
           GOG_TOKEN_STORE: ${{ secrets.GOG_TOKEN_STORE }}
+          DELIVER_ORCHESTRATOR_ENV: ${{ secrets.DELIVER_ORCHESTRATOR_ENV }}
         run: |
           ansible-playbook claude.yml \
             --inventory inventory/hawkfield.proxmox.yml \

--- a/Ansible/roles/claude/defaults/main.yml
+++ b/Ansible/roles/claude/defaults/main.yml
@@ -21,16 +21,16 @@ claude_cron_jobs:
   - name: "deliver-orchestrator autonomy"
     minute: "15"
     job: >-
-      flock -n /home/claude/.local/state/deliver-orchestrator/autonomy.lock
-      /source/Deliver/orchestrator/cron.sh autonomy
+      flock -n {{ claude_orchestrator_state_dir }}/autonomy.lock
+      {{ claude_deliver_dir }}/orchestrator/cron.sh autonomy
   - name: "deliver-orchestrator scheduler"
     minute: "*/30"
     job: >-
-      flock -n /home/claude/.local/state/deliver-orchestrator/scheduler.lock
-      /source/Deliver/orchestrator/cron.sh scheduler
+      flock -n {{ claude_orchestrator_state_dir }}/scheduler.lock
+      {{ claude_deliver_dir }}/orchestrator/cron.sh scheduler
   - name: "deliver-orchestrator receipt"
     minute: "0"
     hour: "18"
     job: >-
-      flock -n /home/claude/.local/state/deliver-orchestrator/receipt.lock
-      /source/Deliver/orchestrator/cron.sh receipt
+      flock -n {{ claude_orchestrator_state_dir }}/receipt.lock
+      {{ claude_deliver_dir }}/orchestrator/cron.sh receipt

--- a/Ansible/roles/claude/defaults/main.yml
+++ b/Ansible/roles/claude/defaults/main.yml
@@ -4,3 +4,33 @@ claude_deliver_repo: "git@github.com:clincha/Deliver.git"
 claude_deliver_version: "master"
 claude_deliver_dir: /source/Deliver
 claude_orchestrator_state_dir: /home/claude/.local/state/deliver-orchestrator
+
+claude_cron_jobs:
+  - name: "email-summaries weekly"
+    minute: "0"
+    hour: "1"
+    weekday: "1"
+    job: /home/claude/email-summaries/weekly/run.sh
+  - name: "email-summaries daily"
+    minute: "30"
+    hour: "5"
+    job: /home/claude/email-summaries/daily/run.sh
+  - name: "email-summaries inbox-watcher"
+    minute: "*/30"
+    job: /home/claude/email-summaries/inbox-watcher/run.sh
+  - name: "deliver-orchestrator autonomy"
+    minute: "15"
+    job: >-
+      flock -n /home/claude/.local/state/deliver-orchestrator/autonomy.lock
+      /source/Deliver/orchestrator/cron.sh autonomy
+  - name: "deliver-orchestrator scheduler"
+    minute: "*/30"
+    job: >-
+      flock -n /home/claude/.local/state/deliver-orchestrator/scheduler.lock
+      /source/Deliver/orchestrator/cron.sh scheduler
+  - name: "deliver-orchestrator receipt"
+    minute: "0"
+    hour: "18"
+    job: >-
+      flock -n /home/claude/.local/state/deliver-orchestrator/receipt.lock
+      /source/Deliver/orchestrator/cron.sh receipt

--- a/Ansible/roles/claude/defaults/main.yml
+++ b/Ansible/roles/claude/defaults/main.yml
@@ -1,2 +1,6 @@
 ---
 claude_gogcli_version: "0.33.0"
+claude_deliver_repo: "git@github.com:clincha/Deliver.git"
+claude_deliver_version: "master"
+claude_deliver_dir: /source/Deliver
+claude_orchestrator_state_dir: /home/claude/.local/state/deliver-orchestrator

--- a/Ansible/roles/claude/handlers/main.yml
+++ b/Ansible/roles/claude/handlers/main.yml
@@ -4,3 +4,9 @@
     name: claude-remote-control
     state: restarted
     daemon_reload: true
+
+- name: "Restart deliver-poller"
+  ansible.builtin.systemd:
+    name: deliver-poller
+    state: restarted
+    daemon_reload: true

--- a/Ansible/roles/claude/tasks/main.yml
+++ b/Ansible/roles/claude/tasks/main.yml
@@ -410,3 +410,94 @@
     enabled: true
     state: started
     daemon_reload: true
+
+- name: "Ensure /source directory exists"
+  ansible.builtin.file:
+    path: /source
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+# /source is root-owned, so the target has to be pre-created for the
+# unprivileged clone below.
+- name: "Ensure Deliver checkout directory exists"
+  ansible.builtin.file:
+    path: "{{ claude_deliver_dir }}"
+    state: directory
+    owner: claude
+    group: claude
+    mode: "0755"
+
+# update:false — clone if absent, never touch a live working copy. Deliver has
+# linked worktrees under /source/Deliver-wt that a reset --hard would break.
+- name: "Clone Deliver repository into /source"
+  ansible.builtin.git:
+    repo: "{{ claude_deliver_repo }}"
+    dest: "{{ claude_deliver_dir }}"
+    version: "{{ claude_deliver_version }}"
+    update: false
+    accept_hostkey: true
+    key_file: /home/claude/.ssh/id_ed25519
+  become: true
+  become_user: claude
+
+- name: "Ensure deliver-orchestrator config directory exists"
+  ansible.builtin.file:
+    path: /home/claude/.config/deliver-orchestrator
+    state: directory
+    owner: claude
+    group: claude
+    mode: "0700"
+
+- name: "Deploy deliver-orchestrator environment file"
+  ansible.builtin.copy:
+    content: "{{ lookup('env', 'DELIVER_ORCHESTRATOR_ENV') }}"
+    dest: /home/claude/.config/deliver-orchestrator/env
+    owner: claude
+    group: claude
+    mode: "0600"
+  no_log: true
+  # Unguarded, a missing secret truncates the live file to 0 bytes and every
+  # orchestrator job then dies on an empty env.
+  when: lookup('env', 'DELIVER_ORCHESTRATOR_ENV') | length > 0
+  notify: "Restart deliver-poller"
+
+- name: "Ensure deliver-orchestrator state directory exists"
+  ansible.builtin.file:
+    path: "{{ claude_orchestrator_state_dir }}"
+    state: directory
+    owner: claude
+    group: claude
+    mode: "0755"
+
+- name: "Deploy deliver-poller systemd service"
+  ansible.builtin.copy:
+    content: |
+      [Unit]
+      Description=Deliver Telegram poller (long-poll daemon)
+      After=network-online.target
+      Wants=network-online.target
+      StartLimitIntervalSec=0
+
+      [Service]
+      User=claude
+      WorkingDirectory={{ claude_deliver_dir }}/orchestrator
+      ExecStart=/usr/bin/python3 poller.py
+      Restart=always
+      RestartSec=2
+
+      [Install]
+      WantedBy=multi-user.target
+    dest: /etc/systemd/system/deliver-poller.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: "Restart deliver-poller"
+
+- name: "Enable and start deliver-poller service"
+  ansible.builtin.systemd:
+    name: deliver-poller
+    enabled: true
+    state: started
+    daemon_reload: true

--- a/Ansible/roles/claude/tasks/main.yml
+++ b/Ansible/roles/claude/tasks/main.yml
@@ -501,3 +501,17 @@
     enabled: true
     state: started
     daemon_reload: true
+
+- name: "Schedule claude cron jobs"
+  ansible.builtin.cron:
+    name: "{{ item.name }}"
+    user: claude
+    minute: "{{ item.minute | default('*') }}"
+    hour: "{{ item.hour | default('*') }}"
+    day: "{{ item.day | default('*') }}"
+    month: "{{ item.month | default('*') }}"
+    weekday: "{{ item.weekday | default('*') }}"
+    job: "{{ item.job }}"
+  loop: "{{ claude_cron_jobs }}"
+  loop_control:
+    label: "{{ item.name }}"


### PR DESCRIPTION
Extends the `claude` role to cover the cron layer end to end, so a reprovisioned host comes up with its scheduled work intact rather than silently empty.

## What changed

- **`/source/Deliver` checkout** — `ansible.builtin.git` with `update: false` (clone-if-absent). Never resets a live working copy; `/source/Deliver-wt` linked worktrees would break under a `reset --hard`. `/source` is root-owned, so the target dir is pre-created as `claude` before the unprivileged clone.
- **`~/.config/deliver-orchestrator/env`** from a new `DELIVER_ORCHESTRATOR_ENV` repo secret, following the `GOG_*` pattern from #332 with the #388 guard (`no_log: true` + `when: lookup('env', ...) | length > 0`), so a missing secret skips rather than truncating a live credential file.
- **`deliver-poller.service`** — byte-for-byte the live unit, with only `WorkingDirectory` templated off `claude_deliver_dir`, plus a restart handler notified by both the unit and the env file.
- **Six cron entries** via `ansible.builtin.cron`, looped over `claude_cron_jobs` in `defaults/`, `flock` wrappers intact.
- **Workflow** — `DELIVER_ORCHESTRATOR_ENV` added to the `ansible-claude.yaml` playbook `env:` block.

Ordering matters and is respected: the env file and the Deliver clone land before the poller starts and before any cron entry can fire.

## Required manual steps

1. **Create the `DELIVER_ORCHESTRATOR_ENV` repo secret** — verbatim contents of `/home/claude/.config/deliver-orchestrator/env` (six `KEY=value` lines). Until it exists the file task skips and orchestrator jobs stay broken on a fresh host.
2. **Remove the six hand-added entries from claude's crontab at merge time.** They carry no `#Ansible: ` marker, so the first run appends managed copies alongside them. `flock` protects the three Deliver jobs; the three `email-summaries` jobs would double-fire.

## Review findings addressed

The three `flock` cron entries hardcoded `/source/Deliver` and the state dir rather than using `claude_deliver_dir` / `claude_orchestrator_state_dir`, so changing either variable would relocate the checkout and the poller's `WorkingDirectory` while leaving cron pointing at the old paths — now templated, with rendered strings unchanged.

## Verification

Every value was diffed against the live `claude-hawk-1`: the unit file is byte-identical, the repo URL/default branch (`master`) and `orchestrator/poller.py` path check out, the worktrees that justify `update: false` exist, and all six rendered `job` strings match `crontab -l` exactly. `ansible-lint Ansible/` and `yamllint` report the same 21 findings as master (no new ones); `--syntax-check` clean. No `--check` run against hawkfield — no Tailscale/vault credentials in this environment.

Out of scope per the issue: `~/.claude/.credentials.json`, so a reprovisioned host's crons still fail at `claude --print` until someone authenticates interactively.

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)