### PR TITLE
uptime-kuma: move the database to MariaDB on hawkstore

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -9,6 +9,7 @@ rules:
       - 'Ansible/roles/users/defaults/main.yml'
       - 'kubernetes/flux/infrastructure/base/media/controller/secret.yml'
       - 'kubernetes/flux/infrastructure/hawkfield/monitoring/loki-rustfs-creds.sops.yaml'
+      - 'kubernetes/flux/infrastructure/hawkfield/uptime-kuma/mariadb-credentials.sops.yaml'
       # Long ${{ secrets.* }} expressions and release URLs. Pre-existing; the
       # linter only sees these files when something in them changes.
       - 'Ansible/kubernetes.yml'

--- a/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
+++ b/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
@@ -19,9 +19,24 @@ spec:
   # Values are inline rather than valuesFrom: helm-controller does not watch the
   # referenced ConfigMap, so an edit there needs a manual --force reconcile.
   values:
-    # /app/data is the SQLite database. Mounted from hawkstore NFS rather than a
-    # PVC — a Longhorn journal abort silently wedged two volumes with EIO for 18
-    # days on 2026-07-08.
+    # The monitoring data lives in MariaDB on hawkstore (the TrueNAS `mariadb`
+    # app, on local ZFS). SQLite on the NFS mount below could not keep up: fsync
+    # there costs 58-105ms against 7ms locally, so a WAL insert took ~558ms and
+    # the pod restarted 228 times in 5 days. Env wins over db-config.json and
+    # rewrites it, so this switch needs no manual file surgery.
+    externalDatabase:
+      enabled: true
+      type: mariadb
+      hostname: 10.1.2.10
+      port: 3306
+      database: uptime_kuma
+      existingSecret: uptime-kuma-mariadb-credentials
+      existingSecretUsernameKey: username
+      existingSecretPasswordKey: password
+    # /app/data still holds db-config.json, uploads, screenshots and docker-tls
+    # — all low-traffic. Mounted from hawkstore NFS rather than a PVC because a
+    # Longhorn journal abort silently wedged two volumes with EIO for 18 days on
+    # 2026-07-08.
     volume:
       enabled: false
     additionalVolumes:
@@ -46,17 +61,16 @@ spec:
         value: "3019"
       - name: PGID
         value: "3021"
-    # SQLite fsync on that NFS mount runs 58-105ms against 7ms on local disk, so
-    # a single WAL insert takes ~558ms. The chart's 1s/2s probe timeouts expire
-    # whenever the stat_hourly aggregation holds the Knex pool, and the restart
-    # re-runs the aggregation: 228 restarts in 5 days.
+    # Kept from the SQLite-on-NFS era. MariaDB removes the stall that used to
+    # trip these, but the chart's 1s/2s defaults leave no room for a slow query
+    # either, and a killed pod is a worse outcome than a slow one.
     readinessProbe:
       timeoutSeconds: 5
       failureThreshold: 6
     livenessProbe:
       timeoutSeconds: 10
       failureThreshold: 6
-    # RollingUpdate surges a second pod (25% of 1 rounds up), which would put
-    # two writers on the one SQLite file.
+    # RollingUpdate surges a second pod (25% of 1 rounds up). Harmless against
+    # MariaDB, but /app/data is still a shared RWX mount.
     strategy:
       type: Recreate

--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/kustomization.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/kustomization.yml
@@ -4,3 +4,4 @@ metadata:
   name: uptime-kuma
 resources:
   - ../../base/uptime-kuma
+  - mariadb-credentials.sops.yaml

