### PR TITLE
uptime-kuma: rename the account from admin to clincha

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-credentials.sops.yaml
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-credentials.sops.yaml
@@ -5,31 +5,31 @@ metadata:
     namespace: uptime-kuma
 type: Opaque
 stringData:
-    username: ENC[AES256_GCM,data:isdWzEs=,iv:Zb39bJ03OlusoomChFpsRzR8Ot6zztlXfOifP4TSh4o=,tag:r2Gz0MqFszLN0HhNku4wng==,type:str]
-    password: ENC[AES256_GCM,data:aJ5OFwq/jou2JyDby5zEozdofDJSmHfrDLS/gb2oPeQ=,iv:PZK5jy2BLB/as126sg9nz8y8kWfqn3WNRpri/XJwung=,tag:EIOio+CwSVa6rc0f++p+OA==,type:str]
+    username: ENC[AES256_GCM,data:V6+uutFbUQ==,iv:FIhJBgiuyq5ANOGkKdxqD9NcqKRSP3NpzvVKEAk19Ao=,tag:LjdK88C9PqGMv4VbsQRNrg==,type:str]
+    password: ENC[AES256_GCM,data:3YbmLZhXKolN025FgjuzJE8igDWyFr3z8vuoyD8jufs=,iv:8M+c1lPbOKHG8SpRnV81FHUkBR+DcsEcOtZUzRP2/3g=,tag:29IHb/2on48AxYgAbmn3Qw==,type:str]
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-02T16:11:16Z"
-    mac: ENC[AES256_GCM,data:c8dlSjLMqToJjnSEOcBXyDvRw0p4tZfAvohax/unDezTuaWCE+ByMY6TVe8N40OrzuS+55pEhTn2Zut3YBH9aCR696PYac98jdT8dh2pSQcm9g/uMnELru7Ub5EQgDVqihl0fkSW8gxg9UNgLpJNXela21E/oEmnuzpHfyWTu5I=,iv:2sWGYAHcHBN19Kg0aXQlnrPUwX1vmH6Z2UtvQgyBOC0=,tag:FCLRjnHCzMHlqhmdxkRX9g==,type:str]
+    lastmodified: "2026-08-02T17:36:34Z"
+    mac: ENC[AES256_GCM,data:xYPtwuva2t4FYamw+hhMq6tRNlahmFueK5vqoNXjm45ox5Ytn+5ayj+iHZ9k8+cB8vhWFQsIKgj4JNJIqTSsQJoEP01XkOh0nsnIrsQH/g1PphJejWgonGZJXxpfFXpmddKVxRqr/GWz/D3srAm46lUZkd25I5mLBq3ZjAdgMxc=,iv:tG/GDEELiLy8VlTZ9Zgzvt7BmrzZtQT2uux1T4DmZgU=,tag:Mh4IPR32Iwv8yN2d0H852Q==,type:str]
     pgp:
