### PR TITLE
monitoring: point runAsGroup at the realigned hawkstore GIDs

### DIFF
--- a/Documentation/hawkstore-accounts.md
+++ b/Documentation/hawkstore-accounts.md
@@ -1,0 +1,79 @@
+# hawkstore users and groups
+
+hawkstore (`10.1.2.10`) is **not managed as code** — users, groups and datasets are configured
+through the TrueNAS UI/API. Only the Kubernetes consumers live in this repo, so any change here
+has a manual NAS half that must land in the same window.
+
+## The rule
+
+**GID == UID for every account with its own primary group.** The one deliberate exception is the
+media stack, where nine app accounts share `media(3011)`.
+
+Before creating an account, check **both** `user.query` and `group.query`. Never take "the next
+free number" from one sequence alone. Until 2026-08-05 the two sequences had drifted apart and
+almost every GID in 3003–3022 was also a *different* account's UID; that is how Ombi shipped with
+`PUID: 3015`, which was `asta` — a real person with SMB access.
+
+## Current map
+
+| account | uid | primary group | gid | notes |
+|---|---|---|---|---|
+| clincha | 3000 | clincha | 3000 | human, SMB |
+| cclinch | 3001 | cclinch | 3001 | human, SMB |
+| hawkprint | 3002 | hawkprint | 3002 | printer/scanner, SMB |
+| prometheus | 3003 | prometheus | 3003 | `/mnt/data/prometheus` |
+| ansible | 3004 | ansible | 3004 | |
+| grafana | 3005 | grafana | 3005 | `/mnt/data/grafana` |
+| dave | 3006 | dave | 3006 | FULL_ADMIN, owns the API key |
+| nasexporter | 3007 | nasexporter | 3007 | bound to privilege `nas-exporter-readonly` |
+| tautulli | 3008 | media | 3011 | |
+| tdarr | 3009 | media | 3011 | |
+| plex | 3010 | media | 3011 | |
+| sonarr | 3011 | media | 3011 | |
+| radarr | 3012 | media | 3011 | |
+| bazarr | 3013 | media | 3011 | |
+| sabnzbd | 3014 | media | 3011 | |
+| asta | 3015 | asta | 3015 | human, SMB — treat as fixed |
+| immich | 3016 | media | 3011 | |
+| ombi | 3017 | media | 3011 | |
+| loki | 3018 | loki | 3018 | `/mnt/data/loki` |
+| uptimekuma | 3019 | uptimekuma | 3019 | `/mnt/data/uptime-kuma` |
+| s3 | 3020 | s3 | 3020 | rustfs, `/mnt/userstore/s3` |
+
+Shared/auxiliary groups: `media(3011)`, `printing(3023)` (clincha, hawkprint — owns
+`/mnt/userstore/scans`), `family(3024)` (clincha, cclinch, asta).
+
+Free GIDs: 3008–3010, 3012–3014, 3016, 3017, 3021, 3022, 3025+.
+
+## Renumbering, if it is ever needed again
+
+TrueNAS will **not** change a GID. `group.update` rejects the field outright, so a renumber is
+delete + recreate at the target GID, with the user's primary group repointed in between:
+
+1. rename the old group out of the way
+2. create the new group at the target GID (it must be free *at that moment*)
+3. `user.update` the owner's primary group to the new group
+4. delete the old group
+5. `chgrp` the affected trees
+
+Because step 2 needs a free target, a renumber is a strict cascade — moving `prometheus` onto
+3003 first required `printing` to vacate it. Order the moves so each target frees up before it is
+needed, and stop any workload holding files under a group before renumbering it.
+
+Two traps found doing this on 2026-08-05:
+
+- **Admin accounts are frozen while global 2FA is on.** Any `user.update` on an account holding
+  `FULL_ADMIN` without its own 2FA configured returns HTTP 422. This affects `dave`.
+- **A group can be pinned by a privilege.** Deleting `nasexporter`'s old group failed until
+  privilege `nas-exporter-readonly` was repointed to the new GID. Check `privilege.query` for the
+  GID before deleting, or the account silently loses its roles.
+
+Also note that a TrueNAS *app* carries its own `run_as` uid/gid, independent of the dataset: after
+the realignment `rustfs` kept writing as the deleted GID 3022 until `app.update` set it to 3020.
+
+## NFS and SMB
+
+Exports are `root_squash` with empty maproot/mapall, so pods set `runAsUser`/`runAsGroup` rather
+than relying on root. Server-side group membership does not gate NFS access — under AUTH_SYS the
+*client* supplies the GID — so a wrong `runAsGroup` fails silently rather than loudly. It matters
+for SMB, local tools, and if `manage_gids` is ever enabled.

