### PR TITLE
uptime-kuma: manage monitors and the admin user in code

### DIFF
--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -8,6 +8,8 @@ on:
   pull_request:
     paths:
       - "terraform/**"
+      # Has its own workflow; this one would plan three Proxmox sites for nothing.
+      - "!terraform/uptime-kuma/**"
       - ".github/workflows/terraform-plan.yaml"
 
 concurrency:

--- a/.github/workflows/terraform-uptime-kuma.yaml
+++ b/.github/workflows/terraform-uptime-kuma.yaml
@@ -63,16 +63,27 @@ jobs:
             ${{ secrets.UPTIME_KUMA_TELEGRAM_BOT_TOKEN }}
           TF_VAR_telegram_chat_id:
             ${{ secrets.UPTIME_KUMA_TELEGRAM_CHAT_ID }}
-        run: terraform plan -no-color -out=tfplan | tee plan_output.txt
+        # continue-on-error so a failed plan still gets posted to the PR; the
+        # gate below turns it back into a job failure. pipefail because the
+        # exit code of a pipeline is tee's, which would hide the failure.
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          terraform plan -no-color -out=tfplan | tee plan_output.txt
 
       - name: Post plan to the PR
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
             const path = 'terraform/uptime-kuma/plan_output.txt';
-            const plan = fs.readFileSync(path, 'utf8');
+            let plan = 'plan output not available';
+            try {
+              plan = fs.readFileSync(path, 'utf8');
+            } catch (e) {
+              // plan may have failed before writing anything
+            }
             const body = '### Terraform plan — uptime-kuma\n\n'
               + '<details><summary>Show plan</summary>\n\n'
               + '```terraform\n' + plan.slice(-60000) + '\n```\n\n'
@@ -83,6 +94,12 @@ jobs:
               repo: context.repo.repo,
               body,
             });
+
+      - name: Fail if the plan failed
+        if: steps.plan.outcome == 'failure'
+        run: |
+          echo "::error::terraform plan failed — see the step above"
+          exit 1
 
       - name: Terraform Apply
         if: github.event_name != 'pull_request'