-        - created_at: "2026-08-02T16:11:16Z"
+        - created_at: "2026-08-02T17:36:34Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA+iIV7UXPYO1ARAAlD7HwqXcLiosINjE2EP/ktbWk9J3O8WgJ04uut3utkB0
-            MuJtv2Wunm4zpN6pEeh9PiK2P6qelP57KJ+tgCHusiK3g+EsJC9tdPmfDoHs/Ahl
-            M5O/1MiGchW15nrhYH1iMRsERTGcIBuVPNAXNZLt56fZdGphJ0JUd86qZW3cLSDv
-            cxs3vr7etTmceBtZVE2u0Ciu6x0asSm3KaDtBuxshsGYXRGP5tzjHwxfFnq6Aan/
-            Opo7S01GD/ghc9sKV16s24i8ACQ3KS+G7NS82nPEOcUufh9qTKL9brFXZJshDKRi
-            Ygivl0Bx/rdKpCF8S5BkHCfmQA9ltALDgMJ1TtZL3nErDlWALZhGhImsPE5Ehukr
-            oI5ohQQsGpSUf+Y/mxB27wHYVoO1ui85zSDNPHM3jYKUctlGvpz6wUgFV02ZOKeQ
-            2eqtXZqEgYrVHyx/nBErOJX722TSQ+tAWVZYps9loEeK2xLx+dQaiHyrTtQ8tYoP
-            Hucb8MY+7XkAp3j/AtdTNNPc5+ypVsMQ84ByQMyJMiApmv4qG1au4Hp+PR3No+m7
-            Vib2Tik2EuL7UOvL3gLi3FZzjV70Yq/M5hdL9CH6OEd/g9N9OkuHRn5RH7p0FrB1
-            7lWFmmMcfOYtrwawAPhrbdEfl/wS2FSzT7+4G+V6PoPD+NNrz10/MggiJHBe/VPS
-            XAHCtbnNDW7Ku/qvEUm/VKMJr5u0z3g5MqCoaxlS5jFz36YYFpAP7pE6wUVvx7Mm
-            +FtEZNDOWKJJ+MadgLvQNalVrpVoNjO/eWsIHXqOUzWZXBi782pmFoD1DPHj
-            =ERgF
+            hQIMA+iIV7UXPYO1AQ//RZO+A2o6/I8gFjl5PneGPmoOhEIxQ0hPQc6NpWvqhKSo
+            FH0zGld8Fg00q+g+sDzTJsASXYeAOm1zlLNUc2IDZ9u1UiesypWWc/W/0XmUpI23
+            HfBmYgO0/6TG0oGokl3GKaGN5+TmQW81YZ7yo8rnmugnCbFEnvGfPMuP+q+kyFEC
+            s/mzYEg0F2jRSL/SBQ2/liSVCLOrAdaSZuUQHxpI/YKBAbNrMTdl6uvyYGFByVn+
+            GKNawDvDAT0J+iFfzQc+MkevvrMpUaGcf9Fr+rKGsue4/jvoCZ9oxN8FzU2sw/cT
+            41xi7Nh/B3CcxERGaUMSdId5mu9wOLQR1ol3eshcv2k5PM0JdC1jNMXqtW6DgGJp
+            KNh6c8grCJEgNBqkOGbyKOr02rjwo6BFiQVsqkv2AarCea/dwfBCgOEiEcbeQTJu
+            JpZxey9vP9MFHOwcNRgxu2Ure9i69weY4kCOt2CYGkjG7ccmnj7NBR5lmtWCrNI5
+            5fGcetRUra+98MJYKNXghVgRSJWRHJqMLet7nCxiuUO+YXTh5FKPhj0CB1tQ1SD3
+            MJAR9guH9+ZXjI08toLqiWQ6GVO/g5gJCVk5EGdFTjuNkGKnpcS8jSTz3oglpvM/
+            SxLoSbwWvtLYY0mJSFnfkzwMj2c/dI+c6eWWX8xszPcan939NtPOYjEX3PVjGnXS
+            XgG5f1NyGAKRPELe+f7hMnPmhZeq0N75BvjSXAt1elYQtECa0Up53laU0r572Om+
+            CsaY8LgzU021Dh9GcaxxPP2ljHLXr1whK497HqsIMU7NvKnQPzr38hfHq1sOyoE=
+            =yPjI
             -----END PGP MESSAGE-----
           fp: 76AF39813C2297E8F98C542D42436A07A9BA1DE0
     version: 3.13.1

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -18,7 +18,8 @@ It has its own workflow rather than joining the matrix in `terraform.yaml`:
 that workflow passes `-var="pm_api_token_secret"` to every stack, and Terraform
 errors on a `-var` it has no declaration for.
 
-The admin user it authenticates as is created by a Flux Job
+Uptime Kuma is single-user: the account Terraform authenticates as (`clincha`) is
+also the one you log in with. It is created by a Flux Job
 (`kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap-job.yml`),
 not by hand — Uptime Kuma has no env-based bootstrap, so the Job calls the
 Socket.IO `setup` event. Re-running is safe; the server rejects a second setup

--- a/terraform/uptime-kuma/variables.tf
+++ b/terraform/uptime-kuma/variables.tf
@@ -3,9 +3,11 @@ variable "endpoint" {
   default = "https://status.clincha.co.uk"
 }
 
+# Uptime Kuma is single-user, so this is both Angus's login and the account
+# Terraform authenticates as. Keep it in step with the bootstrap secret.
 variable "username" {
   type    = string
-  default = "admin"
+  default = "clincha"
 }
 
 variable "password" {


### PR DESCRIPTION
Uptime Kuma is **single-user**. In 2.4.0 the only account-related socket events are `login`, `loginByToken`, `needSetup`, `setup` and `changePassword` — there is no `addUser`, `deleteUser` or `getUsers`, and Settings has no Users page. So there was no second account to add; the one account is both Angus's login and the identity Terraform authenticates as.

## Renamed, not recreated

`setup` only fires against an empty user table, and `monitor` rows carry `user_id`, so deleting the row to re-run bootstrap would have taken the five monitors with it. Instead the live account was renamed in place — still id 1, still owning all 5 monitors, password unchanged.

This PR makes the code agree, so a rebuild from scratch produces `clincha` rather than reverting to `admin`:

- bootstrap SOPS secret re-encrypted with `username: clincha`
- Terraform `username` variable default moved to `clincha`
- README notes the single-user constraint

Vault item renamed `Uptime Kuma admin` → **`Uptime Kuma login`**, username updated, password untouched.

## Verified live

```
login as clincha: {"ok":true}
login as admin (should fail): {"ok":false,"msg":"authIncorrectCreds"}
```

## Sequencing

The rename was applied to the live instance *before* opening this PR deliberately. Merging touches `terraform/uptime-kuma/**`, which fires the apply — and that apply now authenticates as `clincha`, which already exists. Doing it the other way round would have broken auth in the window between.

Expect the apply to report **0 added, 0 changed, 0 destroyed**; the username is a provider credential, not tracked state.

## Validation

`terraform validate` and `fmt -check` clean, kubeconform 37/37, yamllint exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)