### PR TITLE
renovate: turn off the dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "flux": {
     "managerFilePatterns": ["/^kubernetes/flux/.+\\.ya?ml$/"]
   },
-  "dependencyDashboard": true,
+  "dependencyDashboard": false,
   "prConcurrentLimit": 3,
   "prHourlyLimit": 2,
   "ignorePaths": [


### PR DESCRIPTION
Sets `dependencyDashboard: false`. `config:recommended` turns it on, so an explicit `false` is needed to override it.

Renovate closes the existing Dependency Dashboard issue on the next run rather than leaving it stale.

Note: the dashboard is the only place deps Renovate *can't* raise a PR for show up — errored lookups, rate-limited branches, the `no-result` on `immich-machine-learning`. Without it those go silent, and the runner log is the only signal left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)