### PR TITLE
Record what each hawkstore app is for

### DIFF
--- a/Documentation/hawkstore/apps.md
+++ b/Documentation/hawkstore/apps.md
@@ -1,0 +1,73 @@
+# hawkstore apps
+
+What each TrueNAS app on hawkstore (`10.1.2.10`) is for, named by its **consumer** rather than
+by its software.
+
+hawkstore is **not managed as code** — apps are installed and configured through the TrueNAS
+UI/API, so this page is the only record of intent. TrueNAS catalog apps have **no editable
+description or notes field**: `description` comes from the catalog and is read-only, so there is
+nowhere on the box to write "this one backs uptime-kuma". If you add, remove or repurpose an app,
+change this page in the same sitting or the knowledge is gone.
+
+Written **2026-08-07** (clincha-org/clincha#407), after two database apps had sat running for
+weeks with nothing recording what they served.
+
+## Current apps
+
+| app | version | serves | data | published port |
+|---|---|---|---|---|
+| `rustfs` | 1.0.0-beta.11 | Terraform remote state and cluster kubeconfigs. Object store for the whole homelab; replaced MinIO 2026-07-30. Managed by `terraform/rustfs`. | `/mnt/userstore/s3` | 30292, 30293 on `0.0.0.0` |
+| `mariadb` | 11.8.8 | **uptime-kuma**, the status page at `status.clincha.co.uk`. Sole consumer. | `/mnt/.ix-apps/app_mounts/mariadb/data` (local ZFS) | 3306 on `10.1.2.10` |
+| `tdarr-node` | 2.85.01 | Transcoding worker for the Tdarr server in the cluster. Reads the media library directly off the NAS rather than over the network. | `/mnt/data/media` (ro work), transcodes under `app_mounts/tdarr-node` | none |
+
+### mariadb
+
+Stood up 2026-08-02 (#404) to get uptime-kuma off SQLite. Its `/app/data` lived on an NFS mount
+where fsync costs 58–105 ms against 7 ms locally, so a single WAL insert took ~558 ms, the
+readiness and liveness probes both blew, and the pod restarted 228 times in 5 days.
+
+The Kubernetes side is in this repo at
+`kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml` — `externalDatabase` pointing
+at `10.1.2.10:3306`, database `uptime_kuma`, credentials from the
+`uptime-kuma-mariadb-credentials` secret. Root and application passwords are in the Bitwarden
+item **`Uptime Kuma MariaDB`**.
+
+Deliberately on `.ix-apps` (local ZFS) and not on `data` — putting it on NFS would recreate the
+exact problem it was installed to solve. It is snapshotted and replicated regardless; see
+[backup-policy.md](backup-policy.md). Monitor *definitions* come from `terraform/uptime-kuma`, so
+they are reproducible, but the monitoring **history** exists only here.
+
+Port 3306 binds to `10.1.2.10` alone as of 2026-08-07. It was previously published on every
+interface — `0.0.0.0` and `::`, which on this box means `docker0`, three compose bridges and
+`incusbr0` as well as the LAN. The k8s nodes reach it over the LAN address, so nothing legitimate
+used the others. Narrowing it drops existing connections: uptime-kuma logs
+`Connection lost: The server closed the connection` and reconnects through its pool without
+restarting the pod.
+
+## Removed
+
+### mongodb — removed 2026-08-07
+
+Installed 2026-07-28, removed under #407 with Angus's confirmation. It served nothing.
+
+Evidence, for the next person who wonders whether it was load-bearing: across the app's entire
+lifetime the container log held **397,351 connections and every one came from `127.0.0.1`** — the
+TrueNAS healthcheck's own `mongosh` probe, every 30 seconds. No client ever connected over the
+network. Nothing in this repo, in `/source`, or in any Deployment, StatefulSet or ConfigMap in
+the cluster referenced `27017`, `mongo` or a `mongodb://` URL.
+
+It did hold data, which the first pass at #407 missed. One database `systems-system`, an empty
+`systems` collection and a `habits` collection containing a single document,
+`{ name: 'Recipe selection' }` — the start of a habit tracker, whose ObjectId dates it to
+**2025-08-04**, a year before this container existed. Two things made it easy to miss: the app's
+configured database name was `system-systems`, the reverse of the real one, and the 496 MB on
+disk was almost entirely `diagnostic.data`, MongoDB's own FTDC metrics. Actual user data was
+135 KB.
+
+Both a `mongodump` archive and a tar of the data directory are at
+`/mnt/backups/apps/mongodb-decommission-20260807/`, so the document is recoverable.
+
+Its data lived at `/mnt/userstore/mongodb` — a bare directory on the `userstore` **root**
+dataset, not a dataset of its own, so it could never have been snapshotted or replicated
+independently. That directory is now deleted, which also closes item 6 of #408. Port 27017 is no
+longer listening.

--- a/Documentation/hawkstore/backup-policy.md
+++ b/Documentation/hawkstore/backup-policy.md
@@ -62,7 +62,8 @@ buckets as they stood immediately before deletion, so what was discarded is at l
 Note that `cclinch/Documents` was kept while `aclinch/Documents` was not.
 
 `userstore/ix-apps/app_mounts/mariadb/data` is the MariaDB behind uptime-kuma. Its monitor
-definitions come from terraform, but the monitoring *history* only exists here.
+definitions come from terraform, but the monitoring *history* only exists here. What every app
+on the box is for is in [apps.md](apps.md).
 
 ### Schedules
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Per-machine hardware spec sheets — board, CPU, memory, drives, free slots and 
 
 What the NAS backs up, what it deliberately does not, and why — [Documentation/hawkstore/backup-policy.md](Documentation/hawkstore/backup-policy.md).
 
+What each app on the NAS is for, and what has been removed — [Documentation/hawkstore/apps.md](Documentation/hawkstore/apps.md).
+
 ## Workflow Status
 
 ### Infrastructure


### PR DESCRIPTION
Closes #407.

hawkstore ran four apps with no record of what two of them were for. TrueNAS catalog apps have **no editable description or notes field** — `description` comes from the catalog and is read-only — so there is nowhere on the box to write it down. The repo has to carry it, hence `Documentation/hawkstore/apps.md`.

## mariadb — kept, documented

It is the live uptime-kuma backend: 28 tables, 14 monitors, 8.5k heartbeats. The issue described it as an empty schema, which was a snapshot taken mid-migration; a later comment on #407 had already flagged that half as stale.

Its published port went from every interface (`0.0.0.0` and `::` — which on this box means `docker0`, three compose bridges and `incusbr0` as well as the LAN) to `10.1.2.10` alone. The k8s nodes reach it over the LAN, so nothing legitimate used the others. Applied live; uptime-kuma logged `Connection lost: The server closed the connection` and reconnected through its pool without restarting the pod. Heartbeats verified still writing afterwards, 5s behind the DB clock.

## mongodb — removed

Angus confirmed. Across the app's whole lifetime the log held **397,351 connections, every one from `127.0.0.1`** — the TrueNAS healthcheck's `mongosh` probe every 30s. No network client ever connected, and nothing in this repo, `/source` or any Deployment/StatefulSet/ConfigMap referenced `27017`, `mongo` or a `mongodb://` URL.

It was **not** empty, which the original investigation missed. Database `systems-system` held a `habits` collection with one document, `{ name: 'Recipe selection' }`, ObjectId-dated 2025-08-04 — a year before the container existed. Two things hid it: the app's configured database name was `system-systems`, the reverse of the real one, and the 496 MB on disk was almost all `diagnostic.data` (MongoDB's own FTDC metrics) against 135 KB of actual data.

A `mongodump` archive and a tar of the data directory are at `/mnt/backups/apps/mongodb-decommission-20260807/`, so it is reversible. App deleted, `/mnt/userstore/mongodb` deleted, 27017 no longer listening.

This also closes item 6 of #408.

## Not done

The issue asked for the purpose to be recorded in the app's TrueNAS description/notes field. That field does not exist for catalog apps — I checked the app schema, and the only writable free text is a Docker label under Labels Configuration, which shows in the app's edit form but not in the apps list. So reading the apps list still will not tell you what `mariadb` is for; the README and `apps.md` are the answer instead. Say if you want the labels set as well and I will add them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)