### PR TITLE
Ansible: bump ansible-core to 2.18.18 for CVE-2026-11332

### DIFF
--- a/Ansible/galaxy-requirements.yml
+++ b/Ansible/galaxy-requirements.yml
@@ -16,7 +16,9 @@ collections:
 
   - name: "https://github.com/kubernetes-sigs/kubespray"
     type: git
-    version: v2.29.1  # adds hostendpoints "watch" RBAC (kubespray#11076)
+    # First release on ansible-core 2.18, required for CVE-2026-11332. Do not go
+    # below v2.29.1 — that added the hostendpoints "watch" RBAC (kubespray#11076).
+    version: v2.31.0
 
   - name: "ansible.netcommon"
     version: "8.1.0"

--- a/Ansible/requirements.txt
+++ b/Ansible/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core==2.17.14 # locked for compatibility with Kubespray
+ansible-core==2.18.18 # locked for compatibility with Kubespray; 2.18.18 is the CVE-2026-11332 floor
 distlib==0.4.3 # Required to install collections
 requests==2.34.2 # Required for Proxmox dynamic inventory
 passlib # password hashing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ ansible-inventory -i inventory/london.proxmox.yml --list
 
 ### Ansible
 
-All Ansible commands run from the `Ansible/` directory. Python 3.13, ansible-core 2.17.14 (pinned for Kubespray compatibility).
+All Ansible commands run from the `Ansible/` directory. Python 3.13, ansible-core 2.18.18 (pinned for Kubespray compatibility).
 
 ```bash
 # Install Python dependencies
@@ -67,7 +67,7 @@ packer build packer/ubuntu2404/main.pkr.hcl
 - **Roles**: `base/`, `users/`, `sudoers/`, `helm/`
 - **Inventory**: Dynamic Proxmox-based (`inventory/hawkfield.proxmox.yml`, `inventory/london.proxmox.yml`)
 - **Group vars**: `group_vars/all.yml`, `group_vars/hawkfield.yml`, `group_vars/london.yml`
-- Kubespray v2.29.1 (installed via Galaxy as a collection)
+- Kubespray v2.31.0 (installed via Galaxy as a collection)
 
 ### Kubernetes (`kubernetes/flux/`)
 


### PR DESCRIPTION
Closes Dependabot alert [#3](https://github.com/clincha-org/clincha/security/dependabot/3) — GHSA-w8p5-mx5w-cpqj / CVE-2026-11332, high: argument injection in `ansible-galaxy role install` leading to arbitrary code execution.

## Why it needs a Kubespray bump too

`ansible-core` 2.17 is **EOL at 2.17.14** — that is the last release on PyPI and there is no in-branch fix, so the patched floor for us is `2.18.18`. Staying on the current pin means staying vulnerable indefinitely, not just until the next patch release.

The pin was held for Kubespray compatibility, and that constraint is real:

| Kubespray | ansible pin | → ansible-core | patched? |
| --- | --- | --- | --- |
| v2.29.1 (current) | `ansible==10.7.0` | 2.17.x | no — EOL |
| v2.30.0 | `ansible==10.7.0` | 2.17.x | no |
| **v2.31.0** | `ansible==11.13.0` | `~=2.18.12` | **yes — permits 2.18.18** |

v2.31.0 is the first Kubespray release that moves off core 2.17, so the two bumps have to land together.

## Cluster version is unchanged

`kube_version` stays `1.33.5`. v2.31.0 defaults to 1.35.4, but we pin explicitly, and I confirmed v2.31.0 still ships checksums for 1.33.5 (`kubelet`, `kubectl`, `kubeadm`, amd64). That matters because v2.31.0 added a hard failure when `kube_version` is absent from the checksums dict rather than the old cryptic `AnsibleUndefined`.

The two headline breaking changes in v2.31.0 do not apply here: the removed Dashboard addon (`dashboard_enabled` appears nowhere in this repo) and cgroup v1 no longer being on by default (`cgroup` is not referenced).

Collection floors required by v2.31.0 are all satisfied by existing pins — `community.general>=7.0.0` (11.4.0), `ansible.posix>=1.5.4` (2.1.0), `kubernetes.core>=2.4.2` (6.2.0), `ansible.netcommon>=5.3.0` (8.1.0).

## Verification

Installed `ansible-core==2.18.18` and Kubespray v2.31.0 into a scratch collections path and ran `ansible-playbook --syntax-check` on **all nine playbooks** against that exact combination — adguard, base, claude, monitoring, proxmox, proxmox-bootstrap, update-proxmox, update-k8s, kubernetes: all pass.

**This is a parse-level check, not a run.** Runtime behaviour changes in core 2.18 would not show up, and `cluster-rebuild` has not been exercised. That playbook carries the real risk and is worth running deliberately rather than discovering during an incident.

## Note on Dependabot

`.github/dependabot.yaml` ignores `version-update:semver-minor` and `semver-major` for `ansible-core` — exactly the bump this fix requires. That is why the alert has sat open since 2026-07-16 with no PR, and why this had to be done by hand. Worth deciding separately whether that ignore rule should carve out security updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)