### PR TITLE
workflows: drop the production gate from terraform apply

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -92,18 +92,27 @@ Workflows use concurrency groups to prevent dangerous parallel runs:
 |-------|-----------|-----------|
 | `cluster-{site}` | terraform.yaml (apply only), ansible-base.yaml | Per-site — each site's job serialises with that site's terraform apply |
 | `cluster-hawkfield` | cluster-rebuild.yaml | Serialises the rebuild against Hawkfield's other cluster work |
-
-Approval-gated jobs (`terraform.yaml` apply, `cluster-rebuild.yaml` destroy) must not
-declare a concurrency group: a job acquires its group *before* it waits on the
-environment gate, so an unapproved deployment holds the group indefinitely and every
-later run in it pends until cancelled. Both workflows therefore isolate the
-`production` gate in a group-less `approve` job that the real work `needs`.
-
-`terraform.yaml`'s plan job has no group either — `terraform plan` is read-only and
-Terraform's own state locking covers an overlapping apply.
 | `terraform-plan-{PR}` | terraform-plan.yaml | Per-PR, cancels in-progress — only latest plan matters |
 | `packer-{host}` | packer.yaml | Per-host — prevents parallel builds on the same Proxmox node |
 | `{workflow name}` | ansible-update-proxmox, ansible-proxmox, ansible-proxmox-bootstrap | Serialised per workflow |