--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/mariadb-credentials.sops.yaml
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/mariadb-credentials.sops.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: uptime-kuma-mariadb-credentials
+    namespace: uptime-kuma
+type: Opaque
+stringData:
+    username: ENC[AES256_GCM,data:h4+tugCirFpNZRU=,iv:vZtkGPowiFtE58pWs/Yp/HMvBJvB+86ulI60TTpd6Nk=,tag:PTIkkmKXViAUfMGZwJfnxQ==,type:str]
+    password: ENC[AES256_GCM,data:RNLZkH93aR3QcSrMqWlOW3+TsQieIC9+YujDlY7WfUo=,iv:ZZwBBYBY5yJpzw5D0U9vsuZGROwf7wT5EDPE73rwnws=,tag:bFgWv1gVnMx3y9a+y5I5hw==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-02T15:11:23Z"
+    mac: ENC[AES256_GCM,data:dNRbZo/FEGsl+Mn/5PtPVb5j4QQSLVLQGnEKpkhVEpuoWVa6OujJkFPtKfzrGVytPOCI+MK/lbTSVM8/9Gi2go4uTtWrkL7orKaMtado66cAi3zfuM44OY6pGOUCOfXszQTv74cxTqmgqSc5pLyLUSsP79NRGzS/5FQgC3FmM1M=,iv:FxP7dyaevSleJX6BVqEJF4KNHCSakCSofCmM812qxqw=,tag:hHQn4298uqlCs2zdX7AMZg==,type:str]
+    pgp:
+        - created_at: "2026-08-02T15:11:23Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA+iIV7UXPYO1AQ/9FfYIxSTExBwQGpdleyylw5jn7+R6v4YRCoWIl49qs16p
+            TG7LqKpUARe17tdXwa6a3Z3PVn5spjMyetZ40M+KsGLaVQQWglRCOh0uMCnwDUNi
+            VkIv3gTq/7CV8RJi/du/dikI77Lvx7SUhEQ6XsM87i8aH11VWFjPmG85SCi5iLie
+            7MWpt9ZA4brMMp2xaGPtqxhgfc8Wm+kz3L7uTXQOlqdbMK65CQOIVlLPcQEG5DBQ
+            /Fuj6FewUWivXamGsSuW8MP99H0nrE3ouRcwZtAnDwbmM0Wvv3AtwmwLChnaTBz+
+            wvBmxWEaN6IdyVZbywn/QnvCC2Gw6wCojDvtTz1p6ExUmSnf0aHbkiaX0qhnevN4
+            Oh8zjqAYxgFOlYJlTJoZ0t7FCqQKavQh0SpRGNkdmaFskcC6PioBAKvmxH8jiqbf
+            EGf1Fpk4MJNY1YLVNPWKZsSgkJ7GlHVYhDH/bDuFm5K6dMqiY8mFzEbfdScNBc8o
+            QoaQB2LLvqJSKebnnI7e/2Hy9UZsBRW37hIlR7eGihUrteI0lP/YFBvUJOlm0xol
+            ubSLCHuNeOmn3ioDMwBsWmBISJ/OBi+KEzG70N3VL6TuSl/zRjle80wfdfiXdW+G
+            z2VjKpOb1rxJ40jqvfZwom3gGdxXmOrFD8UBBq1J32E0nf6Wd99xEgKGOD0Ot4rS
+            XAHqIWIT8J2r0ZR3cze+inaVWjFOCuNklXOHE5mOwVEmWsiJjGQLoPJtUlMfvrG9
+            uHjvwpXIQYKhrfTDGLKpc+QHwb0eyEu3/UzwpDJo+aZIxImpmMbfS+Dypg2e
+            =85Ia
+            -----END PGP MESSAGE-----
+          fp: 76AF39813C2297E8F98C542D42436A07A9BA1DE0
+    version: 3.13.1


### PR DESCRIPTION
Stacked on #403 — merge that first and GitHub will retarget this to `master`.

#403 stops uptime-kuma being killed for being slow. This removes the slowness.

## What changed outside the repo

MariaDB 11.8.8 is already installed and running on hawkstore as the TrueNAS community `mariadb` app (1.1.9), the same train as the `mongodb` app that was already there:

- data on `/mnt/.ix-apps/app_mounts/mariadb/data` — **local ZFS, not NFS**
- publishes 3306 on the LAN, same shape as mongodb on 27017
- database `uptime_kuma`, user `uptime_kuma@%`, utf8mb4 / utf8mb4_uca1400_ai_ci
- verified reachable from inside the cluster: `select version()` returns `11.8.8-MariaDB-ubu2404` as `uptime_kuma@%`
- credentials in Bitwarden as `Uptime Kuma MariaDB` (item also holds the root password)

The point is that the database engine now owns its own local disk and uptime-kuma talks to it over a socket, rather than a process in the cluster holding a database *file* open across NFS.

## Repo changes

- `externalDatabase` enabled against `10.1.2.10:3306`, password out of a new SOPS secret
- `mariadb-credentials.sops.yaml` in the hawkfield overlay, encrypted to the existing flux PGP key
- the `/app/data` NFS mount stays — `db-config.json`, uploads, screenshots and `docker-tls` still live there, all low-traffic
- probe comment updated: the values from #403 are kept, but the reasoning is now defensive rather than a workaround
- new SOPS file added to the `.yamllint` line-length ignore list, matching `loki-rustfs-creds.sops.yaml`

## Why MariaDB and not Postgres

`server/database.js` in 2.3.0 accepts `sqlite`, `mariadb` and `embedded-mariadb`, and throws `Unknown Database type` on anything else. Postgres is not an option. `embedded-mariadb` would put the data back on `/app/data`, which is the problem we are leaving.

## Data

There is no SQLite→MariaDB import in the image (`/app/extra` and `/app/db` have nothing, and nothing in `server/` references one). **This starts from an empty schema.** Agreed tradeoff: rebuild the 5 monitors, 1 notification and 1 status page by hand, and leave 10,920 heartbeats going back to 14 June behind. The old `kuma.db` stays on the NFS mount as an archive rather than being deleted.

## Apply notes

`setup-database.js` gives env precedence over `db-config.json` and **rewrites the file** with the new config, so the existing `{"type":"sqlite"}` needs no manual surgery. It also means this is one-way: pulling the env vars back out later leaves `db-config.json` pointing at MariaDB.

Expect the setup wizard on first load — it will want a fresh admin account.

Also carried over from #403: the live Deployment still has an API-server-defaulted `rollingUpdate` block that helm's 3-way merge will not remove, so if the upgrade rejects it alongside `type: Recreate`, clear it with `kubectl -n uptime-kuma patch deploy uptime-kuma-uptime-kuma --type=merge -p '{"spec":{"strategy":{"rollingUpdate":null}}}'`.

## Validation

yamllint exit 0, kubeconform sweep 37/37 overlays valid, and the rendered overlay carries the expected `externalDatabase` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)