### PR TITLE
uptime-kuma: loosen probes and stop RollingUpdate double-writing

### DIFF
--- a/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
+++ b/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
@@ -46,3 +46,17 @@ spec:
         value: "3019"
       - name: PGID
         value: "3021"
+    # SQLite fsync on that NFS mount runs 58-105ms against 7ms on local disk, so
+    # a single WAL insert takes ~558ms. The chart's 1s/2s probe timeouts expire
+    # whenever the stat_hourly aggregation holds the Knex pool, and the restart
+    # re-runs the aggregation: 228 restarts in 5 days.
+    readinessProbe:
+      timeoutSeconds: 5
+      failureThreshold: 6
+    livenessProbe:
+      timeoutSeconds: 10
+      failureThreshold: 6
+    # RollingUpdate surges a second pod (25% of 1 rounds up), which would put
+    # two writers on the one SQLite file.
+    strategy:
+      type: Recreate


### PR DESCRIPTION
uptime-kuma has been crash-looping since ~28 Jul — 228 restarts on a single 5-day-old pod, 21 of them since this morning. Investigated today off the back of an error-log uptick starting ~10:01 BST.

## Cause

`/app/data` moved to hawkstore NFS in 3208502. Measured from inside the running pod:

| | NFS (`/app/data`) | local (`/tmp`) |
|---|---|---|
| 64x4k `conv=fsync` | 58–105 ms | 7 ms |
| single SQLite WAL insert | **558 ms** | — |

At ~0.5s per transaction the Knex pool saturates while the `stat_daily` / `stat_hourly` aggregation runs. Today that produced 19 `Timeout acquiring a connection` and 4 `SQLITE_BUSY: database is locked`. HTTP handlers stall, so the chart defaults — readiness `timeoutSeconds: 1`, liveness `extra/healthcheck` `timeoutSeconds: 2` — both expire, kubelet kills the container, and the restart re-runs the same aggregation.

**The database is not corrupt.** `PRAGMA quick_check` returns `ok`; 50 MB, ~10.7k heartbeats. Two `SQLITE_CORRUPT` entries exist from 28 Jul (the migration + chart v4 window) and none since.

## Changes

- readiness `timeoutSeconds` 1 → 5, liveness 2 → 10, both `failureThreshold` 3 → 6. Enough headroom for an NFS fsync stall without blinding us to a genuinely hung process.
- `strategy.type: Recreate`. Latent bug, not todays failure: `maxSurge: 25%` of 1 replica rounds **up**, so a rollout briefly runs two writers against one SQLite file on an RWX mount. Same reasoning as 495f374 for factorio.

## Validation

`yamllint` clean, and the full kubeconform sweep passes locally (37/37 overlays valid).

## Follow-up, not in this PR

This makes the symptom survivable; it does not make SQLite-on-NFS a good idea. The real fix is getting `kuma.db` onto local storage (hostPath on a pinned node) or onto uptime-kuma 2.x's supported MariaDB/Postgres backend. Worth a separate issue.

⚠️ On apply, the live Deployment still carries an API-server-defaulted `rollingUpdate` block that helm's 3-way merge will not remove, so the upgrade may reject `rollingUpdate` alongside `type: Recreate`. If it does, `kubectl -n uptime-kuma patch deploy uptime-kuma-uptime-kuma --type=merge -p '{"spec":{"strategy":{"rollingUpdate":null}}}'` clears it and Flux reconciles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)