### PR TITLE
Add Alertmanager with Telegram pod-restart alerts; fix stuck Grafana rollout

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -9,6 +9,9 @@ rules:
       - 'Ansible/roles/users/defaults/main.yml'
       - 'kubernetes/flux/infrastructure/base/media/controller/secret.yml'
       - 'kubernetes/flux/infrastructure/hawkfield/monitoring/loki-rustfs-creds.sops.yaml'
+      - 'kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager-telegram.sops.yaml'
+      # runbook_url is an 88-char GitHub blob URL that cannot wrap.
+      - 'kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml'
       - 'kubernetes/flux/infrastructure/hawkfield/uptime-kuma/mariadb-credentials.sops.yaml'
       - 'kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-credentials.sops.yaml'
       # Long ${{ secrets.* }} expressions and release URLs. Pre-existing; the

--- a/Documentation/runbooks/pod-restarts.md
+++ b/Documentation/runbooks/pod-restarts.md
@@ -41,19 +41,23 @@ Grafana is one of the things being watched.
 
 ## Quiet hours — know the exact behaviour
 
-Warnings are muted 23:00–07:00 Europe/London. Critical alerts are never muted.
+Warnings are muted 23:00–06:00 Europe/London. Critical alerts are never muted.
 
 Muting is **suppression, not queueing**. Alertmanager has no store-and-forward. So:
 
-- A warning that is *still firing* when the window lifts is delivered shortly after 07:00.
+- A warning that is *still firing* when the window lifts is delivered shortly after 06:00.
   The warning route uses `repeat_interval: 4h` so the next delivery attempt lands within an
-  hour or so of 07:00 rather than waiting on the 6h default.
+  hour or so of 06:00 rather than waiting on the 6h default.
 - A warning that fires *and resolves* entirely inside the window is **never announced**. You
   will not hear about it at all.
 
 That second case matters here: the nightly Plex Butler thumbnail run (02:00–07:00) drives NAS
 load and is the most likely source of overnight restarts. If you want a morning record of what
 happened overnight, check Prometheus rather than trusting silence.
+
+Note the overlap: Butler runs until 07:00 but muting stops at 06:00, so Butler-driven restarts
+between 06:00 and 07:00 *will* reach you. If that turns into a recurring morning nuisance, move
+the mute back to 07:00 rather than widening the alert threshold.
 
 ## Triage
 

