### PR TITLE
uptime-kuma: run 2.4.0 so Terraform can create monitors

### DIFF
--- a/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
+++ b/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
@@ -19,6 +19,12 @@ spec:
   # Values are inline rather than valuesFrom: helm-controller does not watch the
   # referenced ConfigMap, so an edit there needs a manual --force reconcile.
   values:
+    # Ahead of the chart's appVersion (2.3.0) to match what
+    # breml/uptimekuma tests against. 2.3.0 has no `bearer_token` column on
+    # `monitor`, so every Terraform-created HTTP monitor fails on INSERT.
+    # Drop this once the chart ships an appVersion of 2.4.0 or later.
+    image:
+      tag: "2.4.0"
     # The monitoring data lives in MariaDB on hawkstore (the TrueNAS `mariadb`
     # app, on local ZFS). SQLite on the NFS mount below could not keep up: fsync
     # there costs 58-105ms against 7ms locally, so a WAL insert took ~558ms and

--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap-job.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap-job.yml
@@ -20,7 +20,7 @@ spec:
         # The uptime-kuma image already carries socket.io-client, so the
         # bootstrap always speaks the same protocol version as the server.
         - name: bootstrap
-          image: louislam/uptime-kuma:2.3.0
+          image: louislam/uptime-kuma:2.4.0
           command:
             - node
             - /script/admin-bootstrap.js


### PR DESCRIPTION
The apply on master ([run 30757772924](https://github.com/clincha-org/clincha/actions/runs/30757772924)) failed on all five monitors:

```
Unknown column 'bearer_token' in 'INSERT INTO'
```

`breml/uptimekuma` v0.4.0 writes a `bearer_token` column that 2.3.0's `monitor` table does not have. This is the provider-churn risk I flagged in #409 landing immediately — concretely it is version skew, since the provider's acceptance tests run against `louislam/uptime-kuma:2.4.0` and we were a minor behind.

**Current state is half-applied:** the Telegram notification was created (it is a dependency, so it went first), then every monitor failed. Verified against MariaDB — 1 notification, 0 monitors, 0 status pages. Terraform persists resources as it creates them, so the notification is in state and the next plan should read `6 to add`, not 7. I will confirm that from the plan rather than assume it.

## Why the image tag override

Chart 4.1.0 is the latest available and still pins appVersion 2.3.0, so there is no chart bump to take. The chart exposes `image.tag` as a first-class value. The comment marks it for removal once a chart ships 2.4.0 or later, so Renovate bumping the chart will not silently strand it.

2.5.0 exists too, but 2.4.0 is what the provider is tested against — no reason to get ahead of it and repeat this.

The bootstrap Job tracks the same tag, since it borrows `socket.io-client` from this image and should not drift from the server it talks to.

## Validation

yamllint exit 0, kubeconform 37/37 overlays valid, rendered manifests carry `tag: 2.4.0` on both the HelmRelease and the Job.

Once merged I will confirm the pod comes up on 2.4.0, the schema gains the column, and the Terraform apply completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)