--- a/kubernetes/flux/infrastructure/base/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/prometheus.yml
@@ -43,7 +43,7 @@ spec:
           securityContext:
             runAsUser: 3003
             runAsNonRoot: false
-            runAsGroup: 3004
+            runAsGroup: 3003
           args:
             - --web.enable-remote-write-receiver
             - --config.file=/etc/prometheus/prometheus.yml

--- a/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
+++ b/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
@@ -66,7 +66,7 @@ spec:
       - name: PUID
         value: "3019"
       - name: PGID
-        value: "3021"
+        value: "3019"
     # Kept from the SQLite-on-NFS era. MariaDB removes the stall that used to
     # trip these, but the chart's 1s/2s defaults leave no room for a slow query
     # either, and a killed pod is a worse outcome than a slow one.

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/loki-values.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/loki-values.yml
@@ -9,11 +9,11 @@ loki:
   auth_enabled: false
   # The export is root_squash, so run as the hawkstore loki user rather than the
   # chart default 10001. fsGroupChangePolicy is dropped: recursive chown of the
-  # mount is pointless on NFS and the dataset is already owned 3018:3020.
+  # mount is pointless on NFS and the dataset is already owned 3018:3018.
   podSecurityContext:
     runAsUser: 3018
-    runAsGroup: 3020
-    fsGroup: 3020
+    runAsGroup: 3018
+    fsGroup: 3018
     runAsNonRoot: true
   commonConfig:
     replication_factor: 1


### PR DESCRIPTION
Closes #405.

hawkstore's UID and GID sequences had drifted apart, so from uid 3003 onward nearly every service account's primary GID was *another account's UID*. The groups have now been rebuilt on the NAS so **GID == UID**; this PR is the matching manifest half, and the two must land together.

## NAS-side changes already applied

Eight memberless leftover groups deleted (`tautulli` 3009, `tdarr` 3010, `plex` 3012, `sonarr` 3013, `radarr` 3014, `bazarr` 3015, `sabnzbd` 3016, `immich` 3019), then 11 groups rebuilt in cascade order:

| group | old gid | new gid |
| --- | --- | --- |
| printing | 3003 | 3023 |
| prometheus | 3004 | **3003** |
| ansible | 3005 | **3004** |
| grafana | 3006 | **3005** |
| dave | 3007 | **3006** (pending, see below) |
| nasexporter | 3008 | **3007** (pending) |
| asta | 3017 | **3015** |
| family | 3018 | 3024 |
| loki | 3020 | **3018** |
| s3 | 3022 | **3020** |
| uptimekuma | 3021 | **3019** |

TrueNAS will not renumber a GID (`group.update` rejects the field), so each was delete + recreate at the target GID with the primary group repointed — which is why the order matters. `printing` and `family` had to vacate 3003/3018 first; both were recreated with membership and SMB flag intact.

Ownership rewritten to match: 146 files under `/mnt/data/prometheus`, 1 (`/mnt/data/grafana` dataset root), 35 under `/mnt/data/loki`, 8 under `/mnt/data/uptime-kuma`, 190,817 under `/mnt/userstore/s3`, 1 under `/mnt/userstore/scans`, 6 under `userhome/ansible`, and asta's home split correctly — 5,856 family-owned files to 3024 and 38,035 to 3015.

ZFS snapshots `@pre-gid-realign-20260805` were taken on all seven affected datasets first.

## Manifest changes here

- `prometheus.yml` — `runAsGroup` 3004 → 3003
- `loki-values.yml` — `runAsGroup`/`fsGroup` 3020 → 3018
- `uptime-kuma/helm-release.yml` — `PGID` 3021 → 3019
- `grafana.yml` — **no change**; grafana lands on 3005, which the manifest already set. Its files were already `3005:3005`; only the dataset root (`3005:3006`, i.e. group-owned by `ansible`) was wrong, and that is now fixed. This was the live drift #405 called out.

## Still outstanding

`dave` (3006) and `nasexporter` (3007) are not yet moved. `dave` holds `FULL_ADMIN`, and TrueNAS rejects any `user.update` on an admin account that has no 2FA configured while global 2FA is on (HTTP 422). `nasexporter` is queued behind it because it needs 3007 vacated. Group `dave`(3006) exists but is empty; the user still sits on `dave_t405`(3007). Awaiting a decision on how to clear the 2FA guard.

Flux reconciliation for `monitoring` and `uptime-kuma` is suspended and the four workloads are scaled to zero while this lands.