+
+### Concurrency and the `production` gate
+
+A job acquires its concurrency group *before* it waits on an environment gate, so a job
+that declares both holds the group for as long as nobody approves it — every later run
+in that group pends until it is cancelled ([#399](https://github.com/clincha-org/clincha/issues/399)).
+No job in this repo may declare `environment:` and `concurrency:` together. `terraform.yaml`
+and `cluster-rebuild.yaml` therefore isolate the `production` gate in a group-less
+`approve` job that the real work `needs`, so the lock is taken only once work is authorised.
+
+`cluster-rebuild.yaml` holds `cluster-hawkfield` per job rather than for the whole run, so
+the group is briefly free between `destroy`, `provision` and `configure`. An hourly
+`ansible-base` run can slip into those gaps and fail against half-rebuilt hosts; that is
+preferred over the workflow-level group, which reintroduces the wedge above.
+
+`terraform.yaml`'s plan job has no group — `terraform plan` is read-only, so an overlapping
+apply cannot be corrupted by it. These backends configure no state locking
+(no `dynamodb_table`, no `use_lockfile`), so the plan output may be stale instead.
 
 ## Secrets
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,6 +1,6 @@
 # CI/CD Workflows
 
-All workflows run on GitHub Actions and connect to internal infrastructure via [Tailscale](https://tailscale.com/). Destructive operations (terraform apply, cluster rebuild) require approval through the `production` GitHub environment.
+All workflows run on GitHub Actions and connect to internal infrastructure via [Tailscale](https://tailscale.com/). Cluster rebuild requires approval through the `production` GitHub environment. Terraform apply does not — its plan is reviewed on the PR, and merging to `master` is the approval.
 
 ## Infrastructure Lifecycle
 
@@ -48,7 +48,7 @@ These run when changes are pushed to `master` (i.e. a PR is merged).
 | Workflow | File | Triggers | Sites | What it does |
 |----------|------|----------|-------|-------------|
 | **Packer Build** | `packer.yaml` | Push to master (paths: `packer/**`), weekly Sunday 04:00 UTC, manual | hawk01–03, lon01 | Builds Ubuntu 24.04 VM templates on all Proxmox nodes (matrix build, one per host) |
-| **Terraform Apply** | `terraform.yaml` | Push to master (paths: `terraform/**`), manual | Hawkfield, London | Plans then applies Terraform for both sites (matrix). Apply waits on an `approve` job gated by the `production` environment |
+| **Terraform Apply** | `terraform.yaml` | Push to master (paths: `terraform/**`), manual | Hawkfield, London | Plans then applies Terraform for both sites (matrix). Applies unattended — `terraform-plan.yaml` already posted the plan on the PR |
 | **Ansible Base** | `ansible-base.yaml` | Push to master (paths: `Ansible/**`), hourly, manual | Hawkfield, London (parallel) | Runs `base.yml` playbook — user accounts, sudoers, base packages |
 | **Proxmox Config** | `ansible-proxmox.yaml` | Push to master (paths: `Ansible/proxmox.yml`), hourly, manual | Hawkfield, London (parallel) | Configures Proxmox API roles, users, and ACLs via `proxmox.yml` playbook |
 
@@ -90,7 +90,7 @@ Workflows use concurrency groups to prevent dangerous parallel runs:
 
 | Group | Workflows | Behaviour |
 |-------|-----------|-----------|
-| `cluster-{site}` | terraform.yaml (apply only), ansible-base.yaml | Per-site — each site's job serialises with that site's terraform apply |
+| `cluster-{site}` | terraform.yaml, ansible-base.yaml | Per-site — each site's job serialises with that site's terraform run |
 | `cluster-hawkfield` | cluster-rebuild.yaml | Serialises the rebuild against Hawkfield's other cluster work |
 | `terraform-plan-{PR}` | terraform-plan.yaml | Per-PR, cancels in-progress — only latest plan matters |
 | `packer-{host}` | packer.yaml | Per-host — prevents parallel builds on the same Proxmox node |
@@ -101,18 +101,19 @@ Workflows use concurrency groups to prevent dangerous parallel runs:
 A job acquires its concurrency group *before* it waits on an environment gate, so a job
 that declares both holds the group for as long as nobody approves it — every later run
 in that group pends until it is cancelled ([#399](https://github.com/clincha-org/clincha/issues/399)).
-No job in this repo may declare `environment:` and `concurrency:` together. `terraform.yaml`
-and `cluster-rebuild.yaml` therefore isolate the `production` gate in a group-less
-`approve` job that the real work `needs`, so the lock is taken only once work is authorised.
+No job in this repo may declare `environment:` and `concurrency:` together.
 
-`cluster-rebuild.yaml` holds `cluster-hawkfield` per job rather than for the whole run, so
-the group is briefly free between `destroy`, `provision` and `configure`. An hourly
-`ansible-base` run can slip into those gaps and fail against half-rebuilt hosts; that is
-preferred over the workflow-level group, which reintroduces the wedge above.
+`terraform.yaml` has no gate at all. `terraform-plan.yaml` posts the plan on the PR, so
+approving the merge approves the apply; a second click per run only earned unattended
+runs a lock they held for days.
 
-`terraform.yaml`'s plan job has no group — `terraform plan` is read-only, so an overlapping
-apply cannot be corrupted by it. These backends configure no state locking
-(no `dynamodb_table`, no `use_lockfile`), so the plan output may be stale instead.
+`cluster-rebuild.yaml` keeps the `production` gate — it destroys a live cluster on a
+manual dispatch, with no reviewed plan behind it. The gate sits in a group-less `approve`
+job that `destroy` `needs`, so an unapproved rebuild holds nothing. The three working jobs
+hold `cluster-hawkfield` individually rather than the whole run, which leaves the group
+briefly free between them: an hourly `ansible-base` run can slip into a gap and fail
+against half-rebuilt hosts. That is preferred over a workflow-level group, which puts the
+gate and the lock back in the same run.
 
 ## Secrets
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -48,7 +48,7 @@ These run when changes are pushed to `master` (i.e. a PR is merged).
 | Workflow | File | Triggers | Sites | What it does |
 |----------|------|----------|-------|-------------|
 | **Packer Build** | `packer.yaml` | Push to master (paths: `packer/**`), weekly Sunday 04:00 UTC, manual | hawk01–03, lon01 | Builds Ubuntu 24.04 VM templates on all Proxmox nodes (matrix build, one per host) |
-| **Terraform Apply** | `terraform.yaml` | Push to master (paths: `terraform/**`), manual | Hawkfield, London | Plans then applies Terraform for both sites (matrix). Apply job requires `production` environment approval |
+| **Terraform Apply** | `terraform.yaml` | Push to master (paths: `terraform/**`), manual | Hawkfield, London | Plans then applies Terraform for both sites (matrix). Apply waits on an `approve` job gated by the `production` environment |
 | **Ansible Base** | `ansible-base.yaml` | Push to master (paths: `Ansible/**`), hourly, manual | Hawkfield, London (parallel) | Runs `base.yml` playbook — user accounts, sudoers, base packages |
 | **Proxmox Config** | `ansible-proxmox.yaml` | Push to master (paths: `Ansible/proxmox.yml`), hourly, manual | Hawkfield, London (parallel) | Configures Proxmox API roles, users, and ACLs via `proxmox.yml` playbook |
 
@@ -82,7 +82,7 @@ These are triggered via `workflow_dispatch` only (Actions tab > Run workflow).
 | Workflow | File | Sites | What it does |
 |----------|------|-------|-------------|
 | **Proxmox Bootstrap** | `ansible-proxmox-bootstrap.yaml` | Per `inventory/bootstrap.yml` | Initial Proxmox setup. Uses root password (not SSH key). Run once per new node |
-| **Cluster Rebuild** | `cluster-rebuild.yaml` | Choose: hawkfield or london | Full cluster teardown and rebuild: `terraform destroy` → `terraform apply` → `ansible-playbook kubernetes.yml`. Destroy requires `production` approval |
+| **Cluster Rebuild** | `cluster-rebuild.yaml` | Hawkfield | Full cluster teardown and rebuild: `terraform destroy` → `terraform apply` → `ansible-playbook kubernetes.yml`. Requires `production` approval before the destroy |
 
 ## Concurrency Groups
 
@@ -90,8 +90,17 @@ Workflows use concurrency groups to prevent dangerous parallel runs:
 
 | Group | Workflows | Behaviour |
 |-------|-----------|-----------|
-| `cluster-{site}` | terraform.yaml, ansible-base.yaml | Per-site — each site's job serialises with that site's terraform run |
-| `cluster-{input}` | cluster-rebuild.yaml | Per-cluster — hawkfield and london can run independently |
+| `cluster-{site}` | terraform.yaml (apply only), ansible-base.yaml | Per-site — each site's job serialises with that site's terraform apply |
+| `cluster-hawkfield` | cluster-rebuild.yaml | Serialises the rebuild against Hawkfield's other cluster work |
+
+Approval-gated jobs (`terraform.yaml` apply, `cluster-rebuild.yaml` destroy) must not
+declare a concurrency group: a job acquires its group *before* it waits on the
+environment gate, so an unapproved deployment holds the group indefinitely and every
+later run in it pends until cancelled. Both workflows therefore isolate the
+`production` gate in a group-less `approve` job that the real work `needs`.
+
+`terraform.yaml`'s plan job has no group either — `terraform plan` is read-only and
+Terraform's own state locking covers an overlapping apply.
 | `terraform-plan-{PR}` | terraform-plan.yaml | Per-PR, cancels in-progress — only latest plan matters |
 | `packer-{host}` | packer.yaml | Per-host — prevents parallel builds on the same Proxmox node |
 | `{workflow name}` | ansible-update-proxmox, ansible-proxmox, ansible-proxmox-bootstrap | Serialised per workflow |

--- a/.github/workflows/cluster-rebuild.yaml
+++ b/.github/workflows/cluster-rebuild.yaml
@@ -3,13 +3,22 @@ permissions:
   contents: read
 on:
   workflow_dispatch:
-concurrency:
-  group: "cluster-hawkfield"
 jobs:
-  destroy:
+  # Gate carries no concurrency group: a job holds its group while waiting for
+  # approval, which would lock the site for as long as nobody approves.
+  approve:
     runs-on: ubuntu-latest
     environment:
       name: production
+    steps:
+      - name: Approved
+        run: echo "Rebuild approved"
+
+  destroy:
+    runs-on: ubuntu-latest
+    needs: approve
+    concurrency:
+      group: "cluster-hawkfield"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -33,6 +42,8 @@ jobs:
   provision:
     runs-on: ubuntu-latest
     needs: destroy
+    concurrency:
+      group: "cluster-hawkfield"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -61,6 +72,8 @@ jobs:
   configure:
     runs-on: ubuntu-latest
     needs: provision
+    concurrency:
+      group: "cluster-hawkfield"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/cluster-rebuild.yaml
+++ b/.github/workflows/cluster-rebuild.yaml
@@ -4,8 +4,7 @@ permissions:
 on:
   workflow_dispatch:
 jobs:
-  # Gate carries no concurrency group: a job holds its group while waiting for
-  # approval, which would lock the site for as long as nobody approves.
+  # No concurrency group here: a job holds its group while awaiting approval. See #399.
   approve:
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -44,8 +44,7 @@ jobs:
           path: terraform/${{ matrix.site }}/tfplan
           name: tfplan-${{ matrix.site }}
 
-  # Gate carries no concurrency group: a job holds its group while waiting for
-  # approval, which would lock every site for as long as nobody approves.
+  # No concurrency group here: a job holds its group while awaiting approval. See #399.
   approve:
     name: "Approve"
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -17,6 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         site: [hawkfield, hawkfield-kubernetes, london]
+    concurrency:
+      group: "cluster-${{ matrix.site }}"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -44,21 +46,10 @@ jobs:
           path: terraform/${{ matrix.site }}/tfplan
           name: tfplan-${{ matrix.site }}
 
-  # No concurrency group here: a job holds its group while awaiting approval. See #399.
-  approve:
-    name: "Approve"
-    runs-on: ubuntu-latest
-    needs: plan
-    environment:
-      name: production
-    steps:
-      - name: Approved
-        run: echo "Apply approved"
-
   apply:
     name: "Apply (${{ matrix.site }})"
     runs-on: ubuntu-latest
-    needs: approve
+    needs: plan
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -17,8 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         site: [hawkfield, hawkfield-kubernetes, london]
-    concurrency:
-      group: "cluster-${{ matrix.site }}"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -46,12 +44,22 @@ jobs:
           path: terraform/${{ matrix.site }}/tfplan
           name: tfplan-${{ matrix.site }}
 
-  apply:
-    name: "Apply (${{ matrix.site }})"
+  # Gate carries no concurrency group: a job holds its group while waiting for
+  # approval, which would lock every site for as long as nobody approves.
+  approve:
+    name: "Approve"
     runs-on: ubuntu-latest
     needs: plan
     environment:
       name: production
+    steps:
+      - name: Approved
+        run: echo "Apply approved"
+
+  apply:
+    name: "Apply (${{ matrix.site }})"
+    runs-on: ubuntu-latest
+    needs: approve
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Every `ansible-base` run since 2026-07-30 pended and was cancelled. A job acquires its concurrency group *before* it waits on an environment gate, so Terraform Apply run `30519354702` — unapproved since `06:22:40Z` — has been holding `cluster-hawkfield` and `cluster-london`, which is exactly where `ansible-base`'s two jobs live.

## What changed

- `terraform.yaml` — `environment: production` is deleted from `apply`. That is the whole change to this file; the plan → apply chain and both `cluster-${{ matrix.site }}` groups are untouched. `terraform-plan.yaml` already posts the plan on the PR, so reviewing and merging to `master` is the approval; a second click per run bought nothing and cost a lock held for days.
- `cluster-rebuild.yaml` — gate kept. It runs `terraform destroy` against a live cluster from a manual dispatch with no reviewed plan behind it, so the confirmation is worth having. It moves into a group-less `approve` job that `destroy` needs, and the workflow-level group becomes a per-job `cluster-hawkfield` on `destroy` → `provision` → `configure`, so an unapproved rebuild holds nothing. The group stays hardcoded to hawkfield: every job targets `terraform/hawkfield-kubernetes` and the hawkfield inventory, so the README rows claiming a hawkfield/london choice are corrected rather than the group parameterised.
- `README.md` — header and workflow rows updated, concurrency section rewritten, plus a stated rule that no job may declare `environment:` and `concurrency:` together.

## Verification

- `actionlint` clean on both workflows.
- `yamllint` reports only the pre-existing `document-start`/`truthy` warnings shared by every workflow in the repo.
- No job in `.github/workflows/` declares both `environment:` and `concurrency:`.
- The `production` environment holds 0 secrets and 0 variables (all are repo-level), so dropping `environment:` from `apply` does not change secret resolution.

## Still needs a human

Merging this does not release the locks. The jobs of run `30519354702` keep holding their groups while they wait, regardless of the new YAML. Someone with repo admin needs to reject or cancel `30519354702` and then cancel `30609018483` — and review that pending plan from `24bf78d` first, in case the RustFS backend migration produced a diff worth applying.

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)