### PR TITLE
flux: hash generated ConfigMaps so config edits actually roll out

### DIFF
--- a/kubernetes/flux/applications/dev/factorio/kustomization.yml
+++ b/kubernetes/flux/applications/dev/factorio/kustomization.yml
@@ -21,5 +21,3 @@ configMapGenerator:
       - server-adminlist.json
       - map-gen-settings.json
       - map-settings.json
-    options:
-      disableNameSuffixHash: true

--- a/kubernetes/flux/applications/hawkfield/factorio/kustomization.yml
+++ b/kubernetes/flux/applications/hawkfield/factorio/kustomization.yml
@@ -13,5 +13,3 @@ configMapGenerator:
       - server-adminlist.json
       - map-gen-settings.json
       - map-settings.json
-    options:
-      disableNameSuffixHash: true

--- a/kubernetes/flux/applications/london/factorio/kustomization.yml
+++ b/kubernetes/flux/applications/london/factorio/kustomization.yml
@@ -21,5 +21,3 @@ configMapGenerator:
       - server-adminlist.json
       - map-gen-settings.json
       - map-settings.json
-    options:
-      disableNameSuffixHash: true

--- a/kubernetes/flux/infrastructure/dev/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/dev/monitoring/kustomization.yml
@@ -25,5 +25,3 @@ configMapGenerator:
     namespace: monitoring
     files:
       - values.yml
-    options:
-      disableNameSuffixHash: true

--- a/kubernetes/flux/infrastructure/hawkfield/ingress-nginx/kustomization.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/ingress-nginx/kustomization.yml
@@ -4,10 +4,10 @@ metadata:
   name: ingress-nginx
 resources:
   - ../../base/ingress-nginx
+configurations:
+  - nameref-helmrelease.yml
 configMapGenerator:
   - namespace: ingress-nginx
     name: ingress-nginx-values
     files:
       - values.yml
-    options:
-      disableNameSuffixHash: true

--- a/kubernetes/flux/infrastructure/hawkfield/ingress-nginx/nameref-helmrelease.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/ingress-nginx/nameref-helmrelease.yml
@@ -1,7 +1,7 @@
 ---
 # Kustomize's built-in nameReference transformer doesn't know the HelmRelease
-# CRD, so without this a hashed ConfigMap leaves valuesFrom pointing at the
-# bare name. Copied per overlay — Flux loads with LoadRestrictionsRootOnly.
+# CRD, so a hashed ConfigMap would leave valuesFrom on the bare name. Copied
+# per overlay: default load restrictions reject a path outside the root.
 nameReference:
   - kind: ConfigMap
     version: v1

--- a/kubernetes/flux/infrastructure/hawkfield/ingress-nginx/nameref-helmrelease.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/ingress-nginx/nameref-helmrelease.yml
@@ -1,0 +1,10 @@
+---
+# Kustomize's built-in nameReference transformer doesn't know the HelmRelease
+# CRD, so without this a hashed ConfigMap leaves valuesFrom pointing at the
+# bare name. Copied per overlay — Flux loads with LoadRestrictionsRootOnly.
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
@@ -11,8 +11,6 @@ configMapGenerator:
     namespace: monitoring
     files:
       - prometheus.yml
-    options:
-      disableNameSuffixHash: true
   - name: alloy-values
     namespace: monitoring
     files:
@@ -35,17 +33,11 @@ configMapGenerator:
     namespace: monitoring
     files:
       - graphite_mapping.conf
-    options:
-      disableNameSuffixHash: true
   - name: alloy-syslog-config
     namespace: monitoring
     files:
       - config-syslog.alloy
-    options:
-      disableNameSuffixHash: true
   - name: truenas-exporter-script
     namespace: monitoring
     files:
       - truenas_exporter.py
-    options:
-      disableNameSuffixHash: true

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
@@ -21,8 +21,8 @@ configMapGenerator:
     namespace: monitoring
     files:
       - config.alloy
-    # Keeps the flag: this name is referenced from inside alloy-values.yml's
-    # file content, which kustomize never rewrites.
+    # Flag kept: the name lives inside alloy-values.yml's file content, which
+    # kustomize can't rewrite. Edits here still need a manual rollout restart.
     options:
       disableNameSuffixHash: true
   - name: loki-values

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
@@ -6,6 +6,8 @@ resources:
   - ../../base/monitoring
   - truenas-api-key.sops.yaml
   - loki-rustfs-creds.sops.yaml
+configurations:
+  - nameref-helmrelease.yml
 configMapGenerator:
   - name: prometheus.yml
     namespace: monitoring