--- a/Documentation/runbooks/pod-restarts.md
+++ b/Documentation/runbooks/pod-restarts.md
@@ -1,0 +1,169 @@
+# Runbook: pod restart alerts
+
+Covers `PodRestartingFrequently` (warning) and `PodCrashLooping` (critical), delivered to
+Telegram by Alertmanager.
+
+## The alerts
+
+| Alert | Severity | Fires when |
+| --- | --- | --- |
+| `PodRestartingFrequently` | warning | a container restarted 3+ times in the last hour, sustained for 10m |
+| `PodCrashLooping` | critical | a container has been in `CrashLoopBackOff` for 15m |
+
+Both carry `namespace`, `pod` and `container` labels, and cover **every namespace** in the
+cluster.
+
+The warning window is one hour rather than fifteen minutes on purpose. Kubernetes caps
+CrashLoopBackOff at a 5-minute backoff, so a 15-minute window can only ever hold about three
+restarts — any threshold on it sits right on the boundary and flaps.
+
+A crash-looping pod trips **both** alerts. There is no inhibition rule, so expect two messages
+for the same incident. If that gets annoying, add an `inhibit_rules` block to
+`kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager.yml` matching on
+`namespace` + `pod`.
+
+## How the alert reaches you
+
+```
+kubelet → kube-state-metrics → Alloy (scrape + remote_write) → Prometheus
+       → alert rules → Alertmanager → Telegram (clincha_grafana_bot)
+```
+
+Nothing here goes through Grafana. Grafana's own alerting is unused — deliberately, since
+Grafana is one of the things being watched.
+
+- Rules: `kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml`
+- Routing: `kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager.yml`
+- Bot token + chat ID: `alertmanager-telegram.sops.yaml` (SOPS, same PGP key as every other
+  secret in this repo). The token is also stored in Bitwarden as `Alertmanager Telegram bot`.
+- Alertmanager UI: <https://alertmanager.clinch-home.com> (LAN only)
+- Prometheus alert state: <https://prometheus.clinch-home.com/alerts>
+
+## Quiet hours — know the exact behaviour
+
+Warnings are muted 23:00–07:00 Europe/London. Critical alerts are never muted.
+
+Muting is **suppression, not queueing**. Alertmanager has no store-and-forward. So:
+
+- A warning that is *still firing* when the window lifts is delivered shortly after 07:00.
+  The warning route uses `repeat_interval: 4h` so the next delivery attempt lands within an
+  hour or so of 07:00 rather than waiting on the 6h default.
+- A warning that fires *and resolves* entirely inside the window is **never announced**. You
+  will not hear about it at all.
+
+That second case matters here: the nightly Plex Butler thumbnail run (02:00–07:00) drives NAS
+load and is the most likely source of overnight restarts. If you want a morning record of what
+happened overnight, check Prometheus rather than trusting silence.
+
+## Triage
+
+1. **Identify.** The message gives you `namespace/pod (container)`.
+
+   ```bash
+   kubectl -n <ns> get pods
+   kubectl -n <ns> describe pod <pod> | tail -40
+   ```
+
+2. **Read the crash itself**, not the current attempt:
+
+   ```bash
+   kubectl -n <ns> logs <pod> --previous --tail=50
+   ```
+
+   `--previous` is the important part — the running container is usually a fresh attempt that
+   has not failed yet.
+
+3. **Check for the obvious causes**, in rough order of likelihood here:
+   - `OOMKilled` in `describe` output → memory limit too low.
+   - NFS unavailable → check hawkstore is up (`ssh dave@10.1.2.10`). Most stateful workloads
+     here mount `10.1.2.10` directly and fail hard when it goes away.
+   - A file lock held by another pod → see the worked example below.
+   - A bad image tag from a Renovate bump → compare ReplicaSets (see below).
+
+4. **Silence while you work**, so you are not re-alerted mid-fix:
+
+   ```bash
+   amtool --alertmanager.url=https://alertmanager.clinch-home.com \
+     silence add alertname=PodCrashLooping namespace=<ns> pod=<pod> \
+     --duration=2h --comment="fixing X"
+   ```
+
+   Or use the Alertmanager UI. Silences survive restarts — they are on NFS at
+   `/mnt/data/alertmanager`.
+
+## Worked example: Grafana, 2026-08-06
+
+Symptom: `grafana-f7fc89fb5-vzzqs` in `CrashLoopBackOff`, 286 restarts over 24h — while Grafana
+itself stayed up and served normally.
+
+Cause: two Grafana pods existed. Renovate bumped `13.1.1 → 13.1.2`, and the Deployment used the
+default `RollingUpdate` strategy. With `replicas: 1`, `maxSurge: 25%` rounds *up* to 1, so
+Kubernetes started the new pod before removing the old one. Both mount the same NFS directory
+`/mnt/data/grafana`, and Grafana's bleve unified-search index takes an exclusive lock:
+
+```
+level=error msg="index is locked by another process"
+  indexDir=/var/lib/grafana/unified-search/bleve/... err=timeout
+Error: ✗ index is locked by another process
+```
+
+The old pod held the lock, the new pod could not start, the rollout sat at
+`ProgressDeadlineExceeded` for 24 hours, and the old pod kept serving — which is why nothing
+looked broken from the outside.
+
+Fix: `strategy: Recreate` on the Deployment. The same reasoning applies to Prometheus (TSDB lock
+file) and Alertmanager (silences + nflog), so all three are set to `Recreate`.
+
+**Generalise this:** any single-replica Deployment on shared NFS in this cluster needs
+`Recreate`. `RollingUpdate` will overlap pods and whatever single-writer lock the app uses will
+break the upgrade. Check for this first whenever a crash-loop appears immediately after a
+version bump.
+
+Useful when you suspect a stuck rollout:
+
+```bash
+kubectl -n <ns> get rs -l app.kubernetes.io/name=<app> \
+  -o custom-columns=NAME:.metadata.name,IMAGE:.spec.template.spec.containers[0].image,DESIRED:.spec.replicas,READY:.status.readyReplicas
+kubectl -n <ns> get deploy <app> -o jsonpath='{.status.conditions}'
+```
+
+Two ReplicaSets with `DESIRED=1` is the tell.
+
+## Changing the alerts
+
+Everything is Flux-managed — `kubectl edit` gets reverted. Edit the files above, open a PR, let
+Flux reconcile.
+
+Validate before pushing:
+
+```bash
+# rules
+kubectl -n monitoring exec -i deploy/prometheus -- sh -c 'cat > /tmp/r.yml && promtool check rules /tmp/r.yml' \
+  < kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
+
+# routing (amtool needs the secret files to exist locally; point the *_file keys at dummies)
+amtool check-config alertmanager.yml
+```
+
+The Prometheus and Alertmanager ConfigMaps are generated with content hashes, so a config change
+produces a new ConfigMap name and forces a real rollout. A green Flux reconcile does mean the
+process picked it up — unlike the `alloy-config` ConfigMap, which is pinned with
+`disableNameSuffixHash` and still needs a manual restart.
+
+## Known noise sources
+
+- **Job and CronJob pods.** `kube_pod_container_status_restarts_total` counts retries of
+  `restartPolicy: OnFailure` pods, so a retrying Job can trip the warning. Nothing currently
+  does this often enough to matter; if one starts, exclude it with a label matcher on the rule
+  rather than widening the threshold.
+- **Node reboots.** A power event or node drain restarts everything at once and will produce a
+  burst of warnings. See `hawkfield-power-cut-2026-08-02` for what that looks like.
+
+## Not yet covered
+
+- **No watchdog.** If Prometheus or Alertmanager is down, you get silence rather than an alert.
+  The standard fix is an always-firing `Watchdog` rule routed to an external heartbeat service
+  (healthchecks.io or similar) that alarms when the pings stop. Worth adding before relying on
+  this pipeline for anything critical.
+- **No alerting on anything other than restarts** — no disk, memory, certificate expiry, or
+  target-down rules yet.

