### PR TITLE
monitoring: stop Alloy phoning home and pin its version

### DIFF
--- a/Ansible/roles/monitoring/defaults/main.yml
+++ b/Ansible/roles/monitoring/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+monitoring_alloy_version: "1.18.0-1"
 monitoring_scrape_interval: "15s"
 monitoring_disabled_collectors:
   - wifi

--- a/Ansible/roles/monitoring/tasks/configure.yml
+++ b/Ansible/roles/monitoring/tasks/configure.yml
@@ -16,6 +16,13 @@
     line: 'CONFIG_FILE="/etc/alloy/config.alloy"'
   notify: Restart alloy
 
+- name: Ensure Alloy does not phone home
+  ansible.builtin.lineinfile:
+    path: /etc/default/alloy
+    regexp: '^CUSTOM_ARGS='
+    line: 'CUSTOM_ARGS="--disable-reporting"'
+  notify: Restart alloy
+
 - name: Ensure Alloy service is enabled and started
   ansible.builtin.systemd_service:
     name: alloy

--- a/Ansible/roles/monitoring/tasks/install.yml
+++ b/Ansible/roles/monitoring/tasks/install.yml
@@ -23,5 +23,6 @@
 
 - name: Install Grafana Alloy
   ansible.builtin.apt:
-    name: alloy
+    name: "alloy={{ monitoring_alloy_version }}"
     state: present
+    update_cache: true

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "enabledManagers": ["kubernetes", "flux"],
+  "enabledManagers": ["kubernetes", "flux", "custom.regex"],
   "kubernetes": {
     "managerFilePatterns": ["/^kubernetes/flux/.+\\.ya?ml$/"]
   },
   "flux": {
     "managerFilePatterns": ["/^kubernetes/flux/.+\\.ya?ml$/"]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Grafana Alloy apt pin in the monitoring role",
+      "managerFilePatterns": ["/^Ansible/roles/monitoring/defaults/main\\.yml$/"],
+      "matchStrings": ["monitoring_alloy_version: \"(?<currentValue>.+?)\""],
+      "depNameTemplate": "alloy",
+      "datasourceTemplate": "deb",
+      "versioningTemplate": "deb",
+      "registryUrlTemplate": "https://apt.grafana.com?suite=stable&components=main&binaryArch=amd64"
+    }
+  ],
   "dependencyDashboard": false,
   "prConcurrentLimit": 3,
   "prHourlyLimit": 2,


### PR DESCRIPTION
Alloy v1.16.2 on `claude-hawk-1` retried its DNS-blackholed usage report on a
1-minute ticker forever, six journal lines a cycle — 8.1k lines/day, 23% of the
fleet's error-matching log volume.

- `Ansible/roles/monitoring/tasks/configure.yml` — set
  `CUSTOM_ARGS="--disable-reporting"` in `/etc/default/alloy`, alongside the
  existing `CONFIG_FILE` line, notifying `Restart alloy`. Kills the phone-home
  regardless of Alloy version and stops sending telemetry to Grafana Labs from
  every host.
- `Ansible/roles/monitoring/tasks/install.yml` + `defaults/main.yml` — replace
  `state: present` on a bare package name with an explicit pin,
  `monitoring_alloy_version: "1.18.0-1"`. `state: present` installed once and
  never upgraded, so every host froze at whatever was in the Grafana repo the
  day it was provisioned; this converges claude-hawk-1 onto the same version as
  hawk01/hawk02 and stays deterministic. `update_cache: true` is needed so a
  stale cache can't hide a newly bumped pin.
- `renovate.json` — a `custom.regex` manager on the pin, `deb` datasource
  against `apt.grafana.com`, so the version has a single line for Renovate to
  bump.

Closes #411

Review findings: none requiring changes. Verified against the upstream sources
rather than assuming — the v1.18.0 deb unit really is
`ExecStart=/usr/bin/alloy run $CUSTOM_ARGS ... $CONFIG_FILE` with
`EnvironmentFile=/etc/default/alloy` (so no systemd drop-in fallback is needed),
`--disable-reporting` is a real `alloy run` flag, `1.18.0-1` is the current
version in `apt.grafana.com stable`, and the Packages index Renovate's `deb`
datasource will construct from that registry URL resolves and lists it. Also
confirmed `update_cache` alone does not report `changed`, so the role stays
idempotent on a second run. `ansible-lint --format pep8 --strict` from `Ansible/`
passes on the production profile and yamllint is clean.

Note for after merge: the in-cluster Alloy DaemonSet
(`kubernetes/flux/infrastructure/base/monitoring/helm-release-alloy.yml`) has no
`extraArgs` and still reports. It is on a version that backs off, so it is not a
noise source — left alone as out of scope here, worth a follow-up if the intent
is genuinely no telemetry anywhere. Issue step 3 (`journalctl -u alloy | grep -c
"reporting Alloy stats"` is 0 on claude-hawk-1) can only be checked once
`ansible-monitoring.yaml` runs on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