@@ -15,20 +17,18 @@ configMapGenerator:
     namespace: monitoring
     files:
       - values.yml=alloy-values.yml
-    options:
-      disableNameSuffixHash: true
   - name: alloy-config
     namespace: monitoring
     files:
       - config.alloy
+    # Keeps the flag: this name is referenced from inside alloy-values.yml's
+    # file content, which kustomize never rewrites.
     options:
       disableNameSuffixHash: true
   - name: loki-values
     namespace: monitoring
     files:
       - values.yml=loki-values.yml
-    options:
-      disableNameSuffixHash: true
   - name: graphite-mapping
     namespace: monitoring
     files:

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/nameref-helmrelease.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/nameref-helmrelease.yml
@@ -1,7 +1,7 @@
 ---
 # Kustomize's built-in nameReference transformer doesn't know the HelmRelease
-# CRD, so without this a hashed ConfigMap leaves valuesFrom pointing at the
-# bare name. Copied per overlay — Flux loads with LoadRestrictionsRootOnly.
+# CRD, so a hashed ConfigMap would leave valuesFrom on the bare name. Copied
+# per overlay: default load restrictions reject a path outside the root.
 nameReference:
   - kind: ConfigMap
     version: v1

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/nameref-helmrelease.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/nameref-helmrelease.yml
@@ -1,0 +1,10 @@
+---
+# Kustomize's built-in nameReference transformer doesn't know the HelmRelease
+# CRD, so without this a hashed ConfigMap leaves valuesFrom pointing at the
+# bare name. Copied per overlay — Flux loads with LoadRestrictionsRootOnly.
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/kubernetes/flux/infrastructure/london/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/london/monitoring/kustomization.yml
@@ -25,5 +25,3 @@ configMapGenerator:
     namespace: monitoring
     files:
       - values.yml
-    options:
-      disableNameSuffixHash: true


### PR DESCRIPTION
`disableNameSuffixHash: true` pins a generated ConfigMap's name, so editing its
content updates the ConfigMap and the mounted file but leaves the pod template
byte-identical — no rollout, and the process keeps serving what it parsed at
startup. Flux reports the revision applied and goes green. The same pattern hid
a broken log pipeline for two days in media#37.

The flag was originally needed because kustomize's built-in nameReference
transformer doesn't know Flux's `HelmRelease` CRD — hashing the ConfigMap left
`valuesFrom` pointing at the bare name. That applies to three generators; it was
applied uniformly to all of them.

**A — flag removed, references rewrite automatically (7)**
`prometheus.yml`, `graphite-mapping`, `alloy-syslog-config`,
`truenas-exporter-script` in `hawkfield/monitoring`; `factorio-server-settings`
in all three overlays; `prometheus-values` in `dev`/`london` (dead generator,
nothing references it — removal is a no-op there).

**B — `nameref-helmrelease.yml` added, then flag removed (3)**
A `configurations:` file teaches kustomize about `HelmRelease.spec.valuesFrom[].name`,
after which `alloy-values`, `loki-values` and `ingress-nginx-values` can hash.
This also fixes a second documented gotcha: helm-controller doesn't watch
ConfigMaps referenced via `valuesFrom`, so editing them needed a manual
`flux reconcile --force`. A hashed name makes the edit a HelmRelease spec
change, which upgrades automatically.

**C — flag kept (1)**
`alloy-config`, whose name appears inside `alloy-values.yml`'s *file content*.
Kustomize never rewrites file contents, so no nameReference can reach it.
Commented in place, including that edits there still need a manual restart.

Verified with the CI check locally: 37/37 overlays build and validate, and
every generated ConfigMap in the seven touched overlays resolves to a consumer
carrying the identical hash — no bare names survive except `alloy-config`.

Expect one rollout per affected workload as names change, plus Helm upgrades
for alloy, loki and ingress-nginx. ingress-nginx is the one to watch. Old
ConfigMaps are pruned.

Review: corrected the duplicated `nameref-helmrelease.yml` comment, which
attributed the copy-per-overlay to Flux using `LoadRestrictionsRootOnly` —
Flux builds with `LoadRestrictionsNone`; the binding constraint is kustomize's
default, which is what `kubectl kustomize` enforces in CI (confirmed by test).

Two pre-existing problems found and left alone, both identical on `master`:
`prometheus-values` in dev/london is dead and worth deleting with its
`values.yml`, and `infrastructure/{dev,london}/monitoring` inherit
`base/monitoring` without generating the six ConfigMaps it mounts, so both
render dangling references. Dormant — neither overlay is wired into a cluster.

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)