### PR TITLE
factorio: replace the hawkfield NodePort with a MetalLB VIP

### DIFF
--- a/kubernetes/flux/applications/hawkfield/factorio/kustomization.yml
+++ b/kubernetes/flux/applications/hawkfield/factorio/kustomization.yml
@@ -4,6 +4,13 @@ metadata:
   name: factorio
 resources:
   - ../../base/factorio
+patches:
+  - target:
+      kind: Service
+      version: v1
+      namespace: factorio
+      name: factorio
+    path: service-patch.yml
 configMapGenerator:
   - name: factorio-server-settings
     namespace: factorio

--- a/kubernetes/flux/applications/hawkfield/factorio/service-patch.yml
+++ b/kubernetes/flux/applications/hawkfield/factorio/service-patch.yml
@@ -2,9 +2,7 @@
   path: /spec/type
   value: LoadBalancer
 
-# Both of these are needed: a LoadBalancer allocates node ports by default,
-# and any leftover port in the KUBE-NODE-PORT-UDP bitmap ipset masquerades
-# traffic to the VIP, undoing externalTrafficPolicy: Local.
+# A node port left in the KUBE-NODE-PORT-UDP ipset masquerades VIP traffic too
 - op: remove
   path: /spec/ports/0/nodePort
 

--- a/kubernetes/flux/applications/hawkfield/factorio/service-patch.yml
+++ b/kubernetes/flux/applications/hawkfield/factorio/service-patch.yml
@@ -1,0 +1,22 @@
+- op: replace
+  path: /spec/type
+  value: LoadBalancer
+
+# Both of these are needed: a LoadBalancer allocates node ports by default,
+# and any leftover port in the KUBE-NODE-PORT-UDP bitmap ipset masquerades
+# traffic to the VIP, undoing externalTrafficPolicy: Local.
+- op: remove
+  path: /spec/ports/0/nodePort
+
+- op: add
+  path: /spec/allocateLoadBalancerNodePorts
+  value: false
+
+- op: add
+  path: /spec/externalTrafficPolicy
+  value: Local
+
+- op: add
+  path: /metadata/annotations
+  value:
+    metallb.io/loadBalancerIPs: 10.1.2.204


### PR DESCRIPTION
Factorio was the last service reachable only through a specific node's IP: a NodePort with the default `Cluster` policy, on a Deployment with no `nodeSelector`. If the node holding the pod went down, the saved `<node-ip>:31499` stopped working even after the pod rescheduled, and the SNAT hid real client IPs from the server log.

The hawkfield overlay now patches the Service into a MetalLB `LoadBalancer` on `10.1.2.204` with `externalTrafficPolicy: Local`, matching how Plex and ingress-nginx are exposed. L2 announces the VIP only from the node holding a ready pod, so the address follows the pod.

`allocateLoadBalancerNodePorts: false` plus removing the explicit `nodePort: 31499` are both needed — a leftover node port stays in the `KUBE-NODE-PORT-UDP` bitmap ipset, which masquerades traffic to the VIP as well and silently undoes `Local`.

`base/factorio/` keeps its NodePort so `dev` and `london`, which have no `10.1.2.0/24` pool, are unaffected. Verified: the hawkfield build renders `LoadBalancer` with the annotation, `Local`, `allocateLoadBalancerNodePorts: false` and no `nodePort`; the dev and london builds still render NodePort 31499 unchanged.

Not backwards compatible by design — LAN clients pointing at `<node-ip>:31499` must be re-pointed at `10.1.2.204:34197`. There is no WAN forward for either port, so nothing external breaks.

Review: confirmed the patch renders correctly across all three overlays and that nothing else in the repo references 31499; trimmed a three-line comment down to one line.

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)