### PR TITLE
Monitor every web app the cluster serves

### DIFF
--- a/terraform/uptime-kuma/main.tf
+++ b/terraform/uptime-kuma/main.tf
@@ -13,9 +13,29 @@ locals {
       # /identity answers without auth; the root path redirects to the web app.
       url = "https://plex.clinch-home.com/identity"
     }
-    sonarr          = { url = "https://sonarr.clinch-home.com" }
-    radarr          = { url = "https://radarr.clinch-home.com" }
-    sabnzbd         = { url = "https://sabnzbd.clinch-home.com" }
+    sonarr  = { url = "https://sonarr.clinch-home.com" }
+    radarr  = { url = "https://radarr.clinch-home.com" }
+    sabnzbd = { url = "https://sabnzbd.clinch-home.com" }
+    bazarr  = { url = "https://bazarr.clinch-home.com" }
+    tdarr   = { url = "https://tdarr.clinch-home.com" }
+    immich  = { url = "https://immich.clinch-home.com" }
+    ombi    = { url = "https://ombi.clinch-home.com" }
+    tautulli = {
+      # Root 303s to the login flow; /status is an unauthenticated health payload.
+      url = "https://tautulli.clinch-home.com/status"
+    }
+
+    grafana = {
+      # Root 302s to /login.
+      url = "https://grafana.clinch-home.com/api/health"
+    }
+    prometheus = {
+      # Root 302s to /query.
+      url = "https://prometheus.clinch-home.com/-/healthy"
+    }
+    alloy = { url = "https://alloy.clinch-home.com/-/ready" }
+    loki  = { url = "https://loki.clinch-home.com" }
+
     "clincha.co.uk" = { url = "https://clincha.co.uk" }
   }
 }


### PR DESCRIPTION
uptime-kuma had monitors for 5 of the 15 ingresses in hawkfield. This adds the missing ones.

| Monitor | URL | Why not the root path |
|---|---|---|
| bazarr | `https://bazarr.clinch-home.com` | — |
| tdarr | `https://tdarr.clinch-home.com` | — |
| immich | `https://immich.clinch-home.com` | — |
| ombi | `https://ombi.clinch-home.com` | — |
| tautulli | `.../status` | root 303s to the login flow |
| grafana | `.../api/health` | root 302s to `/login` |
| prometheus | `.../-/healthy` | root 302s to `/query` |
| alloy | `.../-/ready` | root works, but this is the real readiness endpoint |
| loki | `https://loki.clinch-home.com` | gateway returns `OK` |

Every URL was probed from the LAN and returns 200. All nine land on the `all` status page automatically.

Not added: `uptime-kuma` itself — it cannot alert on its own outage, so it needs external monitoring rather than a self-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)