--- a/.github/workflows/terraform-uptime-kuma.yaml
+++ b/.github/workflows/terraform-uptime-kuma.yaml
@@ -1,0 +1,95 @@
+name: Terraform Uptime Kuma
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    paths:
+      - 'terraform/uptime-kuma/**'
+      - '.github/workflows/terraform-uptime-kuma.yaml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'terraform/uptime-kuma/**'
+      - '.github/workflows/terraform-uptime-kuma.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: terraform-uptime-kuma
+  cancel-in-progress: false
+
+jobs:
+  terraform:
+    # Separate from terraform.yaml because that workflow passes
+    # -var="pm_api_token_secret" to every stack in its matrix, and Terraform
+    # errors on a -var it has no declaration for.
+    name: Plan and apply
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform/uptime-kuma
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Terraform
+        uses: ./.github/actions/terraform-setup
+        with:
+          ts-oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          ts-oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+
+      # status.clincha.co.uk resolves only against AdGuard on the LAN. Tailscale
+      # gives the runner a route to the ingress VIP but not that name, and the
+      # ingress needs the Host header to pick the right backend.
+      - name: Resolve the LAN-only hostname
+        run: echo "10.1.2.205 status.clincha.co.uk" | sudo tee -a /etc/hosts
+
+      - name: Terraform Init
+        run: |
+          terraform init \
+            -backend-config="secret_key=${{ secrets.RUSTFS_SECRET_KEY }}"
+
+      - name: Terraform Format
+        run: terraform fmt -check -diff
+
+      - name: Terraform Plan
+        id: plan
+        env:
+          TF_VAR_password: ${{ secrets.UPTIME_KUMA_ADMIN_PASSWORD }}
+          TF_VAR_telegram_bot_token:
+            ${{ secrets.UPTIME_KUMA_TELEGRAM_BOT_TOKEN }}
+          TF_VAR_telegram_chat_id:
+            ${{ secrets.UPTIME_KUMA_TELEGRAM_CHAT_ID }}
+        run: terraform plan -no-color -out=tfplan | tee plan_output.txt
+
+      - name: Post plan to the PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'terraform/uptime-kuma/plan_output.txt';
+            const plan = fs.readFileSync(path, 'utf8');
+            const body = '### Terraform plan — uptime-kuma\n\n'
+              + '<details><summary>Show plan</summary>\n\n'
+              + '```terraform\n' + plan.slice(-60000) + '\n```\n\n'
+              + '</details>';
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
+
+      - name: Terraform Apply
+        if: github.event_name != 'pull_request'
+        env:
+          TF_VAR_password: ${{ secrets.UPTIME_KUMA_ADMIN_PASSWORD }}
+          TF_VAR_telegram_bot_token:
+            ${{ secrets.UPTIME_KUMA_TELEGRAM_BOT_TOKEN }}
+          TF_VAR_telegram_chat_id:
+            ${{ secrets.UPTIME_KUMA_TELEGRAM_CHAT_ID }}
+        run: terraform apply -auto-approve tfplan

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -8,6 +8,8 @@ on:
     paths:
       - '.github/workflows/terraform.yaml'
       - 'terraform/**'
+      # Has its own workflow; this one would apply three Proxmox sites for nothing.
+      - '!terraform/uptime-kuma/**'
   workflow_dispatch:
 jobs:
   plan:

--- a/.yamllint
+++ b/.yamllint
@@ -10,6 +10,7 @@ rules:
       - 'kubernetes/flux/infrastructure/base/media/controller/secret.yml'
       - 'kubernetes/flux/infrastructure/hawkfield/monitoring/loki-rustfs-creds.sops.yaml'
       - 'kubernetes/flux/infrastructure/hawkfield/uptime-kuma/mariadb-credentials.sops.yaml'
+      - 'kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-credentials.sops.yaml'
       # Long ${{ secrets.* }} expressions and release URLs. Pre-existing; the
       # linter only sees these files when something in them changes.
       - 'Ansible/kubernetes.yml'

--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap-job.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap-job.yml
@@ -1,0 +1,47 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uptime-kuma-admin-bootstrap
+  namespace: uptime-kuma
+  annotations:
+    # A Job spec is immutable, and editing the script rewrites the generated
+    # ConfigMap name into it. Let Flux delete and recreate rather than fail the
+    # apply. Re-running is safe: the script is idempotent.
+    kustomize.toolkit.fluxcd.io/force: "enabled"
+spec:
+  # No ttlSecondsAfterFinished on purpose — the completed Job is the record
+  # that bootstrap ran, and letting it expire would just have Flux recreate it.
+  backoffLimit: 10
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        # The uptime-kuma image already carries socket.io-client, so the
+        # bootstrap always speaks the same protocol version as the server.
+        - name: bootstrap
+          image: louislam/uptime-kuma:2.3.0
+          workingDir: /app
+          command:
+            - node
+            - /script/admin-bootstrap.js
+          env:
+            - name: KUMA_URL
+              value: http://uptime-kuma-uptime-kuma:3001
+            - name: KUMA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: uptime-kuma-admin-credentials
+                  key: username
+            - name: KUMA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: uptime-kuma-admin-credentials
+                  key: password
+          volumeMounts:
+            - name: script
+              mountPath: /script
+      volumes:
+        - name: script
+          configMap:
+            name: uptime-kuma-admin-bootstrap

--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap-job.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap-job.yml
@@ -21,11 +21,15 @@ spec:
         # bootstrap always speaks the same protocol version as the server.
         - name: bootstrap
           image: louislam/uptime-kuma:2.3.0
-          workingDir: /app
           command:
             - node
             - /script/admin-bootstrap.js
           env:
+            # Node resolves modules against the script's own directory, so the
+            # ConfigMap mount cannot see /app/node_modules without this.
+            # workingDir has no effect on resolution.
+            - name: NODE_PATH
+              value: /app/node_modules
             - name: KUMA_URL
               value: http://uptime-kuma-uptime-kuma:3001
             - name: KUMA_USERNAME

--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap.js
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap.js
@@ -9,7 +9,13 @@ const done = (code, msg) => {
     process.exit(code);
 };
 
-const socket = io(url, { transports: [ "websocket" ], timeout: 10000 });
+// Leave transports at the default. Forcing ["websocket"] gets as far as an
+// accepted connection server-side but never completes the Socket.IO handshake,
+// so the client sits waiting for a "connect" that never arrives. The default
+// polling-then-upgrade path lands on websocket anyway.
+const socket = io(url, { timeout: 10000 });
+
+setTimeout(() => done(1, "timed out waiting for uptime-kuma"), 60000);
 
 socket.on("connect_error", (err) => done(1, `connect failed: ${err.message}`));
 

--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap.js
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap.js
@@ -1,0 +1,28 @@
+const { io } = require("socket.io-client");
+
+const url = process.env.KUMA_URL;
+const username = process.env.KUMA_USERNAME;
+const password = process.env.KUMA_PASSWORD;
+
+const done = (code, msg) => {
+    console.log(msg);
+    process.exit(code);
+};
+
+const socket = io(url, { transports: [ "websocket" ], timeout: 10000 });
+
+socket.on("connect_error", (err) => done(1, `connect failed: ${err.message}`));
+
+socket.on("connect", () => {
+    socket.emit("setup", username, password, (res) => {
+        if (res.ok) {
+            return done(0, `created admin user '${username}'`);
+        }
+        // Server-side guard: re-running against a populated user table is the
+        // expected steady state, not a failure.
+        if (/has been initialized/.test(res.msg || "")) {
+            return done(0, "admin user already exists, nothing to do");
+        }
+        done(1, `setup failed: ${res.msg}`);
+    });
+});

--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-credentials.sops.yaml
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-credentials.sops.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: uptime-kuma-admin-credentials
+    namespace: uptime-kuma
+type: Opaque
+stringData:
+    username: ENC[AES256_GCM,data:isdWzEs=,iv:Zb39bJ03OlusoomChFpsRzR8Ot6zztlXfOifP4TSh4o=,tag:r2Gz0MqFszLN0HhNku4wng==,type:str]
+    password: ENC[AES256_GCM,data:aJ5OFwq/jou2JyDby5zEozdofDJSmHfrDLS/gb2oPeQ=,iv:PZK5jy2BLB/as126sg9nz8y8kWfqn3WNRpri/XJwung=,tag:EIOio+CwSVa6rc0f++p+OA==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-02T16:11:16Z"
+    mac: ENC[AES256_GCM,data:c8dlSjLMqToJjnSEOcBXyDvRw0p4tZfAvohax/unDezTuaWCE+ByMY6TVe8N40OrzuS+55pEhTn2Zut3YBH9aCR696PYac98jdT8dh2pSQcm9g/uMnELru7Ub5EQgDVqihl0fkSW8gxg9UNgLpJNXela21E/oEmnuzpHfyWTu5I=,iv:2sWGYAHcHBN19Kg0aXQlnrPUwX1vmH6Z2UtvQgyBOC0=,tag:FCLRjnHCzMHlqhmdxkRX9g==,type:str]
+    pgp:
+        - created_at: "2026-08-02T16:11:16Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA+iIV7UXPYO1ARAAlD7HwqXcLiosINjE2EP/ktbWk9J3O8WgJ04uut3utkB0
+            MuJtv2Wunm4zpN6pEeh9PiK2P6qelP57KJ+tgCHusiK3g+EsJC9tdPmfDoHs/Ahl
+            M5O/1MiGchW15nrhYH1iMRsERTGcIBuVPNAXNZLt56fZdGphJ0JUd86qZW3cLSDv
+            cxs3vr7etTmceBtZVE2u0Ciu6x0asSm3KaDtBuxshsGYXRGP5tzjHwxfFnq6Aan/
+            Opo7S01GD/ghc9sKV16s24i8ACQ3KS+G7NS82nPEOcUufh9qTKL9brFXZJshDKRi
+            Ygivl0Bx/rdKpCF8S5BkHCfmQA9ltALDgMJ1TtZL3nErDlWALZhGhImsPE5Ehukr
+            oI5ohQQsGpSUf+Y/mxB27wHYVoO1ui85zSDNPHM3jYKUctlGvpz6wUgFV02ZOKeQ
+            2eqtXZqEgYrVHyx/nBErOJX722TSQ+tAWVZYps9loEeK2xLx+dQaiHyrTtQ8tYoP
+            Hucb8MY+7XkAp3j/AtdTNNPc5+ypVsMQ84ByQMyJMiApmv4qG1au4Hp+PR3No+m7
+            Vib2Tik2EuL7UOvL3gLi3FZzjV70Yq/M5hdL9CH6OEd/g9N9OkuHRn5RH7p0FrB1
+            7lWFmmMcfOYtrwawAPhrbdEfl/wS2FSzT7+4G+V6PoPD+NNrz10/MggiJHBe/VPS
+            XAHCtbnNDW7Ku/qvEUm/VKMJr5u0z3g5MqCoaxlS5jFz36YYFpAP7pE6wUVvx7Mm
+            +FtEZNDOWKJJ+MadgLvQNalVrpVoNjO/eWsIHXqOUzWZXBi782pmFoD1DPHj
+            =ERgF
+            -----END PGP MESSAGE-----
+          fp: 76AF39813C2297E8F98C542D42436A07A9BA1DE0
+    version: 3.13.1

--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/kustomization.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/kustomization.yml
@@ -5,3 +5,10 @@ metadata:
 resources:
   - ../../base/uptime-kuma
   - mariadb-credentials.sops.yaml
+  - admin-credentials.sops.yaml
+  - admin-bootstrap-job.yml
+configMapGenerator:
+  - name: uptime-kuma-admin-bootstrap
+    namespace: uptime-kuma
+    files:
+      - admin-bootstrap.js

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -9,3 +9,22 @@
 terraform init
 terraform apply --var-file=providers.tfvars
 ```
+## Uptime Kuma
+
+`terraform/uptime-kuma` manages the monitors, the Telegram notification and the
+status page. Adding a service is one entry in the `monitors` map in `main.tf`.
+
+It has its own workflow rather than joining the matrix in `terraform.yaml`:
+that workflow passes `-var="pm_api_token_secret"` to every stack, and Terraform
+errors on a `-var` it has no declaration for.
+
+The admin user it authenticates as is created by a Flux Job
+(`kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap-job.yml`),
+not by hand — Uptime Kuma has no env-based bootstrap, so the Job calls the
+Socket.IO `setup` event. Re-running is safe; the server rejects a second setup
+once a user exists.
+
+Credentials live in Bitwarden (`Uptime Kuma admin`,
+`Uptime Kuma Telegram notification`) and as repository secrets
+`UPTIME_KUMA_ADMIN_PASSWORD`, `UPTIME_KUMA_TELEGRAM_BOT_TOKEN` and
+`UPTIME_KUMA_TELEGRAM_CHAT_ID`.

--- a/terraform/uptime-kuma/main.tf
+++ b/terraform/uptime-kuma/main.tf
@@ -1,0 +1,49 @@
+resource "uptimekuma_notification_telegram" "alert" {
+  name       = "Uptime Kuma Alert"
+  bot_token  = var.telegram_bot_token
+  chat_id    = var.telegram_chat_id
+  is_active  = true
+  is_default = true
+}
+
+locals {
+  # Adding a service is one entry here. Everything else follows from it.
+  monitors = {
+    plex = {
+      # /identity answers without auth; the root path redirects to the web app.
+      url = "https://plex.clinch-home.com/identity"
+    }
+    sonarr          = { url = "https://sonarr.clinch-home.com" }
+    radarr          = { url = "https://radarr.clinch-home.com" }
+    sabnzbd         = { url = "https://sabnzbd.clinch-home.com" }
+    "clincha.co.uk" = { url = "https://clincha.co.uk" }
+  }
+}
+
+resource "uptimekuma_monitor_http" "service" {
+  for_each = local.monitors
+
+  name             = each.key
+  url              = each.value.url
+  interval         = 60
+  active           = true
+  notification_ids = [uptimekuma_notification_telegram.alert.id]
+}
+
+resource "uptimekuma_status_page" "all" {
+  slug      = "all"
+  title     = "all"
+  published = true
+
+  public_group_list = [
+    {
+      name   = "Services"
+      weight = 1
+      monitor_list = [
+        for key in sort(keys(local.monitors)) : {
+          id = uptimekuma_monitor_http.service[key].id
+        }
+      ]
+    }
+  ]
+}

--- a/terraform/uptime-kuma/providers.tf
+++ b/terraform/uptime-kuma/providers.tf
@@ -1,0 +1,32 @@
+terraform {
+  backend "s3" {
+    bucket = "terraform"
+    endpoints = {
+      s3 = "http://10.1.2.10:30293"
+    }
+    key        = "uptime-kuma.tfstate"
+    access_key = "terraform"
+
+    region                      = "main"
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    use_path_style              = true
+  }
+  required_providers {
+    uptimekuma = {
+      source  = "breml/uptimekuma"
+      version = "0.4.0"
+    }
+  }
+}
+
+# status.clincha.co.uk only resolves on the LAN, so CI adds a hosts entry
+# pointing at the ingress VIP before running. Hitting 10.1.2.205 directly would
+# miss the Host header the ingress routes on.
+provider "uptimekuma" {
+  endpoint = var.endpoint
+  username = var.username
+  password = var.password
+}

--- a/terraform/uptime-kuma/variables.tf
+++ b/terraform/uptime-kuma/variables.tf
@@ -1,0 +1,24 @@
+variable "endpoint" {
+  type    = string
+  default = "https://status.clincha.co.uk"
+}
+
+variable "username" {
+  type    = string
+  default = "admin"
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
+}
+
+variable "telegram_bot_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "telegram_chat_id" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
Closes the loop on the database rebuild: adding a service becomes a PR, not a click path.

## Monitors as code

`terraform/uptime-kuma` using [`breml/uptimekuma`](https://github.com/breml/terraform-provider-uptimekuma) v0.4.0. Adding a service is one entry:

```hcl
locals {
  monitors = {
    sonarr = { url = "https://sonarr.clinch-home.com" }
    ...
  }
}
```

…and the monitor, its Telegram wiring and its slot on the status page all follow. The 5 monitors, the `Uptime Kuma Alert` notification and the `all` status page are all reproduced from the archived SQLite.

**On the provider choice:** it is a community provider (60 stars, v0.4.0, released 25 July), so the same class of bet as `weinmann-emt/rustfs`. What sold it over the alternatives is that its client library's acceptance tests run against `louislam/uptime-kuma:2.4.0` — it targets 2.x, not stale 1.x — and it covers `monitor_*`, `notification_*`, `status_page`, `tag` and `settings` comprehensively. Worth knowing the schemas may churn before 1.0.

## Admin user as code

There is no env-based bootstrap. I checked every `UPTIME_KUMA_*` variable in the image; none seeds a user. The only path is the Socket.IO `setup` event, which the server guards itself:

```js
if ((await R.knex("user").count("id as count").first()).count !== 0) {
    throw new Error("Uptime Kuma has been initialized. ...");
}
```

So the Job is safely idempotent — it treats that error as success. It runs from `louislam/uptime-kuma:2.3.0` itself, which already ships `socket.io-client` 4.8.3, so the bootstrap can never drift from the server's protocol version.

`kustomize.toolkit.fluxcd.io/force: "enabled"` is on the Job because a Job spec is immutable and editing the script rewrites the hashed ConfigMap name into it — without it the apply would fail rather than re-run.

## CI

Its own workflow. `terraform.yaml` passes `-var="pm_api_token_secret=..."` to every stack in its matrix, and Terraform errors on a `-var` with no matching declaration, so this stack cannot join that matrix as-is. Both Proxmox workflows now exclude `terraform/uptime-kuma/**` so a monitor change stops planning three sites for nothing.

Reachability works like the other stacks: Tailscale via the existing `terraform-setup` action, state in RustFS. One addition — `status.clincha.co.uk` resolves only against AdGuard on the LAN, and hitting the ingress VIP directly would lose the Host header the ingress routes on, so the workflow adds a hosts entry for `10.1.2.205`.

New repository secrets, already set: `UPTIME_KUMA_ADMIN_PASSWORD`, `UPTIME_KUMA_TELEGRAM_BOT_TOKEN`, `UPTIME_KUMA_TELEGRAM_CHAT_ID`. Vault items: `Uptime Kuma admin`, `Uptime Kuma Telegram notification`.

## Bootstrap ordering, resolved

Originally this could not plan until the admin existed, which would have made the first apply fail on ordering alone. Rather than leave that, I ran the bootstrap script against the live instance so the plan in this PR is a real one. Doing that surfaced two genuine bugs in the Job, both now fixed:

- **`Cannot find module 'socket.io-client'`** — Node resolves requires against the *script's* directory, so a script mounted at `/script` cannot see `/app/node_modules`. `workingDir` has no effect on resolution; `NODE_PATH` does.
- **Hung forever on connect** — `transports: ["websocket"]` gets an accepted connection server-side (the server logs it, and logs "Redirect to setup page") but the Socket.IO handshake never completes and `connect` never fires. Default polling-then-upgrade works and lands on websocket anyway. A hard timeout is now in place so this fails the Job rather than hanging.

Verified both paths against the live instance: first run `{"ok":true,"msg":"successAdded"}`, second `admin user already exists, nothing to do`, exit 0. The Flux Job will therefore no-op on merge, which is the correct steady state.

**A third bug, in this workflow:** the first CI run reported green while the plan had actually failed, because the exit code of `terraform plan | tee` is tee'"'"'s. Fixed with `set -o pipefail` plus an explicit gate step, so a failed plan still reaches the PR comment but cannot reach apply.

## Validation

`terraform validate` and `terraform fmt -check` clean; kubeconform 37/37 overlays valid; yamllint exit 0. The rendered Job carries the hashed ConfigMap reference and the force annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
