### PR TITLE
Fix Alertmanager Telegram secret permissions

### DIFF
--- a/kubernetes/flux/infrastructure/base/monitoring/alertmanager.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/alertmanager.yml
@@ -29,6 +29,10 @@ spec:
         app.kubernetes.io/name: alertmanager
         app.kubernetes.io/part-of: kube-prometheus
     spec:
+      # Secret files land root-owned; fsGroup is what makes them group-readable
+      # by the alertmanager user.
+      securityContext:
+        fsGroup: 3021
       containers:
         - name: alertmanager
           image: prom/alertmanager:v0.33.1
@@ -83,7 +87,7 @@ spec:
         - name: secrets
           secret:
             secretName: alertmanager-telegram
-            defaultMode: 0400
+            defaultMode: 0440
         - name: data
           nfs:
             path: /mnt/data/alertmanager


### PR DESCRIPTION
## Problem

Every Telegram notification since #425 has failed. Alertmanager logs, on repeat since 06:41 today:

```
Notify for alerts failed ... err="telegram/telegram[0]: notify retry canceled after 17 attempts:
could not read /etc/alertmanager-secrets/bot-token: open /etc/alertmanager-secrets/bot-token: permission denied"
```

The secret volume mounts `defaultMode: 0400` and the files land `root:root`, but the container runs as `runAsUser: 3021`. So the alertmanager process cannot read its own bot token or chat ID.

`alertmanager_notifications_failed_total{integration="telegram",reason="other"}` was 11 with zero successful deliveries.

## Fix

Pod-level `fsGroup: 3021` (which makes kubelet chgrp the secret files) plus `defaultMode: 0440`. Same pattern already used by `loki` (3018) and `alloy-syslog` (473).

Verified by patching the live Deployment: files became `root:3021` mode `0440` and both were readable as uid 3021. Flux then reverted the patch, so this PR is what makes it stick.

```
-r--r-----    1 root     3021            46 bot-token
-r--r-----    1 root     3021            10 chat-id
```

## Note

`alertmanager_notifications_total` counts *attempts*, not deliveries — it increments even when the notify fails. It was the counter used to sign off #425 as working end-to-end, which is how this went unnoticed. `alertmanager_notifications_failed_total` is the one to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)