### PR TITLE
Add hardware spec sheets for the five physical servers

### DIFF
--- a/Documentation/hardware/README.md
+++ b/Documentation/hardware/README.md
@@ -1,0 +1,117 @@
+# Hardware spec sheets
+
+Physical machine inventory for the homelab. One page per box, covering board, CPU, memory,
+storage, expansion slots and what is free — enough to answer "will this upgrade fit?" without
+opening the case.
+
+Captured **2026-08-01** from the live machines (see [Collection method](#collection-method)).
+Anything that firmware cannot report — PSU model, case model, cooler, fan and cable inventory —
+is listed per page under "Needs a physical check".
+
+## The machines
+
+| Host | Site | Role | Hardware | CPU | RAM | Network |
+|------|------|------|----------|-----|-----|---------|
+| [hawkstore](hawkstore.md) | Hawkfield | TrueNAS storage | Supermicro SSG-6048R-E1CR36L (X10DRH-iT) | 2× Xeon E5-2667 v4 (16c/32t) | 128 GiB DDR4 ECC RDIMM | 2× 10GBase-T bonded |
+| [hawk01](hawk01.md) | Hawkfield | Proxmox, k8s-hawk-1 + dns-hawk-1 | ASUS PRIME B450M-A II | Ryzen 5 5600GT (6c/12t) | 80 GiB DDR4 non-ECC | 1GbE + 10G SFP+ |
+| [hawk02](hawk02.md) | Hawkfield | Proxmox, k8s-hawk-2 + claude-hawk-1 | ASUS PRIME B450M-A II | Ryzen 5 5600GT (6c/12t) | 80 GiB DDR4 non-ECC | 1GbE + 10G SFP+ |
+| [hawk03](hawk03.md) | Hawkfield | Proxmox, k8s-hawk-3 | ASUS PRIME B450M-A II | Ryzen 5 5600GT (6c/12t) | 80 GiB DDR4 non-ECC | 1GbE + 10G SFP+ |
+| [lon01](lon01.md) | London | Proxmox, k8s-lon-1 + dns-lon-1 | HP EliteDesk 705 G4 DM 65W | Ryzen 5 PRO 2400G (4c/8t) | 16 GiB DDR4 SODIMM | 1GbE |
+
+Not covered: `clincha-main` (Angus's desktop, not part of the cluster) and network kit (UniFi
+gateway, switches). The k8s nodes, DNS resolvers and `claude-hawk-1` are guests — see the host
+page of the machine they run on.
+
+## Expansion at a glance
+
+| Host | Free DIMM slots | Free drive attach points | Free PCIe slots |
+|------|-----------------|--------------------------|-----------------|
+| hawkstore | 8 of 16 (4 per CPU) | 3 free SAS3008 ports + spare drive bays | 3× PCIe 3.0 x8 (all on CPU1) |
+| hawk01 | 0 of 4 | 4 of 6 SATA; M.2 occupied | 1× PCIe 2.0 x1 |
+| hawk02 | 0 of 4 | 5 of 6 SATA; M.2 occupied | 1× PCIe 2.0 x1 |
+| hawk03 | 0 of 4 | 4 of 6 SATA; M.2 occupied | 1× PCIe 2.0 x1 |
+| lon01 | 0 of 2 | 0 (1 SATA + 1 M.2, both used) | M.2 WLAN slot only |
+
+## Worked examples
+
+### Can I add an NVMe drive to hawkstore?
+
+Yes. X10DRH-iT has no onboard M.2, so it goes in a PCIe slot, and three are free:
+**CPU1 SLOT1** (x8, short), **CPU1 SLOT2** (x8, full length) and **CPU1 SLOT3** (x8, short).
+All three hang off CPU1, which is populated, so they are electrically live.
+
+- A single-drive M.2→PCIe x4 adapter needs no bifurcation and works in any of the three.
+- A multi-drive carrier (2 or 4 M.2 on one card) needs either PCIe bifurcation in BIOS or an
+  onboard PLX switch. Bifurcation support on X10DRH-iT BIOS 3.4a is unconfirmed — buy a
+  switched card, or test bifurcation before committing.
+- Drives run at PCIe 3.0 x4 max (~3.5 GB/s), fine for any consumer NVMe.
+- Booting from it is a separate question: the boot pool is already a mirror of two SATA SSDs,
+  and NVMe boot support on this BIOS generation is patchy. Adding it as an L2ARC, `special`
+  vdev or SLOG for the `data` pool is the low-risk use — but a SLOG needs power-loss protection,
+  which consumer NVMe does not have.
+- NUMA note: the HBAs are all on CPU2, so an NVMe on CPU1 crosses QPI for pool traffic. Not
+  material at these speeds, but it is why SLOT4-7 would have been the tidier choice if free.
+
+Full detail: [hawkstore.md](hawkstore.md).
+
+### How would I swap the motherboards in the hawkfield cluster?
+
+All three hawk nodes are identical: ASUS PRIME B450M-A II, micro-ATX, socket AM4, running a
+Ryzen 5 5600GT with 4× DDR4 UDIMM slots full. A replacement board must therefore be:
+
+- **micro-ATX or smaller** to fit the existing (unidentified — check physically) desktop cases.
+- **Socket AM4** to keep the 5600GT, with a BIOS that supports Cezanne (Ryzen 5000G). Any
+  B550/X570 board ships new enough firmware; a second-hand B450 may need a BIOS update first.
+- **4× DDR4 DIMM slots** to carry over all 80 GiB, which is 2× 8 GiB + 2× 32 GiB of mismatched
+  Corsair kits currently clocked down to 2133 MT/s. A board swap is the natural moment to
+  replace those with a matched 2× 32 GiB kit and get the memory running at rated speed.
+- **1× PCIe x8-or-wider slot** for the Intel X520 10G NIC (currently in the x16 slot at Gen2 x8),
+  plus ideally a second slot for the GT 730 — though the 5600GT has working integrated graphics,
+  so the GT 730 can simply be dropped. Note the DMI slot labels on these boards are unreliable:
+  the GT 730 is actually negotiating x1 Gen1, so it is in a x1 slot, not the x16.
+- **1× M.2 PCIe 3.0 x4** for the boot NVMe, and **2+ SATA** ports for the ZFS `fast` mirror.
+
+Moving to B550 would upgrade the M.2 to Gen4 and the x16 slot to Gen4 — neither matters for a
+Gen3 boot drive and a Gen2 NIC. The real reasons to swap would be ECC support (the current
+boards run non-ECC, so a Ryzen PRO or Athlon PRO plus an ECC-capable board would be the play) or
+IPMI, which none of these consumer boards have.
+
+Procedure notes: Proxmox survives a board swap as long as the disks move with it, but the NIC
+names change (`enp1s0f0`, `enp8s0`) and `/etc/network/interfaces` pins those names to `vmbr0`
+and `vmbr1` — fix that before rebooting or the node comes up unreachable. Take one node at a
+time; the k8s control plane needs 2 of 3 up for etcd quorum. Physical access on these boxes is
+documented in [../server-refresh/physical-access.md](../server-refresh/physical-access.md).
+
+Full detail: [hawk01.md](hawk01.md), [hawk02.md](hawk02.md), [hawk03.md](hawk03.md).
+
+## Collection method
+
+The Proxmox hosts were captured over SSH as root with
+[`collect-hardware.sh`](collect-hardware.sh):
+
+```bash
+ssh root@10.1.2.11 'bash -s' < Documentation/hardware/collect-hardware.sh > hawk01.txt
+```
+
+hawkstore has no SSH access enabled, so it was captured through the TrueNAS API instead
+(`wss://10.1.2.10/api/current`, API key `Hawkstore API key` in Bitwarden):
+`system.info`, `disk.details`, `pool.query`, `interface.query`, `ipmi.lan.query` and
+`virt.device.pci_choices` for the PCI inventory. DIMM and PCIe slot detail is not exposed by any
+API method, so the raw SMBIOS tables were pulled with `core.download` on `filesystem.get`
+(`/sys/firmware/dmi/tables/DMI` and `smbios_entry_point`), reassembled into a dmidecode dump and
+decoded locally:
+
+```python
+ep = bytearray(open("smbios_entry_point", "rb").read()).ljust(0x1f, b"\0")
+tb = open("DMI", "rb").read()
+struct.pack_into("<I", ep, 0x18, 0x20)          # dmidecode reads the table from offset 0x20
+struct.pack_into("<H", ep, 0x16, len(tb))
+# recompute the _DMI_ and _SM_ checksums, then concatenate ep.ljust(32) + tb
+```
+
+```bash
+dmidecode --from-dump hawkstore-dmi.dump
+```
+
+Refresh these pages after any hardware change, and re-check the "Needs a physical check"
+sections when a case is open anyway.

--- a/Documentation/hardware/collect-hardware.sh
+++ b/Documentation/hardware/collect-hardware.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Hardware inventory dump for the spec sheets in this directory.
+# Run as root on a Proxmox host:  ssh root@10.1.2.11 'bash -s' < collect-hardware.sh > hawk01.txt
+# hawkstore has no shell access — see README.md for the TrueNAS API equivalent.
+
+set -u
+
+section() { echo; echo "##### $1"; }
+
+section HOSTNAME; hostname
+section OS; cat /etc/os-release | head -3
+section PVE; pveversion 2>/dev/null
+section SYSTEM; dmidecode -t system
+section BASEBOARD; dmidecode -t baseboard
+section CHASSIS; dmidecode -t chassis
+section BIOS; dmidecode -t bios
+section CPU; dmidecode -t processor
+section LSCPU; lscpu
+section MEMARRAY; dmidecode -t 16
+section DIMMS; dmidecode -t 17
+section SLOTS; dmidecode -t slot
+section PORTS; dmidecode -t 8
+section MEMINFO; free -h
+section BLOCK; lsblk -d -o NAME,SIZE,MODEL,SERIAL,ROTA,TRAN,REV
+section LSBLK_TREE; lsblk -o NAME,SIZE,FSTYPE,MOUNTPOINT,TYPE
+
+section SATA_PORTS
+for d in /sys/block/sd*; do
+    echo "$(basename "$d"): $(readlink -f "$d" | grep -o 'ata[0-9]*' | head -1) $(cat "$d/device/model" 2>/dev/null)"
+done
+
+section SMART
+for d in $(lsblk -dn -o NAME | grep -E '^(sd|nvme)'); do
+    echo "-- /dev/$d"
+    smartctl -i "/dev/$d" | grep -Ei 'model|serial|capacity|form factor|rotation|sata version|firmware'
+    smartctl -A "/dev/$d" | grep -Ei 'power_on_hours|percentage used|wear|total_lbas_written|data units written'
+done
+
+section LSPCI; lspci -nn
+section PCIE_LINKS
+for d in $(lspci -n | awk '{print $1}'); do
+    lspci -vv -s "$d" | grep -qE 'LnkSta:' || continue
+    echo "-- $d $(lspci -s "$d" | cut -d: -f3-)"
+    lspci -vv -s "$d" | grep -E 'LnkCap:|LnkSta:'
+done
+
+section NET; ip -br link
+for i in $(ls /sys/class/net | grep -Ev 'lo|tap|veth|fw|bonding_masters'); do
+    echo "-- $i"
+    ethtool "$i" 2>/dev/null | grep -Ei 'speed|duplex|supported link modes'
+    ethtool -i "$i" 2>/dev/null | grep -Ei 'driver|bus-info'
+done
+section INTERFACES; cat /etc/network/interfaces
+
+section ZPOOL; zpool list; zpool status
+section LVM; pvs; vgs; lvs
+section PVE_STORAGE_CFG; cat /etc/pve/storage.cfg
+section GUESTS; qm list; pct list
+section GUEST_CONF
+for c in /etc/pve/qemu-server/*.conf /etc/pve/lxc/*.conf; do
+    [ -f "$c" ] || continue
+    echo "-- $c"
+    grep -E '^(name|cores|memory|sockets|net[0-9]|scsi[0-9]|virtio[0-9]|rootfs|onboot|hostpci)' "$c"
+done
+
+section BOOTMODE; [ -d /sys/firmware/efi ] && echo UEFI || echo BIOS
+section SECUREBOOT; mokutil --sb-state 2>/dev/null || echo n/a
+section DRI; ls /dev/dri 2>/dev/null || echo none

--- a/Documentation/hardware/hawk01.md
+++ b/Documentation/hardware/hawk01.md
@@ -1,0 +1,119 @@
+# hawk01
+
+Proxmox hypervisor, Hawkfield. Hosts `k8s-hawk-1` and the `dns-hawk-1` resolver.
+Captured 2026-08-01.
+
+| | |
+|---|---|
+| Management IP | 10.1.2.11 (vmbr0, 1GbE) / 10.1.2.21 (vmbr1, 10G) |
+| Access | `ssh root@10.1.2.11`, password in Bitwarden `Proxmox - root` |
+| OS | Proxmox VE 8.4.19, kernel 6.8.12-32-pve |
+| Firmware | AMI BIOS 4631, 14 Jan 2025. UEFI boot, Secure Boot disabled |
+| Out-of-band | None — consumer board, no BMC/IPMI |
+
+## Chassis and board
+
+| | |
+|---|---|
+| Board | ASUS PRIME B450M-A II, rev X.0x, micro-ATX |
+| Board serial | 211092947903200 |
+| System/chassis | Generic desktop tower, SMBIOS strings unset ("System Product Name") |
+| Chipset | AMD B450 |
+
+The board reports no system or chassis identity, so case, PSU and cooler are unrecorded. See
+[Needs a physical check](#needs-a-physical-check).
+
+## CPU
+
+| | |
+|---|---|
+| Model | AMD Ryzen 5 5600GT with Radeon Graphics (Cezanne) |
+| Socket | AM4, populated 1 of 1 |
+| Cores / threads | 6 / 12 |
+| Clocks | 3.6 GHz base, 4.65 GHz max |
+| L3 cache | 16 MiB |
+| Virtualisation | AMD-V, single NUMA node |
+
+Upgrade path: any AM4 CPU the B450 board's BIOS supports, up to a Ryzen 9 5950X (16c/32t).
+Dropping the integrated graphics would make the GT 730 mandatory rather than optional.
+
+## Memory
+
+80 GiB DDR4, **non-ECC**, all 4 slots populated. Board maximum is 128 GiB.
+
+| Slot | Size | Part | Rated | Running at |
+|------|------|------|-------|------------|
+| DIMM_A1 | 8 GB | Corsair CMK16GX4M2Z3600C18 | 3600 | 2133 MT/s |
+| DIMM_A2 | 32 GB | Corsair CMK32GX4M1A2666C16 | 2666 | 2133 MT/s |
+| DIMM_B1 | 8 GB | Corsair CMK16GX4M2Z3600C18 | 3600 | 2133 MT/s |
+| DIMM_B2 | 32 GB | Corsair CMK32GX4M1A2666C16 | 2666 | 2133 MT/s |
+
+Two mismatched kits, so the whole set falls back to 2133 MT/s — roughly half the rated speed of
+the faster kit. Going to 128 GiB means replacing all four sticks with a matched 4× 32 GiB kit;
+going to a matched 2× 32 GiB kit would cost 16 GiB but run at full speed in dual channel.
+
+## Storage
+
+| Device | Model | Size | Attach | Use | Health |
+|--------|-------|------|--------|-----|--------|
+| nvme0n1 | GIGABYTE GP-GSM2NE3128GNTD | 128 GB | M.2, PCIe 3.0 x4 | Proxmox root + `local-lvm` thin pool | **55% life used**, 41.8 TB written |
+| sda | KINGSTON SA400S37120G | 120 GB | SATA port 1 | ZFS `fast` mirror | 29,579 power-on hours |
+| sdb | KINGSTON SA400S37120G | 120 GB | SATA port 2 | ZFS `fast` mirror | 29,521 power-on hours |
+
+- `fast` — ZFS mirror, 111 GB, 10% used, ONLINE, last scrub clean 12 Jul 2026. Shared storage
+  definition covers hawk01/02/03.
+- `local-lvm` — LVM-thin on the NVMe, 53.9 GB pool.
+
+**Free attach points:** 4 of 6 SATA connectors (`SATA6G_1`–`SATA6G_6` per firmware) and no free
+M.2 — the single M.2 socket is occupied. Adding bulk storage means SATA, or an NVMe on a x1
+adapter in the free PCIe slot (which would cap at ~500 MB/s).
+
+The boot NVMe at 55% endurance is the thing to watch on this node.
+
+## Expansion slots
+
+Firmware reports three slots. The labels are unreliable — the measured link widths below say
+what is really where.
+
+| Slot (DMI label) | Reported | Occupant | Measured link |
+|------------------|----------|----------|---------------|
+| PCIEX16 | x16, long | Intel 82599ES (X520) dual SFP+ 10G | Gen2 x8 |
+| PCIEX1_2 | x1, short | NVIDIA GK208B GeForce GT 730 (+ HDMI audio) | Gen1 x1 (downgraded) |
+| PCIEX1_1 | x1, short | **free** | — |
+
+The GT 730 negotiating x1 confirms it sits in a x1 slot, not the x16. One x1 slot is free; a x4
+or wider card has nowhere to go unless the GT 730 comes out and the 5600GT's integrated graphics
+takes over display duties.
+
+## Network
+
+| Interface | Hardware | Link | Bridge | Address |
+|-----------|----------|------|--------|---------|
+| enp8s0 | Realtek RTL8111/8168 onboard | 1GbE, up | vmbr0 | 10.1.2.11/24, gw 10.1.2.1 |
+| enp1s0f0 | Intel 82599ES port 0 | 10G SFP+ fibre, up | vmbr1 | 10.1.2.21/24 |
+| enp1s0f1 | Intel 82599ES port 1 | down, **unused** | — | — |
+
+Both bridges run MTU 9000. `/etc/network/interfaces` still carries stale stanzas for
+`enp9s0f0`/`enp9s0f1` from an earlier PCIe layout — interface names are pinned by name in that
+file, so any board or NIC change breaks networking on reboot unless the file is updated first.
+
+The second X520 port is free if a second 10G link or a LACP bond is ever wanted.
+
+## Guests
+
+| VMID | Name | Type | vCPU | RAM | Disks |
+|------|------|------|------|-----|-------|
+| 111 | k8s-hawk-1 | VM, running | 10 | 64 GiB | 50 GB `local-lvm` + 100 GB `fast` |
+| 131 | dns-hawk-1 | LXC, running | 2 | 2 GiB | 8 GB `local-lvm` |
+| 101 | ubuntu2404 | VM template, stopped | 2 | 4 GiB | 50 GB |
+
+64 GiB of the host's 80 GiB is committed to `k8s-hawk-1`, leaving little headroom — memory is
+the binding constraint on this node, not CPU.
+
+## Needs a physical check
+
+- PSU make, model and wattage; number of spare SATA power and PCIe power connectors.
+- Case model and how many 2.5"/3.5" drive bays are free.
+- CPU cooler and case fan count (board has CPU_FAN, CHA_FAN1, CHA_FAN2 headers).
+- Whether the free x1 slot is open-ended (it accepts a longer card only if it is).
+- TPM header is present and unpopulated.

--- a/Documentation/hardware/hawk02.md
+++ b/Documentation/hardware/hawk02.md
@@ -1,0 +1,106 @@
+# hawk02
+
+Proxmox hypervisor, Hawkfield. Hosts `k8s-hawk-2` and `claude-hawk-1` (Dave).
+Captured 2026-08-01.
+
+| | |
+|---|---|
+| Management IP | 10.1.2.12 (vmbr0, 1GbE) / 10.1.2.22 (vmbr1, 10G) |
+| Access | `ssh root@10.1.2.12`, password in Bitwarden `Proxmox - root` |
+| OS | Proxmox VE 8.4.19, kernel 6.8.12-32-pve |
+| Firmware | AMI BIOS 4631, 14 Jan 2025. UEFI boot, Secure Boot disabled |
+| Out-of-band | None — consumer board, no BMC/IPMI |
+
+## Chassis and board
+
+| | |
+|---|---|
+| Board | ASUS PRIME B450M-A II, rev X.0x, micro-ATX |
+| Board serial | 250250960901942 |
+| System/chassis | Generic desktop tower, SMBIOS strings unset ("System Product Name") |
+| Chipset | AMD B450 |
+
+## CPU
+
+| | |
+|---|---|
+| Model | AMD Ryzen 5 5600GT with Radeon Graphics (Cezanne) |
+| Socket | AM4, populated 1 of 1 |
+| Cores / threads | 6 / 12 |
+| Clocks | 3.6 GHz base, 4.65 GHz max |
+| L3 cache | 16 MiB |
+| Virtualisation | AMD-V, single NUMA node |
+
+Unlike hawk01 and hawk03, the integrated Radeon graphics is enabled here — the host exposes two
+render nodes (`/dev/dri/card1` and `card2`, the iGPU and the GT 730). That makes hawk02 the only
+node currently able to pass a GPU through for hardware transcoding without a BIOS change.
+
+## Memory
+
+80 GiB DDR4, **non-ECC**, all 4 slots populated. Board maximum is 128 GiB.
+
+| Slot | Size | Part | Rated | Running at |
+|------|------|------|-------|------------|
+| DIMM_A1 | 8 GB | Corsair CMK16GX4M2Z3600C18 | 3600 | 2133 MT/s |
+| DIMM_A2 | 32 GB | Corsair CMK32GX4M1A2666C16 | 2666 | 2133 MT/s |
+| DIMM_B1 | 8 GB | Corsair CMK16GX4M2Z3600C18 | 3600 | 2133 MT/s |
+| DIMM_B2 | 32 GB | Corsair CMK32GX4M1A2666C16 | 2666 | 2133 MT/s |
+
+Mismatched kits clock the whole set down to 2133 MT/s. At capture the host had 71 GiB of 77 GiB
+in use — this is the tightest node in the cluster for memory.
+
+## Storage
+
+| Device | Model | Size | Attach | Use | Health |
+|--------|-------|------|--------|-----|--------|
+| nvme0n1 | Crucial CT1000P510SSD8 | 1 TB | M.2, PCIe 3.0 x4 | Proxmox root + `local-lvm` (794 GB thin pool) | 2% life used, 20.8 TB written |
+| sda | Patriot Burst Elite 120GB | 120 GB | SATA port 1 | **unused** — stale ZFS label | 1,486 power-on hours |
+| sdb | SanDisk Ultra | 32 GB | USB | Proxmox installer stick left plugged in | — |
+
+Two things differ from the other nodes:
+
+- **The `fast` ZFS mirror does not exist here.** `sda` carries a label for pool `fast` as a
+  member of a two-disk mirror, but its partner is gone and `zpool import` finds nothing —
+  the SSD was replaced (1,486 hours on the current one) and the pool was never rebuilt.
+  `storage.cfg` still lists hawk02 as a `fast` node, and `k8s-hawk-2`'s 100 GB data disk sits on
+  `local-lvm` while hawk01/hawk03 put theirs on `fast`. Either rebuild the mirror with a second
+  SSD, or drop hawk02 from the `fast` node list.
+- The 1 TB Crucial P510 is a PCIe 5.0 drive running at Gen3 x4 — the board's ceiling. It is the
+  largest and healthiest boot drive in the cluster, and the obvious donor if hawk01's 55%-worn
+  NVMe needs replacing.
+
+**Free attach points:** 5 of 6 SATA connectors, no free M.2.
+
+## Expansion slots
+
+| Slot (DMI label) | Reported | Occupant | Measured link |
+|------------------|----------|----------|---------------|
+| PCIEX16 | x16, long | Intel 82599ES (X520) dual SFP+ 10G | Gen2 x8 |
+| PCIEX1_2 | x1, short | NVIDIA GK208B GeForce GT 730 (+ HDMI audio) | Gen1 x1 (downgraded) |
+| PCIEX1_1 | x1, short | **free** | — |
+
+## Network
+
+| Interface | Hardware | Link | Bridge | Address |
+|-----------|----------|------|--------|---------|
+| enp8s0 | Realtek RTL8111/8168 onboard | 1GbE, up | vmbr0 | 10.1.2.12/24 |
+| enp1s0f0 | Intel 82599ES port 0 | 10G SFP+ fibre, up | vmbr1 | 10.1.2.22/24 |
+| enp1s0f1 | Intel 82599ES port 1 | down, **unused** | — | — |
+
+Interface names are pinned by name in `/etc/network/interfaces`; update it before any board or
+NIC swap or the node comes back unreachable.
+
+## Guests
+
+| VMID | Name | Type | vCPU | RAM | Disks |
+|------|------|------|------|-----|-------|
+| 112 | k8s-hawk-2 | VM, running | 10 | 64 GiB | 50 GB + 100 GB, both `local-lvm` |
+| 122 | claude-hawk-1 | VM, running | 4 | 8 GiB | 50 GB + 100 GB `local-lvm` |
+| 102 | ubuntu2404 | VM template, stopped | 2 | 4 GiB | 50 GB |
+
+## Needs a physical check
+
+- PSU make, model and wattage; spare SATA power connectors.
+- Case model and free drive bays.
+- Whether the USB installer stick and USB keyboard should stay connected.
+- Whether the free x1 slot is open-ended.

--- a/Documentation/hardware/hawk03.md
+++ b/Documentation/hardware/hawk03.md
@@ -1,0 +1,90 @@
+# hawk03
+
+Proxmox hypervisor, Hawkfield. Hosts `k8s-hawk-3`. Captured 2026-08-01.
+
+| | |
+|---|---|
+| Management IP | 10.1.2.13 (vmbr0, 1GbE) / 10.1.2.23 (vmbr1, 10G) |
+| Access | `ssh root@10.1.2.13`, password in Bitwarden `Proxmox - root` |
+| OS | Proxmox VE 8.4.19, kernel 6.8.12-32-pve |
+| Firmware | AMI BIOS 4631, 14 Jan 2025. UEFI boot, Secure Boot disabled |
+| Out-of-band | None — consumer board, no BMC/IPMI |
+
+## Chassis and board
+
+| | |
+|---|---|
+| Board | ASUS PRIME B450M-A II, rev X.0x, micro-ATX |
+| Board serial | 211092947901897 |
+| System/chassis | Generic desktop tower, SMBIOS strings unset ("System Product Name") |
+| Chipset | AMD B450 |
+
+## CPU
+
+| | |
+|---|---|
+| Model | AMD Ryzen 5 5600GT with Radeon Graphics (Cezanne) |
+| Socket | AM4, populated 1 of 1 |
+| Cores / threads | 6 / 12 |
+| Clocks | 3.6 GHz base, 4.65 GHz max |
+| L3 cache | 16 MiB |
+| Virtualisation | AMD-V, single NUMA node |
+
+## Memory
+
+80 GiB DDR4, **non-ECC**, all 4 slots populated. Board maximum is 128 GiB.
+
+| Slot | Size | Part | Rated | Running at |
+|------|------|------|-------|------------|
+| DIMM_A1 | 8 GB | Corsair CMK16GX4M2Z3600C18 | 3600 | 2133 MT/s |
+| DIMM_A2 | 32 GB | Corsair CMK32GX4M1A2666C16 | 2666 | 2133 MT/s |
+| DIMM_B1 | 8 GB | Corsair CMK16GX4M2Z3600C18 | 3600 | 2133 MT/s |
+| DIMM_B2 | 32 GB | Corsair CMK32GX4M1A2666C16 | 2666 | 2133 MT/s |
+
+## Storage
+
+| Device | Model | Size | Attach | Use | Health |
+|--------|-------|------|--------|-----|--------|
+| nvme0n1 | GIGABYTE GP-GSM2NE3128GNTD | 128 GB | M.2, PCIe 3.0 x4 | Proxmox root + `local-lvm` thin pool | **47% life used**, 35.4 TB written |
+| sda | GIGABYTE GP-GSTFS31120GNTD | 120 GB | SATA port 1 | ZFS `fast` mirror | 34,024 power-on hours |
+| sdb | GIGABYTE GP-GSTFS31120GNTD | 120 GB | SATA port 2 | ZFS `fast` mirror | 34,016 power-on hours, link negotiated at 3 Gb/s |
+
+- `fast` — ZFS mirror, 111 GB, 15% used, ONLINE, last scrub clean 12 Jul 2026.
+- `sdb` has trained down to SATA 3 Gb/s rather than 6 Gb/s. Usually a cable or port issue and
+  worth reseating next time the case is open; the drive itself reports SATA 3.2 capable.
+- These two SSDs have ~34,000 hours (nearly 4 years) on them, the oldest drives in the cluster.
+
+**Free attach points:** 4 of 6 SATA connectors, no free M.2.
+
+## Expansion slots
+
+| Slot (DMI label) | Reported | Occupant | Measured link |
+|------------------|----------|----------|---------------|
+| PCIEX16 | x16, long | Intel 82599ES (X520) dual SFP+ 10G | Gen2 x8 |
+| PCIEX1_2 | x1, short | NVIDIA GK208B GeForce GT 730 (+ HDMI audio) | Gen1 x1 (downgraded) |
+| PCIEX1_1 | x1, short | **free** | — |
+
+## Network
+
+| Interface | Hardware | Link | Bridge | Address |
+|-----------|----------|------|--------|---------|
+| enp8s0 | Realtek RTL8111/8168 onboard | 1GbE, up | vmbr0 | 10.1.2.13/24 |
+| enp1s0f0 | Intel 82599ES port 0 | 10G SFP+ fibre, up | vmbr1 | 10.1.2.23/24 |
+| enp1s0f1 | Intel 82599ES port 1 | down, **unused** | — | — |
+
+`/etc/network/interfaces` also carries stale stanzas for `enp9s0f0`/`enp9s0f1` from an earlier
+PCIe layout. Names are pinned there, so update the file before any board or NIC swap.
+
+## Guests
+
+| VMID | Name | Type | vCPU | RAM | Disks |
+|------|------|------|------|-----|-------|
+| 113 | k8s-hawk-3 | VM, running | 10 | 64 GiB | 50 GB `local-lvm` + 100 GB `fast` |
+| 103 | ubuntu2404 | VM template, stopped | 2 | 4 GiB | 50 GB |
+
+## Needs a physical check
+
+- PSU make, model and wattage; spare SATA power connectors.
+- Case model and free drive bays.
+- The `sdb` SATA cable and port (link running at 3 Gb/s).
+- Whether the free x1 slot is open-ended.

--- a/Documentation/hardware/hawkstore.md
+++ b/Documentation/hardware/hawkstore.md
@@ -1,0 +1,144 @@
+# hawkstore
+
+TrueNAS storage server, Hawkfield. Backs the whole homelab over NFS — Prometheus TSDB, Grafana,
+Loki chunks, all media volumes. Captured 2026-08-01.
+
+| | |
+|---|---|
+| IP | 10.1.2.10 (bond0, 10G) |
+| BMC / IPMI | 10.1.2.9, static, MAC ac:1f:6b:4a:34:f6 |
+| Access | Web UI + API. The SSH service listens on 22, but no user has an authorised key and `password_login_groups` is empty, so there is no shell access today. API key in Bitwarden `Hawkstore API key` (Bearer, user `dave`) |
+| OS | TrueNAS 25.10.4 "Goldeye" Community Edition |
+| Firmware | AMI BIOS 3.4a, 16 Aug 2021 |
+
+## Chassis and board
+
+| | |
+|---|---|
+| System | Supermicro SSG-6048R-E1CR36L (4U storage server) |
+| System serial | S17496627B11491 |
+| Chassis serial | C8470FG34NA0299 |
+| Board | Supermicro X10DRH-iT rev 1.10 |
+| Board serial | NM178S018578 |
+| Chipset | Intel C612 |
+| BMC | ASPEED AST2400 (graphics at 06:00.0), IPMI on a dedicated port |
+
+The model designation is Supermicro's 36-bay platform (24 front + 12 rear 3.5" hot-swap bays).
+**TrueNAS reports no SES enclosure**, so drive-to-bay mapping is not available from software —
+the bays are almost certainly cabled straight to the HBAs rather than through an expander
+backplane. Label the bays physically before pulling anything.
+
+## CPU
+
+| Socket | Model | Cores / threads | Clocks |
+|--------|-------|-----------------|--------|
+| SOCKET 0 | Intel Xeon E5-2667 v4 | 8 / 16 | 3.2 GHz base, 3.6 GHz turbo |
+| SOCKET 1 | Intel Xeon E5-2667 v4 | 8 / 16 | 3.2 GHz base, 3.6 GHz turbo |
+
+16 cores / 32 threads total, LGA2011-3, both sockets populated. Load average at capture was 0.67
+— this box is nowhere near CPU-bound.
+
+## Memory
+
+128 GiB DDR4 ECC registered, **8 of 16 slots populated** (one DIMM per channel, 4 channels per
+CPU). Multi-bit ECC active.
+
+| Slots populated | Size each | Part | Speed |
+|-----------------|-----------|------|-------|
+| P1_DIMMA1, B1, C1, D1 (CPU1) | 16 GB | Micron 36ASF2G72PZ-2G3B1 | 2400 MT/s |
+| P2_DIMME1, F1, G1, H1 (CPU2) | 16 GB | Micron 36ASF2G72PZ-2G3B1 | 2400 MT/s |
+
+Free slots: **P1_DIMMA2/B2/C2/D2 and P2_DIMME2/F2/G2/H2** — 8 empty, 4 per CPU. Firmware reports
+512 GB maximum per CPU (1 TB total with LRDIMMs). The cheap upgrade is another 8× 16 GB RDIMM
+matching the existing Micron part, taking the box to 256 GiB and keeping one-DIMM-per-channel
+symmetry across both CPUs. ZFS will use every byte of it as ARC.
+
+## Storage
+
+20 drives, all SATA, on three LSI SAS3008 HBAs plus the onboard AHCI controllers.
+
+| Controller | SCSI host | Drives | Ports used |
+|------------|-----------|--------|------------|
+| LSI SAS3008 (CPU2 SLOT5/6/7) | host0 | sdd, sdf, sdg, sdh | 4 of 8 |
+| LSI SAS3008 | host13 | sdi, sdj, sdk, sdl | 4 of 8 |
+| LSI SAS3008 | host14 | sdm, sdn, sdo, sdp, sdq, sdr, sds, sdt | 8 of 8 |
+| Onboard C612 AHCI (sSATA + SATA) | host6–9 | sda, sdb, sdc, sde | 4 of ~10 |
+
+That leaves roughly 8 unused HBA ports and 6 unused onboard SATA ports — the enclosure has spare
+bays, and the controllers have spare ports to drive them. Confirm the breakout cabling
+physically before buying drives.
+
+### Drives
+
+| Device | Model | Size | Type | Pool | Temp |
+|--------|-------|------|------|------|------|
+| sda | Crucial CT500BX500SSD1 | 500 GB | SSD | userstore | 43 °C |
+| sdb | Crucial CT500BX500SSD1 | 500 GB | SSD | userstore | 38 °C |
+| sdc | Patriot P210 256GB | 256 GB | SSD | boot-pool | 39 °C |
+| sde | Patriot P210 256GB | 256 GB | SSD | boot-pool | 37 °C |
+| sdd, sdg, sdh, sdk, sdm, sdn | Seagate ST4000VN008 (IronWolf) | 4 TB | 5980 rpm | data | 36–40 °C |
+| sdf, sdo, sdp | Seagate ST4000DM004 (Barracuda) | 4 TB | 5400 rpm | data | 40–45 °C |
+| sdl | WD WD40EFRX (Red) | 4 TB | 5400 rpm | data | 41 °C |
+| sdi | WD WD30EZRX (Green) | 3 TB | 5400 rpm | backups | 40 °C |
+| sdj | TPH01203000GB | 3 TB | 7200 rpm | backups | 42 °C |
+| sdq, sdr | WD WD10EARX / WD10EADS | 1 TB | — | backups | 33–34 °C |
+| sds, sdt | WD WD20EARX | 2 TB | — | backups | 32–34 °C |
+
+### Pools
+
+| Pool | Layout | Raw size | Allocated | Notes |
+|------|--------|----------|-----------|-------|
+| `data` | 3× RAIDZ1 vdevs of 3 disks + 1 hot spare | 36.0 TB | 23.4 TB | The NFS workhorse — Prometheus, Grafana, Loki, media |
+| `backups` | 3× 2-way mirrors | 6.0 TB | 0.06 TB | Mixed 1/2/3 TB pairs |
+| `userstore` | 1× 2-way mirror (SSD) | 0.49 TB | 0.15 TB | |
+| `boot-pool` | 1× 2-way mirror (SSD) | 253 GB | — | TrueNAS system |
+
+All pools ONLINE. Note `data` is RAIDZ1 on 4 TB drives — a second failure during a resilver
+loses the vdev, and resilver windows on 4 TB spinning disks are long.
+
+## Expansion slots
+
+Seven PCIe 3.0 slots, four occupied. **Three are free, all on CPU1.**
+
+| Slot | Width / length | Occupant |
+|------|----------------|----------|
+| CPU1 SLOT1 | x8, short | **free** |
+| CPU1 SLOT2 | x8, full length | **free** |
+| CPU1 SLOT3 | x8, short | **free** |
+| CPU2 SLOT4 | x16, full length | NVIDIA GK104 GeForce GTX 660 Ti (+ HDMI audio) |
+| CPU2 SLOT5 | x8, short | LSI SAS3008 HBA |
+| CPU2 SLOT6 | x8, full length | LSI SAS3008 HBA |
+| CPU2 SLOT7 | x8, full length | LSI SAS3008 HBA |
+
+X10DRH-iT has **no onboard M.2**, so any NVMe goes in one of the free CPU1 slots on an adapter:
+
+- Single-drive M.2→PCIe x4 adapter: works in any of the three, no bifurcation needed, runs at
+  PCIe 3.0 x4 (~3.5 GB/s).
+- Multi-drive carrier: needs BIOS bifurcation (unconfirmed on this board at BIOS 3.4a) or an
+  onboard PLX switch. Buy a switched card, or test bifurcation first.
+- The GTX 660 Ti in SLOT4 is a Kepler card doing nothing that a NAS needs. Pulling it frees a
+  x16 slot, drops idle power and heat, and is the tidiest way to make room on the CPU2 side
+  where the HBAs live.
+- Booting from NVMe on this BIOS generation is unreliable; the boot pool is already a mirrored
+  SSD pair, so use new NVMe for ARC/`special`/SLOG duty instead. A SLOG in particular needs
+  power-loss protection — consumer NVMe does not have it, so use an enterprise drive
+  (Optane, or a PLP-equipped datacentre part) if that is the goal.
+
+## Network
+
+| Interface | Hardware | Link |
+|-----------|----------|------|
+| eno1 | Intel X540-AT2 port 0, onboard | 10GBase-T, up |
+| enp3s0f1 | Intel X540-AT2 port 1, onboard | 10GBase-T, up |
+| bond0 | LACP aggregate of both | up, 10.1.2.10/24, MTU 9000 |
+
+Both onboard 10G ports are in an LACP LAG with jumbo frames. There is no spare onboard NIC port
+— extra links would need a card in one of the free CPU1 slots.
+
+## Needs a physical check
+
+- PSU configuration: the chassis is a redundant-PSU platform but SMBIOS reports one power cord.
+- Which bays are populated and which are empty, and the breakout cabling from each HBA.
+- Whether the rear 12-bay cage is fitted and cabled.
+- Whether the GTX 660 Ti can be removed (nothing in software depends on it).
+- BMC credentials — the IPMI LAN at 10.1.2.9 is configured but no login is recorded in Bitwarden.

--- a/Documentation/hardware/lon01.md
+++ b/Documentation/hardware/lon01.md
@@ -1,0 +1,107 @@
+# lon01
+
+Proxmox hypervisor, London. Hosts `k8s-lon-1` and the `dns-lon-1` resolver.
+Captured 2026-08-01.
+
+| | |
+|---|---|
+| Management IP | 10.2.2.11 (vmbr0, 1GbE) |
+| Access | `ssh root@10.2.2.11`, password in Bitwarden `Proxmox - root` |
+| OS | Proxmox VE 9.2.6, kernel 7.0.2-2-pve |
+| Firmware | HP BIOS Q26 Ver. 02.16.00, 15 Apr 2021. UEFI boot, Secure Boot disabled |
+| Out-of-band | None enabled (see [Expansion](#expansion-slots)) |
+
+This node runs a **different Proxmox major version** from the Hawkfield nodes (9.2.6 vs 8.4.19)
+on a much newer kernel. Worth reconciling before any cross-site clustering work.
+
+## Chassis and board
+
+| | |
+|---|---|
+| System | HP EliteDesk 705 G4 DM 65W (TAA) — 1L "mini desktop" |
+| System serial | MXL9332F80 |
+| Board | HP 83E9, KBC version 07.D1.00 |
+| Board serial | PHEMT0D8JCB2ML |
+| Chipset | AMD 300 series (Promontory) |
+
+A 1L mini chassis with an external 65W power brick. Everything about expansion on this box is
+constrained by that form factor, not by the board.
+
+## CPU
+
+| | |
+|---|---|
+| Model | AMD Ryzen 5 PRO 2400G with Radeon Vega Graphics (Raven Ridge) |
+| Socket | AM4, populated 1 of 1 |
+| Cores / threads | 4 / 8 |
+| Clocks | 3.6 GHz base, 3.9 GHz max |
+| Virtualisation | AMD-V |
+
+Socketed AM4, so a CPU upgrade is physically possible, but HP's BIOS whitelist and the 65W brick
+plus 1L cooling put a hard ceiling on what is sensible. A Ryzen 5 PRO 3400G is the usual
+drop-in.
+
+## Memory
+
+16 GiB DDR4 SODIMM, **non-ECC**, both slots populated. Board maximum is 32 GiB.
+
+| Slot | Size | Part | Speed |
+|------|------|------|-------|
+| DIMM1 | 8 GB | Hynix HMA81GS6JJR8N-VK | 2667 MT/s |
+| DIMM3 | 8 GB | Hynix HMA81GS6JJR8N-VK | 2667 MT/s |
+
+A matched pair running at rated speed. Doubling to 32 GiB means replacing both with 2× 16 GiB
+SODIMMs — the cheapest meaningful upgrade available to this node, which was at 5.7 GiB used of
+14 GiB at capture.
+
+## Storage
+
+| Device | Model | Size | Attach | Use | Health |
+|--------|-------|------|--------|-----|--------|
+| nvme0n1 | Samsung MZVLB256HAHQ-000H7 (PM981) | 256 GB | M.2 SSD slot, PCIe 3.0 x4 | Proxmox root + `local-lvm` | OEM drive |
+| sda | P3-1TB | 1 TB | SATA port 1, 2.5" bay | secondary | 6,678 power-on hours, negotiated 3 Gb/s |
+
+Both attach points are used: one M.2 SSD socket and one 2.5" SATA bay is all the chassis has.
+`sda` trains at SATA 3 Gb/s — normal for this chassis' SATA flex cable, not necessarily a fault.
+Adding capacity here means replacing a drive, not adding one.
+
+`zpool list` reports no ZFS pools; storage is `local` plus LVM-thin `local-lvm`.
+
+## Expansion slots
+
+| Slot (DMI label) | Reported | Occupant |
+|------------------|----------|----------|
+| Slot3 / M2 SSD | PCIe 3.0 x4 | Samsung PM981 NVMe |
+| Slot2 / M2 WLAN/BT | PCIe 3.0 x1 | **free** |
+| Slot1 / DGPU PCIEXP | PCIe 3.0 x8 | **reported free** |
+
+The x8 "DGPU" slot is a firmware artifact of the shared 705 G4 board design — the DM (mini)
+chassis has no riser or space for a card, so treat it as unusable without confirming physically.
+The free M.2 WLAN slot is real and takes an A/E-key card (WiFi, or a Coral TPU-style accelerator).
+
+The board also exposes a Realtek RTL8111xP with an IPMI-interface function and two UARTs, which
+is HP's optional management path; nothing is configured on it today.
+
+## Network
+
+| Interface | Hardware | Link | Bridge | Address |
+|-----------|----------|------|--------|---------|
+| eno1 | Realtek RTL8111/8168 onboard | 1GbE, up | vmbr0 | 10.2.2.11/24, gw 10.2.2.1 |
+
+Single 1GbE port, standard MTU. No 10G at this site.
+
+## Guests
+
+| VMID | Name | Type | vCPU | RAM | Disks |
+|------|------|------|------|-----|-------|
+| 111 | k8s-lon-1 | VM, running | 4 | 8 GiB | 50 GB + 100 GB `local-lvm` |
+| 131 | dns-lon-1 | LXC, running | 2 | 2 GiB | 8 GB `local-lvm` |
+| 101 | ubuntu2404 | VM template, stopped | 2 | 4 GiB | 50 GB |
+
+The two running guests commit 10 GiB of the host's 14 GiB usable.
+
+## Needs a physical check
+
+- Confirm the 65W external power brick is the original and rated for any CPU change.
+- Confirm there is genuinely no PCIe riser fitted (firmware claims a x8 slot).
+- Dust/thermals: 1L chassis with a 65W APU, no fan telemetry exposed to the OS.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Everything is deployed as code: Packer builds VM templates, Terraform provisions
 | **Applications** | Homepage, Factorio, Satisfactory | Homepage |
 | **Other VMs** | claude-hawk-1 (Claude Code) | — |
 
+Per-machine hardware spec sheets — board, CPU, memory, drives, free slots and upgrade paths — are in [Documentation/hardware](Documentation/hardware/README.md).
+
 ## Workflow Status
 
 ### Infrastructure


### PR DESCRIPTION
Per-machine pages for hawkstore, hawk01/02/03 and lon01 covering board, CPU, DIMM population, drives and controller ports, PCIe slot occupancy with measured link widths, network and guests — enough to answer "will this upgrade fit" without opening a case.

Captured live: SSH + dmidecode on the Proxmox hosts, and the TrueNAS API on hawkstore, where the SMBIOS tables were pulled out of sysfs and decoded locally because no API method exposes DIMM or slot detail.

Includes the collection script so the pages can be refreshed.