### PR TITLE
claude: schedule hourly memory autosave

### DIFF
--- a/Ansible/roles/claude/defaults/main.yml
+++ b/Ansible/roles/claude/defaults/main.yml
@@ -4,6 +4,7 @@ claude_deliver_repo: "git@github.com:clincha/Deliver.git"
 claude_deliver_version: "master"
 claude_deliver_dir: /source/Deliver
 claude_orchestrator_state_dir: /home/claude/.local/state/deliver-orchestrator
+claude_memory_autosave_state_dir: /home/claude/.local/state/memory-autosave
 
 claude_cron_jobs:
   - name: "email-summaries weekly"
@@ -34,3 +35,8 @@ claude_cron_jobs:
     job: >-
       flock -n {{ claude_orchestrator_state_dir }}/receipt.lock
       {{ claude_deliver_dir }}/orchestrator/cron.sh receipt
+  - name: "memory autosave"
+    minute: "50"
+    job: >-
+      flock -n {{ claude_memory_autosave_state_dir }}/run.lock
+      /home/claude/memory-autosave/run.sh

--- a/Ansible/roles/claude/tasks/main.yml
+++ b/Ansible/roles/claude/tasks/main.yml
@@ -471,6 +471,16 @@
     group: claude
     mode: "0755"
 
+# flock creates the lock file but not its parent, so the cron entry below would
+# fail every hour without this.
+- name: "Ensure memory autosave state directory exists"
+  ansible.builtin.file:
+    path: "{{ claude_memory_autosave_state_dir }}"
+    state: directory
+    owner: claude
+    group: claude
+    mode: "0755"
+
 - name: "Deploy deliver-poller systemd service"
   ansible.builtin.copy:
     content: |


### PR DESCRIPTION
## Why

`ansible-claude.yaml` runs on push to `master` under `Ansible/**` plus manual dispatch — there is no `schedule:`. The role's push-then-reset block (`tasks/main.yml:148-204`) is therefore the *only* thing that gets Dave's memory to `origin`, and it only fires when someone deploys.

That is fine for a redeploy: dirty state is auto-committed and pushed before the `force: true` clone. It is not fine for a wipe-and-rebuild — the save/push tasks are gated on `when: claude_repo_git_dir.stat.exists`, so on a host with no `/home/claude/.git` they are skipped entirely and the clone takes whatever `origin/main` has. Anything never pushed is gone.

## What

Hourly cron running `/home/claude/memory-autosave/run.sh` (open-dave/dave@12d164d), which commits and pushes the home working copy. Bounds intra-day loss to an hour.

- `git add -A`, matching the role's own auto-save. `/home/claude/.gitignore` is deny-by-default with an explicit allowlist, so runtime secrets (`.bw-master`, `env.sh`, `bw-api.sh`, gogcli credentials) are never staged — verified with `git add -A --dry-run`.
- A failed push leaves the commit local and exits non-zero. The next run retries; if it keeps failing, the role's own pre-deploy push fails loudly rather than resetting over the work.
- `flock -n` so a long run cannot overlap the next tick.

Cron entry is added with the `ansible.builtin.cron` name marker, so the one already installed by hand on hawk-1 is adopted rather than duplicated.

## Verification

`ansible-lint --strict` from `Ansible/` passes (65 files, profile `production`). Script exercised end-to-end on hawk-1: committed and pushed 8 dirty memory files as `46fc229`, working tree clean afterwards; second run logged `clean, nothing to save` and exited 0.

Partly addresses #390 (provisioning the cron layer) — this covers one job, not the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)