--- a/kubernetes/flux/infrastructure/base/monitoring/alertmanager.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/alertmanager.yml
@@ -1,0 +1,110 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alertmanager
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/instance: k8s
+    app.kubernetes.io/name: alertmanager
+    app.kubernetes.io/part-of: kube-prometheus
+spec:
+  replicas: 1
+  # Silences and the notification log live on shared NFS — never overlap two pods.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: alertmanager
+      app.kubernetes.io/instance: k8s
+      app.kubernetes.io/name: alertmanager
+      app.kubernetes.io/part-of: kube-prometheus
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: alertmanager
+        app.kubernetes.io/instance: k8s
+        app.kubernetes.io/name: alertmanager
+        app.kubernetes.io/part-of: kube-prometheus
+    spec:
+      containers:
+        - name: alertmanager
+          image: prom/alertmanager:v0.33.1
+          ports:
+            - containerPort: 9093
+              name: http
+          args:
+            - --config.file=/etc/alertmanager/alertmanager.yml
+            - --storage.path=/alertmanager
+            - --web.external-url=https://alertmanager.clinch-home.com
+            # Single replica: disable gossip so it doesn't wait on a peer that never arrives.
+            - --cluster.listen-address=
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
+            runAsUser: 3021
+            runAsGroup: 3021
+          volumeMounts:
+            - mountPath: /etc/alertmanager
+              name: config
+            - mountPath: /etc/alertmanager-secrets
+              name: secrets
+              readOnly: true
+            - mountPath: /alertmanager
+              name: data
+      volumes:
+        - name: config
+          configMap:
+            name: alertmanager.yml
+        - name: secrets
+          secret:
+            secretName: alertmanager-telegram
+            defaultMode: 0400
+        - name: data
+          nfs:
+            path: /mnt/data/alertmanager
+            server: 10.1.2.10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/instance: k8s
+    app.kubernetes.io/name: alertmanager
+    app.kubernetes.io/part-of: kube-prometheus
+spec:
+  selector:
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/instance: k8s
+    app.kubernetes.io/name: alertmanager
+    app.kubernetes.io/part-of: kube-prometheus
+  ports:
+    - name: http
+      port: 9093
+      targetPort: http
+      protocol: TCP

--- a/kubernetes/flux/infrastructure/base/monitoring/alertmanager.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/alertmanager.yml
@@ -11,7 +11,8 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
 spec:
   replicas: 1
-  # Silences and the notification log live on shared NFS — never overlap two pods.
+  # Silences and the notification log live on shared NFS — never overlap
+  # two pods.
   strategy:
     type: Recreate
   selector:
