### PR TITLE
uptime-kuma: use Angus's own password for the account

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-credentials.sops.yaml
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-credentials.sops.yaml
@@ -5,31 +5,31 @@ metadata:
     namespace: uptime-kuma
 type: Opaque
 stringData:
-    username: ENC[AES256_GCM,data:V6+uutFbUQ==,iv:FIhJBgiuyq5ANOGkKdxqD9NcqKRSP3NpzvVKEAk19Ao=,tag:LjdK88C9PqGMv4VbsQRNrg==,type:str]
-    password: ENC[AES256_GCM,data:3YbmLZhXKolN025FgjuzJE8igDWyFr3z8vuoyD8jufs=,iv:8M+c1lPbOKHG8SpRnV81FHUkBR+DcsEcOtZUzRP2/3g=,tag:29IHb/2on48AxYgAbmn3Qw==,type:str]
+    username: ENC[AES256_GCM,data:+vIHP+qkWw==,iv:aGWh9Jk8bfKOOIVCkkWl/tAwNpsSORi6+uQWPtD8Qko=,tag:q2bvvuNrnkxHbsfD8QfPeQ==,type:str]
+    password: ENC[AES256_GCM,data:mT1kxhNg4z+eLh5c,iv:z4HJsEHjKZ9DFCh5GUxu1cziXmH3JmVvQHQWc9bZqi0=,tag:QJUDYTNh+dfXwAjz8f2x6Q==,type:str]
 sops:
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-02T17:36:34Z"
-    mac: ENC[AES256_GCM,data:xYPtwuva2t4FYamw+hhMq6tRNlahmFueK5vqoNXjm45ox5Ytn+5ayj+iHZ9k8+cB8vhWFQsIKgj4JNJIqTSsQJoEP01XkOh0nsnIrsQH/g1PphJejWgonGZJXxpfFXpmddKVxRqr/GWz/D3srAm46lUZkd25I5mLBq3ZjAdgMxc=,iv:tG/GDEELiLy8VlTZ9Zgzvt7BmrzZtQT2uux1T4DmZgU=,tag:Mh4IPR32Iwv8yN2d0H852Q==,type:str]
+    lastmodified: "2026-08-02T17:53:25Z"
+    mac: ENC[AES256_GCM,data:/OEzis2lUQF+8Sk2TAmhDWxk29bZQYuAI3fjqbFxfI0nNP1OT9JhmjWknHlqCcpkeNgmNPl+XIH2Cwja73BpDWVAAuwZ5Je67Gay8E6Ib5T+SH6zE7ht6ELczb428d73cYuBDK9U/w9ZGMVk7UcssSiV5ktzm2h0Td9zC2bWI3A=,iv:kURvlUgEI8uAoS2PirCM55Us7Eddbi1C8iAV5e87SUc=,tag:ssy73TqVzwKhrj8ZJvCdug==,type:str]
     pgp:
-        - created_at: "2026-08-02T17:36:34Z"
+        - created_at: "2026-08-02T17:53:25Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA+iIV7UXPYO1AQ//RZO+A2o6/I8gFjl5PneGPmoOhEIxQ0hPQc6NpWvqhKSo
-            FH0zGld8Fg00q+g+sDzTJsASXYeAOm1zlLNUc2IDZ9u1UiesypWWc/W/0XmUpI23
-            HfBmYgO0/6TG0oGokl3GKaGN5+TmQW81YZ7yo8rnmugnCbFEnvGfPMuP+q+kyFEC
-            s/mzYEg0F2jRSL/SBQ2/liSVCLOrAdaSZuUQHxpI/YKBAbNrMTdl6uvyYGFByVn+
-            GKNawDvDAT0J+iFfzQc+MkevvrMpUaGcf9Fr+rKGsue4/jvoCZ9oxN8FzU2sw/cT
-            41xi7Nh/B3CcxERGaUMSdId5mu9wOLQR1ol3eshcv2k5PM0JdC1jNMXqtW6DgGJp
-            KNh6c8grCJEgNBqkOGbyKOr02rjwo6BFiQVsqkv2AarCea/dwfBCgOEiEcbeQTJu
-            JpZxey9vP9MFHOwcNRgxu2Ure9i69weY4kCOt2CYGkjG7ccmnj7NBR5lmtWCrNI5
-            5fGcetRUra+98MJYKNXghVgRSJWRHJqMLet7nCxiuUO+YXTh5FKPhj0CB1tQ1SD3
-            MJAR9guH9+ZXjI08toLqiWQ6GVO/g5gJCVk5EGdFTjuNkGKnpcS8jSTz3oglpvM/
-            SxLoSbwWvtLYY0mJSFnfkzwMj2c/dI+c6eWWX8xszPcan939NtPOYjEX3PVjGnXS
-            XgG5f1NyGAKRPELe+f7hMnPmhZeq0N75BvjSXAt1elYQtECa0Up53laU0r572Om+
-            CsaY8LgzU021Dh9GcaxxPP2ljHLXr1whK497HqsIMU7NvKnQPzr38hfHq1sOyoE=
-            =yPjI
+            hQIMA+iIV7UXPYO1ARAAqsrWn58uao5WMeW8kBWzlOvr7ZUPA3uDLiwekQTJg638
+            JcdBe4Wto2IXs2L3LTYCNVxbv8TdZyCMEhIpjN4psISGSbOPFVncHu+ZzTavwB6b
+            +Q+FHn4Op/pZSdnWlYc4omOZXvE/RQFVZR3d0puTdPeV9iM8wtbqieBeN4zS+J0K
+            7UWDd25YZFj/dtSPevkJ2Fs8TTbtf5EZ/21qlTIU7zvB7gLqNR7TOtwb46Pn60Pw
+            euX+6BlKfDvWTSQVz5BGRPMxD03Ve8B7Ve8c68WRNZAfLR5kkmEBVOzMg7i8LEUq
+            IeiTOxTszo7clpIAY7fDogxkVd0Go319XnZ9BM0oEWCm0r5JHI0PrrhT9jEMpXm9
+            1HDLKyZfaMMAwyI3V9YH13DxFDs9N6mVr5l4jxs3yS0exXGy1wkHRxT4ijimPQxH
+            EVqMhWB8MzggnxtBHkLCd24wLLUXQqFOIFjlskd5k5gcSmGPt/ap2ovh699U6Vgb
+            zWTn78JE/k9k1ao5DbbEuG6HtknsmqigoX2kkQHaQLL3gEStr8/236cq/mOJqEZA
+            yqInzCCXNejiJYAC6V3JYJTAPar9ySv4OoSwjRlcbtboYeF8PzHOsgvouZ19VkaT
+            r7dpiTgfxaTmx1+4RywrtACAXytLIuGgqWIt9ttjFiKXaw6ecIhgTEHZ+tE690jS
+            XgE/ChkdiTlw8FT2pIDlkXknTiJp86Hr+Hx3WcbLukKK/v5anBAnxIeteLadiOh5
+            33i7OvWqW6GgI95n1YNSURUbbEhf3vZFzU6cAZRzpYPEqhLOwOYeHuK4TZKscLs=
+            =88ai
             -----END PGP MESSAGE-----
           fp: 76AF39813C2297E8F98C542D42436A07A9BA1DE0
     version: 3.13.1

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -25,7 +25,11 @@ not by hand — Uptime Kuma has no env-based bootstrap, so the Job calls the
 Socket.IO `setup` event. Re-running is safe; the server rejects a second setup
 once a user exists.
 
-Credentials live in Bitwarden (`Uptime Kuma admin`,
+Credentials live in Bitwarden (`uptime kuma (clincha)`,
 `Uptime Kuma Telegram notification`) and as repository secrets
 `UPTIME_KUMA_ADMIN_PASSWORD`, `UPTIME_KUMA_TELEGRAM_BOT_TOKEN` and
 `UPTIME_KUMA_TELEGRAM_CHAT_ID`.
+
+Rotating that password means three places at once: the running instance via
+the `changePassword` socket event, the `UPTIME_KUMA_ADMIN_PASSWORD` secret, and
+the bootstrap SOPS secret. Changing it in the UI alone breaks Terraform auth.


### PR DESCRIPTION
Switches the account password to the one already stored in the vault item `uptime kuma (clincha)`, rather than the value generated during bootstrap.

## Already applied live

Uptime Kuma is single-user and that account is also Terraform's credential, so the live change and the secret rotation had to happen together — a PR alone would have left the running instance and the stored secret disagreeing.

- password changed via the `changePassword` socket event (it requires the current password and rejects anything `passwordStrength` rates "Too weak"; the stored value passed)
- `UPTIME_KUMA_ADMIN_PASSWORD` repository secret updated in the same step

Verified against the live instance:

```
new password: {"ok":true}
old password (should fail): {"ok":false,"msg":"authIncorrectCreds"}
```

This PR re-encrypts the bootstrap SOPS secret to match, so a rebuild from scratch creates the account with this password instead of reverting to the generated one.

## Note on the vault

There are now two items holding the same credential — `uptime kuma (clincha)` (yours, now the source of truth) and `Uptime Kuma login` (created during bootstrap). I have left both alone rather than deleting one unprompted; say the word and I will drop `Uptime Kuma login` so they cannot drift apart.

## Validation

kubeconform 37/37 overlays valid, yamllint exit 0. No Terraform files touched, so this does not trigger an apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)