### PR TITLE
Drop dead :9100 node_exporter scrape targets

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
@@ -14,15 +14,6 @@ scrape_configs:
   - job_name: prometheus
     static_configs:
       - targets: ['localhost:9090']
-  - job_name: clincha-main
-    static_configs:
-      - targets: ['10.2.0.51:9100']
-  - job_name: kubernetes-hawkfield
-    static_configs:
-      - targets:
-          - '10.1.2.101:9100'
-          - '10.1.2.102:9100'
-          - '10.1.2.103:9100'
   # TrueNAS (hawkstore) metrics: pushed via Graphite to the graphite_exporter,
   # re-exposed in Prometheus format and scraped here. Single scrape point.
   - job_name: truenas-hawkstore


### PR DESCRIPTION
## What

Remove the `clincha-main` and `kubernetes-hawkfield` static scrape jobs (`10.2.0.51:9100`, `10.1.2.101/102/103:9100`).

## Why

All four targets have had `up=0` for 30d+ (verified: `max_over_time(up[7d]) == 0` for every one). Host metrics actually arrive via Alloy's `integrations/unix` job, so these are superseded config, not an outage — but they keep `up==0` permanently non-empty, which pre-poisons any "targets down" alert or panel.

No alert rule in `alert-rules.yml` references either job, so nothing downstream breaks.

## Verification

- `kubectl kustomize` builds clean.
- After merge, remaining targets should be `prometheus`, `truenas-hawkstore`, `truenas-api`, all `up=1`, and `up==0` should return empty.

Historical `up=0` samples for these instances are being purged from the TSDB separately — removing the job stops new samples but does not retroactively clear the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)