@@ -38,7 +39,8 @@ spec:
             - --config.file=/etc/alertmanager/alertmanager.yml
             - --storage.path=/alertmanager
             - --web.external-url=https://alertmanager.clinch-home.com
-            # Single replica: disable gossip so it doesn't wait on a peer that never arrives.
+            # Single replica: disable gossip so it doesn't wait on a peer
+            # that never arrives.
             - --cluster.listen-address=
           readinessProbe:
             httpGet:

--- a/kubernetes/flux/infrastructure/base/monitoring/certificate.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/certificate.yml
@@ -16,6 +16,20 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  name: alertmanager-certificate
+  namespace: monitoring
+spec:
+  secretName: alertmanager-certificate-secret
+  issuerRef:
+    name: letsencrypt
+    kind: ClusterIssuer
+  dnsNames:
+    - alertmanager.clinch-home.com
+    - alertmanager.clincha.co.uk
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
   name: grafana-certificate
   namespace: monitoring
 spec:

--- a/kubernetes/flux/infrastructure/base/monitoring/grafana.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/grafana.yml
@@ -11,6 +11,11 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
 spec:
   replicas: 1
+  # Recreate, not RollingUpdate: /var/lib/grafana is a shared NFS mount and the
+  # bleve unified-search index takes an exclusive lock, so a surged second pod
+  # crash-loops until the old one goes away.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/component: grafana

--- a/kubernetes/flux/infrastructure/base/monitoring/ingress.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/ingress.yml
@@ -35,6 +35,37 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  name: alertmanager
+  namespace: monitoring
+spec:
+  ingressClassName: nginx
+  tls:
+    - secretName: alertmanager-certificate-secret
+  rules:
+    - host: alertmanager.clinch-home.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: alertmanager
+                port:
+                  number: 9093
+    - host: alertmanager.clincha.co.uk
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: alertmanager
+                port:
+                  number: 9093
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
   name: grafana
   namespace: monitoring
   annotations:

--- a/kubernetes/flux/infrastructure/base/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/kustomization.yml
@@ -10,6 +10,7 @@ resources:
   - alloy-syslog.yml
   - truenas-api-exporter.yml
   - prometheus.yml
+  - alertmanager.yml
   - grafana.yml
   - certificate.yml
   - ingress.yml

--- a/kubernetes/flux/infrastructure/base/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/prometheus.yml
@@ -11,6 +11,10 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
 spec:
   replicas: 1
+  # Same shared-NFS constraint as Grafana: the TSDB holds an exclusive lock file,
+  # so two pods must never overlap.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/component: prometheus
@@ -38,6 +42,8 @@ spec:
           volumeMounts:
             - mountPath: /etc/prometheus
               name: config
+            - mountPath: /etc/prometheus/rules
+              name: rules
             - mountPath: /prometheus
               name: data
           securityContext:
@@ -58,6 +64,9 @@ spec:
         - name: config
           configMap:
             name: prometheus.yml
+        - name: rules
+          configMap:
+            name: prometheus-rules
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/flux/infrastructure/base/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/prometheus.yml
@@ -11,8 +11,8 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
 spec:
   replicas: 1
-  # Same shared-NFS constraint as Grafana: the TSDB holds an exclusive lock file,
-  # so two pods must never overlap.
+  # Same shared-NFS constraint as Grafana: the TSDB holds an exclusive
+  # lock file, so two pods must never overlap.
   strategy:
     type: Recreate
   selector:

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
@@ -1,0 +1,22 @@
+groups:
+  - name: pod-restarts
+    rules:
+      # 1h window rather than 15m: CrashLoopBackOff caps its backoff at 5 minutes,
+      # so a 15m window tops out around 3 restarts and makes any threshold marginal.
+      - alert: PodRestartingFrequently
+        expr: increase(kube_pod_container_status_restarts_total[1h]) >= 3
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'restarted {{ $value | printf "%.0f" }} times in the last hour'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/pod-restarts.md
+
+      - alert: PodCrashLooping
+        expr: kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff"} == 1
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'stuck in CrashLoopBackOff for over 15 minutes'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/pod-restarts.md

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
@@ -1,8 +1,9 @@
 groups:
   - name: pod-restarts
     rules:
-      # 1h window rather than 15m: CrashLoopBackOff caps its backoff at 5 minutes,
-      # so a 15m window tops out around 3 restarts and makes any threshold marginal.
+      # 1h window rather than 15m: CrashLoopBackOff caps its backoff at
+      # 5 minutes, so a 15m window tops out around 3 restarts, which puts
+      # any threshold right on the boundary and makes it flap.
       - alert: PodRestartingFrequently
         expr: increase(kube_pod_container_status_restarts_total[1h]) >= 3
         for: 10m

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager-telegram.sops.yaml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager-telegram.sops.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: alertmanager-telegram
+    namespace: monitoring
+type: Opaque
+stringData:
+    bot-token: ENC[AES256_GCM,data:fem+5XXdc6t8WmCP9I4rAGWW4/c2io6Cb3gl26aPW2mLu76CR1N7dwOTUuw08Q==,iv:aokHKowIU/fscsneFnmIG37hb3U/Suck1+bAmuZv7GE=,tag:1eUcCHAJXwigZ9q4sFNO8A==,type:str]
+    chat-id: ENC[AES256_GCM,data:b24b1YWztpzLvA==,iv:7Mg+DRBsA3lTkJyCGcOYw4Xz0ZZ2luedcZRl+KJF/90=,tag:SKWCTZMELvh9FLvDYmOrFw==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-07T05:57:02Z"
+    mac: ENC[AES256_GCM,data:jfFM/GHZYagpdqpSW1ua2pzhQfBRBGHgQeXi41NP0SFzFe6EvwHXeFXqDQGAsOSBpW+paHXoVB4ommqtfngksYE0ChpK0jBwGFi1x7yoHA9+nndye0oYVLUJS+YEpdmwnPxUYrBGMXOwRJKwGtn1bGGSjdP/WrO57PNdMRzbmzo=,iv:LQ0Z5SirEz3/p/6uFjq27DZvystj9Skd6OKk5eE5P5Q=,tag:CtSN5ArRe1tMrCph7dgM2Q==,type:str]
+    pgp:
+        - created_at: "2026-08-07T05:57:02Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA+iIV7UXPYO1AQ/+IKhk0oGxCpz+jXFKRjRq2JMKSMvwRUAJ5VakG6Sxn0El
+            dX0mVwSwYoHlNYgXKbJqGU/bQcNuHWseahy4RItm5NHEF00bBsB5MdMCdNpcUJnK
+            AB+l7Zo4+MQGtpT0aXp9hwhoNd0ipwI8NRIHMndwD3RZSn3uHnNmUM42lIWgPya2
+            LBMxPu4NHiALbjYSFEek3nhwkojDm2vzFy0RxI/ymcCvd1p8Zktweotlobndz0TN
+            x+hdVAox4GzfpjVj0iv37Hd3dZMUiaq0OSCU4vrbjwWliUYmd+csW62n/lD9VJLj
+            iCUWjI28DSEGjqGSlAEM7/WTFcIzT6lMX43LPaF/egs5TtlInZHgQaUCQUp58wja
+            YOG6/ZWh0MXsjlmPlkxbVRcuqjuDBmRSUpQbQdNYb6d801M3goY+HEinIUTY0Zcz
+            Fe0cYstYQUkKZV2np88dqGSOg3VVryxIybbfjMZ2zOf5UlhIIM6CqWGaWO2tixbg
+            agiCPt6/mSfhPU8KQWmE2RtY63dgWCHhIYM53ru88EAcFmtfuJ+gPH+yT5QoSnmo
+            MxQFtbvHvcazOju4vqEYadNdGvL7Ij+pQRqk/vbuZCiGcgDVa+lguI0qdxBj9JBq
+            aQK/1RcWWc6oZC/BZGLUVkJ/bMpLOqb6l/tSH+Lq2XKIXSq+NvzqoYflmas4qcjS
+            XgH7LTkBrBtWESl+sRYuEfQZ55R7k6qMFFAteFCD89iotx7tzUJ0zr4PqbyTJYCC
+            MIET0OEhXEb3ZZF9Fp6n6I70Lhywo/GGglCSH0ddln4uLbpyJlB7OhrUwLIUVbw=
+            =shu7
+            -----END PGP MESSAGE-----
+          fp: 76AF39813C2297E8F98C542D42436A07A9BA1DE0
+    version: 3.13.1

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager.yml
@@ -17,7 +17,8 @@ route:
       mute_time_intervals:
         - overnight
       # Retries every 4h, so a warning raised inside the quiet window lands
-      # within an hour or so of it lifting rather than waiting for the 6h default.
+      # within an hour or so of it lifting, rather than waiting on the 6h
+      # default.
       repeat_interval: 4h
 
 time_intervals:
@@ -38,9 +39,15 @@ receivers:
         parse_mode: HTML
         send_resolved: true
         message: |-
-          {{ if eq .Status "firing" }}🔴 <b>FIRING</b>{{ else }}✅ <b>RESOLVED</b>{{ end }} — {{ .CommonLabels.alertname }}
+          {{ if eq .Status "firing" }}🔴 <b>FIRING</b>
+          {{- else }}✅ <b>RESOLVED</b>
+          {{- end }} — {{ .CommonLabels.alertname }}
           {{ range .Alerts -}}
-          <b>{{ .Labels.namespace }}/{{ .Labels.pod }}</b>{{ if .Labels.container }} ({{ .Labels.container }}){{ end }}
+          <b>{{ .Labels.namespace }}/{{ .Labels.pod }}</b>
+          {{- if .Labels.container }} ({{ .Labels.container }})
+          {{- end }}
           {{ .Annotations.summary }}
-          {{ if .Annotations.runbook_url }}<a href="{{ .Annotations.runbook_url }}">Runbook</a>{{ end }}
+          {{- if .Annotations.runbook_url }}
+          <a href="{{ .Annotations.runbook_url }}">Runbook</a>
+          {{- end }}
           {{ end }}

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager.yml
@@ -1,0 +1,46 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: telegram
+  group_by: ['alertname', 'namespace']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 6h
+  routes:
+    - receiver: telegram
+      matchers:
+        - severity = "critical"
+    - receiver: telegram
+      matchers:
+        - severity = "warning"
+      mute_time_intervals:
+        - overnight
+      # Retries every 4h, so a warning raised inside the quiet window lands
+      # within an hour or so of it lifting rather than waiting for the 6h default.
+      repeat_interval: 4h
+
+time_intervals:
+  - name: overnight
+    time_intervals:
+      - location: Europe/London
+        times:
+          - start_time: '23:00'
+            end_time: '24:00'
+          - start_time: '00:00'
+            end_time: '07:00'
+
+receivers:
+  - name: telegram
+    telegram_configs:
+      - bot_token_file: /etc/alertmanager-secrets/bot-token
+        chat_id_file: /etc/alertmanager-secrets/chat-id
+        parse_mode: HTML
+        send_resolved: true
+        message: |-
+          {{ if eq .Status "firing" }}🔴 <b>FIRING</b>{{ else }}✅ <b>RESOLVED</b>{{ end }} — {{ .CommonLabels.alertname }}
+          {{ range .Alerts -}}
+          <b>{{ .Labels.namespace }}/{{ .Labels.pod }}</b>{{ if .Labels.container }} ({{ .Labels.container }}){{ end }}
+          {{ .Annotations.summary }}
+          {{ if .Annotations.runbook_url }}<a href="{{ .Annotations.runbook_url }}">Runbook</a>{{ end }}
+          {{ end }}

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager.yml
@@ -29,7 +29,7 @@ time_intervals:
           - start_time: '23:00'
             end_time: '24:00'
           - start_time: '00:00'
-            end_time: '07:00'
+            end_time: '06:00'
 
 receivers:
   - name: telegram

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
@@ -6,6 +6,7 @@ resources:
   - ../../base/monitoring
   - truenas-api-key.sops.yaml
   - loki-rustfs-creds.sops.yaml
+  - alertmanager-telegram.sops.yaml
 configurations:
   - nameref-helmrelease.yml
 configMapGenerator:
@@ -13,6 +14,14 @@ configMapGenerator:
     namespace: monitoring
     files:
       - prometheus.yml
+  - name: prometheus-rules
+    namespace: monitoring
+    files:
+      - alert-rules.yml
+  - name: alertmanager.yml
+    namespace: monitoring
+    files:
+      - alertmanager.yml
   - name: alloy-values
     namespace: monitoring
     files:

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
@@ -3,8 +3,12 @@ global:
   evaluation_interval: 15s
 
 rule_files:
-  # - "first.rules"
-  # - "second.rules"
+  - /etc/prometheus/rules/*.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager.monitoring.svc:9093']
 
 scrape_configs:
   - job_name: prometheus

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval:     15s
+  scrape_interval: 15s
   evaluation_interval: 15s
 
 rule_files:
@@ -20,16 +20,17 @@ scrape_configs:
   - job_name: kubernetes-hawkfield
     static_configs:
       - targets:
-        - '10.1.2.101:9100'
-        - '10.1.2.102:9100'
-        - '10.1.2.103:9100'
+          - '10.1.2.101:9100'
+          - '10.1.2.102:9100'
+          - '10.1.2.103:9100'
   # TrueNAS (hawkstore) metrics: pushed via Graphite to the graphite_exporter,
   # re-exposed in Prometheus format and scraped here. Single scrape point.
   - job_name: truenas-hawkstore
     static_configs:
       - targets: ['graphite-exporter.monitoring.svc:9108']
-  # TrueNAS depth (ZFS pools/datasets/scrub + disk temps) polled from the NAS API
-  # by truenas-api-exporter. Each scrape is a full API roundtrip, so poll gently.
+  # TrueNAS depth (ZFS pools/datasets/scrub + disk temps) polled from the NAS
+  # API by truenas-api-exporter. Each scrape is a full API roundtrip, so poll
+  # gently.
   - job_name: truenas-api
     scrape_interval: 60s
     static_configs:


### PR DESCRIPTION
## The Grafana problem

`grafana-f7fc89fb5-vzzqs` had been in `CrashLoopBackOff` for 24h with 286 restarts — while Grafana itself stayed up and served normally.

Renovate bumped `13.1.1 → 13.1.2`. The Deployment used the default `RollingUpdate` strategy, and at `replicas: 1` a `maxSurge` of 25% rounds *up* to 1 — so Kubernetes started the new pod before removing the old one. Both mount `/mnt/data/grafana` over NFS, and Grafana's bleve unified-search index takes an exclusive lock:

```
level=error msg="index is locked by another process"
  indexDir=/var/lib/grafana/unified-search/bleve/... err=timeout
Error: ✗ index is locked by another process
```

The rollout sat at `ProgressDeadlineExceeded` for 24 hours while the old ReplicaSet kept serving, which is why nothing looked broken from outside.

Fixed with `strategy: Recreate`. Prometheus has the same latent bug (TSDB lock file on NFS) and is fixed too — it just hasn't been bumped recently enough to trip it.

## Alerting

There was no alerting at all: `rule_files` was empty, no `alerting:` block, no Alertmanager. The `monitoring.coreos.com` CRDs on the cluster are vestigial — there's no Prometheus Operator, so rules go in a ConfigMap rather than a `PrometheusRule`.

| Alert | Severity | Fires when |
| --- | --- | --- |
| `PodRestartingFrequently` | warning | 3+ restarts in 1h, sustained 10m |
| `PodCrashLooping` | critical | `CrashLoopBackOff` for 15m |

Cluster-wide, all namespaces. The warning uses a 1h window because CrashLoopBackOff caps its backoff at 5 minutes — a 15m window tops out near 3 restarts, so any threshold on it flaps.

Routing per the agreed design: resolved notifications on, warning/critical split, warnings muted 23:00–06:00 Europe/London. Delivered through the existing `clincha_grafana_bot`.

Because this repo is public, the bot token **and** chat ID live in a SOPS secret and are read via `bot_token_file` / `chat_id_file`, keeping the routing config itself reviewable in git.

## Out-of-band changes

Not in this diff, already applied to hawkstore:
- `alertmanager` user/group at uid/gid 3021 (next free per `Documentation/hawkstore-accounts.md`)
- dataset `data/alertmanager`, owned `3021:3021`, mode 0770
- NFS share for `/mnt/data/alertmanager`

Bot token also stored in Bitwarden as `Alertmanager Telegram bot`.

## Validation

- `amtool check-config` — SUCCESS
- `promtool check rules` — 2 rules
- `promtool check config` — valid, 1 rule file
- `kubectl kustomize` builds; ConfigMap hash suffixes resolve, so config edits force a real rollout

## Known gaps (documented in the runbook)

- No inhibition, so a crash-looping pod sends both a warning and a critical.
- No watchdog — if Prometheus or Alertmanager dies you get silence, not an alert.
- Muting is suppression, not queueing: a warning that fires *and* resolves inside the quiet window is never announced. (A warning still firing when the window lifts *is* delivered — verified against a real Alertmanager.)
- Quiet hours end at 06:00 but the Plex Butler run goes to 07:00, so Butler-driven restarts in that last hour will reach Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
