### PR TITLE
Add off-site watchdog in London

### DIFF
--- a/.github/workflows/ansible-watchdog.yaml
+++ b/.github/workflows/ansible-watchdog.yaml
@@ -1,0 +1,43 @@
+name: Ansible watchdog
+permissions:
+  contents: read
+on:
+  push:
+    branches:
+      - "master"
+    paths:
+      - '.github/workflows/ansible-watchdog.yaml'
+      - 'Ansible/roles/watchdog/**'
+      - 'Ansible/watchdog.yml'
+  workflow_dispatch:
+concurrency:
+  group: "watchdog"
+jobs:
+  watchdog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Set up Ansible
+        uses: ./.github/actions/ansible-setup
+        with:
+          vault-password: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
+          ssh-private-key: ${{ secrets.ANSIBLE_PRIVATE_KEY }}
+
+      - name: Run watchdog playbook
+        working-directory: Ansible
+        env:
+          PROXMOX_TOKEN_SECRET: ${{ secrets.PROXMOX_TOKEN_LONDON_ANSIBLE }}
+          WATCHDOG_ADMIN_PASSWORD: ${{ secrets.WATCHDOG_ADMIN_PASSWORD }}
+        run: |
+          ansible-playbook watchdog.yml \
+            --inventory inventory/london.proxmox.yml \
+            --vault-password-file vault

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -10,6 +10,7 @@ on:
       - "terraform/**"
       # Has its own workflow; this one would plan three Proxmox sites for nothing.
       - "!terraform/uptime-kuma/**"
+      - "!terraform/watchdog/**"
       - ".github/workflows/terraform-plan.yaml"
 
 concurrency:

--- a/.github/workflows/terraform-watchdog.yaml
+++ b/.github/workflows/terraform-watchdog.yaml
@@ -41,6 +41,26 @@ jobs:
           ts-oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           ts-oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
 
+      # The runner reaches London through the "London" subnet router rather
+      # than the "Bristol" one every other stack uses, so a Tailscale ACL that
+      # allows 22 but not 3001 shows up here as a provider timeout with no
+      # hint about the cause. Probe both so the error names the problem.
+      - name: Verify the watchdog is reachable
+        shell: bash
+        run: |
+          for port in 22 3001; do
+            if nc -z -w5 10.2.2.101 "$port"; then
+              echo "10.2.2.101:$port reachable"
+            else
+              echo "10.2.2.101:$port UNREACHABLE"
+            fi
+          done
+          nc -z -w5 10.2.2.101 3001 || {
+            echo "::error::Cannot reach the watchdog on 10.2.2.101:3001 —" \
+              "check the Tailscale ACL for tag:ci"
+            exit 1
+          }
+
       - name: Terraform Init
         run: |
           terraform init \

--- a/.github/workflows/terraform-watchdog.yaml
+++ b/.github/workflows/terraform-watchdog.yaml
@@ -41,25 +41,19 @@ jobs:
           ts-oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           ts-oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
 
-      # The runner reaches London through the "London" subnet router rather
-      # than the "Bristol" one every other stack uses, so a Tailscale ACL that
-      # allows 22 but not 3001 shows up here as a provider timeout with no
-      # hint about the cause. Probe both so the error names the problem.
+      # London is reached through its own subnet router, not the one every
+      # other stack uses. The provider reports any problem as a bare
+      # "connection timed out", so check the socket first to separate a
+      # routing fault from uptime-kuma being wedged.
       - name: Verify the watchdog is reachable
         shell: bash
         run: |
-          for port in 22 3001; do
-            if nc -z -w5 10.2.2.101 "$port"; then
-              echo "10.2.2.101:$port reachable"
-            else
-              echo "10.2.2.101:$port UNREACHABLE"
-            fi
-          done
           nc -z -w5 10.2.2.101 3001 || {
             echo "::error::Cannot reach the watchdog on 10.2.2.101:3001 —" \
-              "check the Tailscale ACL for tag:ci"
+              "check the London subnet route is up"
             exit 1
           }
+          echo "watchdog reachable"
 
       - name: Terraform Init
         run: |

--- a/.github/workflows/terraform-watchdog.yaml
+++ b/.github/workflows/terraform-watchdog.yaml
@@ -1,0 +1,106 @@
+name: Terraform Watchdog
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    paths:
+      - 'terraform/watchdog/**'
+      - '.github/workflows/terraform-watchdog.yaml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'terraform/watchdog/**'
+      - '.github/workflows/terraform-watchdog.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: terraform-watchdog
+  cancel-in-progress: false
+
+jobs:
+  terraform:
+    # Separate from terraform.yaml because that workflow passes
+    # -var="pm_api_token_secret" to every stack in its matrix, and Terraform
+    # errors on a -var it has no declaration for.
+    name: Plan and apply
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform/watchdog
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Terraform
+        uses: ./.github/actions/terraform-setup
+        with:
+          ts-oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          ts-oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+
+      - name: Terraform Init
+        run: |
+          terraform init \
+            -backend-config="secret_key=${{ secrets.RUSTFS_SECRET_KEY }}"
+
+      - name: Terraform Format
+        run: terraform fmt -check -diff
+
+      - name: Terraform Plan
+        id: plan
+        env:
+          TF_VAR_password: ${{ secrets.WATCHDOG_ADMIN_PASSWORD }}
+          TF_VAR_telegram_bot_token:
+            ${{ secrets.UPTIME_KUMA_TELEGRAM_BOT_TOKEN }}
+          TF_VAR_telegram_chat_id:
+            ${{ secrets.UPTIME_KUMA_TELEGRAM_CHAT_ID }}
+        # continue-on-error so a failed plan still gets posted to the PR; the
+        # gate below turns it back into a job failure. pipefail because the
+        # exit code of a pipeline is tee's, which would hide the failure.
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          terraform plan -no-color -out=tfplan | tee plan_output.txt
+
+      - name: Post plan to the PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'terraform/watchdog/plan_output.txt';
+            let plan = 'plan output not available';
+            try {
+              plan = fs.readFileSync(path, 'utf8');
+            } catch (e) {
+              // plan may have failed before writing anything
+            }
+            const body = '### Terraform plan — watchdog\n\n'
+              + '<details><summary>Show plan</summary>\n\n'
+              + '```terraform\n' + plan.slice(-60000) + '\n```\n\n'
+              + '</details>';
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
+
+      - name: Fail if the plan failed
+        if: steps.plan.outcome == 'failure'
+        run: |
+          echo "::error::terraform plan failed — see the step above"
+          exit 1
+
+      - name: Terraform Apply
+        if: github.event_name != 'pull_request'
+        env:
+          TF_VAR_password: ${{ secrets.WATCHDOG_ADMIN_PASSWORD }}
+          TF_VAR_telegram_bot_token:
+            ${{ secrets.UPTIME_KUMA_TELEGRAM_BOT_TOKEN }}
+          TF_VAR_telegram_chat_id:
+            ${{ secrets.UPTIME_KUMA_TELEGRAM_CHAT_ID }}
+        run: terraform apply -auto-approve tfplan

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -10,6 +10,7 @@ on:
       - 'terraform/**'
       # Has its own workflow; this one would apply three Proxmox sites for nothing.
       - '!terraform/uptime-kuma/**'
+      - '!terraform/watchdog/**'
   workflow_dispatch:
 jobs:
   plan:

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ terraform/**/.terraform/
 terraform/**/.terraform.lock.hcl
 terraform/**/*.tfstate
 terraform/**/*.tfstate.backup
+terraform/**/tfplan
+terraform/**/plan_output.txt
 
 # IDE
 .idea/

--- a/.yamllint
+++ b/.yamllint
@@ -10,6 +10,7 @@ rules:
       - 'kubernetes/flux/infrastructure/base/media/controller/secret.yml'
       - 'kubernetes/flux/infrastructure/hawkfield/monitoring/loki-rustfs-creds.sops.yaml'
       - 'kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager-telegram.sops.yaml'
+      - 'kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager-watchdog.sops.yaml'
       # runbook_url is an 88-char GitHub blob URL that cannot wrap.
       - 'kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml'
       - 'kubernetes/flux/infrastructure/hawkfield/uptime-kuma/mariadb-credentials.sops.yaml'

--- a/Ansible/galaxy-requirements.yml
+++ b/Ansible/galaxy-requirements.yml
@@ -11,13 +11,17 @@ collections:
   - name: "ansible.posix"
     version: "2.1.0"
 
+  - name: "community.docker"
+    version: "5.1.0"
+
   - name: "kubernetes.core"
     version: "6.2.0"
 
   - name: "https://github.com/kubernetes-sigs/kubespray"
     type: git
-    # First release on ansible-core 2.18, required for CVE-2026-11332. Do not go
-    # below v2.29.1 — that added the hostendpoints "watch" RBAC (kubespray#11076).
+    # First release on ansible-core 2.18, required for CVE-2026-11332. Do not
+    # go below v2.29.1 — that added the hostendpoints "watch" RBAC
+    # (kubespray#11076).
     version: v2.31.0
 
   - name: "ansible.netcommon"

--- a/Ansible/inventory/london.proxmox.yml
+++ b/Ansible/inventory/london.proxmox.yml
@@ -19,5 +19,8 @@ groups:
   kube_control_plane: "'kubernetes_master' in (proxmox_tags_parsed|list)"
   etcd: "'kubernetes_master' in (proxmox_tags_parsed|list)"
   kube_node: "'kubernetes_worker' in (proxmox_tags_parsed|list)"
-  k8s_cluster: "'kubernetes_worker' in (proxmox_tags_parsed|list) or 'kubernetes_master' in (proxmox_tags_parsed|list)"
+  k8s_cluster: >-
+    'kubernetes_worker' in (proxmox_tags_parsed|list) or
+    'kubernetes_master' in (proxmox_tags_parsed|list)
   adguard: "'adguard' in (proxmox_tags_parsed|list)"
+  watchdog: "'watchdog' in (proxmox_tags_parsed|list)"

--- a/Ansible/roles/watchdog/defaults/main.yml
+++ b/Ansible/roles/watchdog/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# 2.4.0 is the floor for the breml/uptimekuma Terraform provider — see
+# terraform/uptime-kuma.
+watchdog_image: "louislam/uptime-kuma:2.4.0"
+watchdog_data_dir: "/var/lib/uptime-kuma"
+watchdog_script_dir: "/opt/uptime-kuma"
+watchdog_port: 3001
+watchdog_bind_address: "{{ ansible_default_ipv4.address }}"
+watchdog_admin_username: "clincha"
+watchdog_admin_password: "{{ lookup('env', 'WATCHDOG_ADMIN_PASSWORD') }}"

--- a/Ansible/roles/watchdog/files/admin-bootstrap.js
+++ b/Ansible/roles/watchdog/files/admin-bootstrap.js
@@ -1,0 +1,34 @@
+const { io } = require("socket.io-client");
+
+const url = process.env.KUMA_URL;
+const username = process.env.KUMA_USERNAME;
+const password = process.env.KUMA_PASSWORD;
+
+const done = (code, msg) => {
+    console.log(msg);
+    process.exit(code);
+};
+
+// Leave transports at the default. Forcing ["websocket"] gets as far as an
+// accepted connection server-side but never completes the Socket.IO handshake,
+// so the client sits waiting for a "connect" that never arrives. The default
+// polling-then-upgrade path lands on websocket anyway.
+const socket = io(url, { timeout: 10000 });
+
+setTimeout(() => done(1, "timed out waiting for uptime-kuma"), 60000);
+
+socket.on("connect_error", (err) => done(1, `connect failed: ${err.message}`));
+
+socket.on("connect", () => {
+    socket.emit("setup", username, password, (res) => {
+        if (res.ok) {
+            return done(0, `created admin user '${username}'`);
+        }
+        // Server-side guard: re-running against a populated user table is the
+        // expected steady state, not a failure.
+        if (/has been initialized/.test(res.msg || "")) {
+            return done(0, "admin user already exists, nothing to do");
+        }
+        done(1, `setup failed: ${res.msg}`);
+    });
+});

--- a/Ansible/roles/watchdog/files/admin-bootstrap.js
+++ b/Ansible/roles/watchdog/files/admin-bootstrap.js
@@ -21,8 +21,10 @@ socket.on("connect_error", (err) => done(1, `connect failed: ${err.message}`));
 
 socket.on("connect", () => {
     socket.emit("setup", username, password, (res) => {
+        // The username comes from the environment; interpolating it into the
+        // log is what CodeQL flags as clear-text logging of sensitive data.
         if (res.ok) {
-            return done(0, `created admin user '${username}'`);
+            return done(0, "created admin user");
         }
         // Server-side guard: re-running against a populated user table is the
         // expected steady state, not a failure.

--- a/Ansible/roles/watchdog/tasks/bootstrap.yml
+++ b/Ansible/roles/watchdog/tasks/bootstrap.yml
@@ -1,0 +1,26 @@
+---
+- name: Wait for uptime-kuma to accept connections
+  ansible.builtin.uri:
+    url: "http://{{ watchdog_bind_address }}:{{ watchdog_port }}/"
+    status_code: [200, 302]
+  register: watchdog_ready
+  retries: 30
+  delay: 2
+  until: watchdog_ready is succeeded
+
+# uptime-kuma has no env-based admin bootstrap, so the account is created over
+# Socket.IO. The server refuses a second setup, which makes this idempotent.
+- name: Create the admin user
+  community.docker.docker_container_exec:
+    container: uptime-kuma
+    command: "node /scripts/admin-bootstrap.js"
+    env:
+      # Node resolves modules against the script's own directory, so /scripts
+      # cannot see /app/node_modules without this.
+      NODE_PATH: /app/node_modules
+      KUMA_URL: "http://localhost:3001"
+      KUMA_USERNAME: "{{ watchdog_admin_username }}"
+      KUMA_PASSWORD: "{{ watchdog_admin_password }}"
+  register: watchdog_bootstrap
+  changed_when: "'created admin user' in watchdog_bootstrap.stdout"
+  no_log: true

--- a/Ansible/roles/watchdog/tasks/configure.yml
+++ b/Ansible/roles/watchdog/tasks/configure.yml
@@ -1,0 +1,37 @@
+---
+- name: Create uptime-kuma directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop:
+    - "{{ watchdog_data_dir }}"
+    - "{{ watchdog_script_dir }}"
+
+- name: Install the admin bootstrap script
+  ansible.builtin.copy:
+    src: admin-bootstrap.js
+    dest: "{{ watchdog_script_dir }}/admin-bootstrap.js"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Run uptime-kuma
+  community.docker.docker_container:
+    name: uptime-kuma
+    image: "{{ watchdog_image }}"
+    state: started
+    restart_policy: unless-stopped
+    env:
+      # Without this a fresh data dir parks on the database-setup wizard and
+      # serves HTML on the Socket.IO endpoint, so bootstrap cannot connect.
+      # SQLite is local disk here, not the NFS that forced hawkfield onto
+      # MariaDB.
+      UPTIME_KUMA_DB_TYPE: "sqlite"
+    published_ports:
+      - "{{ watchdog_bind_address }}:{{ watchdog_port }}:3001"
+    volumes:
+      - "{{ watchdog_data_dir }}:/app/data"
+      - "{{ watchdog_script_dir }}:/scripts:ro"

--- a/Ansible/roles/watchdog/tasks/install.yml
+++ b/Ansible/roles/watchdog/tasks/install.yml
@@ -1,0 +1,15 @@
+---
+- name: Install Docker and the Python SDK
+  ansible.builtin.apt:
+    name:
+      - docker.io
+      - python3-docker
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Ensure Docker is enabled and started
+  ansible.builtin.systemd:
+    name: docker
+    enabled: true
+    state: started

--- a/Ansible/roles/watchdog/tasks/main.yml
+++ b/Ansible/roles/watchdog/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Install Docker
+  ansible.builtin.import_tasks: install.yml
+
+- name: Configure uptime-kuma
+  ansible.builtin.import_tasks: configure.yml
+
+- name: Bootstrap the admin user
+  ansible.builtin.import_tasks: bootstrap.yml

--- a/Ansible/watchdog.yml
+++ b/Ansible/watchdog.yml
@@ -1,0 +1,9 @@
+---
+# Deliberately off-site: the watchdog has to outlive whatever it watches, so
+# it runs on its own site with its own internet egress rather than in the
+# hawkfield cluster.
+- name: Install off-site watchdog
+  hosts: watchdog
+  become: true
+  roles:
+    - role: watchdog

--- a/kubernetes/flux/infrastructure/base/monitoring/alertmanager.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/alertmanager.yml
@@ -78,6 +78,9 @@ spec:
             - mountPath: /etc/alertmanager-secrets
               name: secrets
               readOnly: true
+            - mountPath: /etc/alertmanager-watchdog
+              name: watchdog
+              readOnly: true
             - mountPath: /alertmanager
               name: data
       volumes:
@@ -87,6 +90,10 @@ spec:
         - name: secrets
           secret:
             secretName: alertmanager-telegram
+            defaultMode: 0440
+        - name: watchdog
+          secret:
+            secretName: alertmanager-watchdog
             defaultMode: 0440
         - name: data
           nfs:

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
@@ -1,4 +1,16 @@
 groups:
+  # Fires forever on purpose. It proves Prometheus is evaluating rules and
+  # Alertmanager is delivering; the London watchdog alerts when it stops
+  # arriving. Nothing here can detect its own death, which is the point.
+  - name: watchdog
+    rules:
+      - alert: Watchdog
+        expr: vector(1)
+        labels:
+          severity: none
+        annotations:
+          summary: 'alerting pipeline heartbeat'
+
   - name: pod-restarts
     rules:
       # 1h window rather than 15m: CrashLoopBackOff caps its backoff at

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager-watchdog.sops.yaml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager-watchdog.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: alertmanager-watchdog
+    namespace: monitoring
+type: Opaque
+stringData:
+    push-url: ENC[AES256_GCM,data:0xyGpViMu1k+z8CKMoemzWV+MJwV2rM/7xQj5DWlVrCddWWwD0vNaR0ooDb7X6LGL7OoB+hyVbPLNHxFaq3S4g==,iv:6N5XX9rImrLi6eyHdFM0SKrQOC5clW56rWJfhKoz3x8=,tag:JaHU2dk2XxXc366odPQ71g==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-07T15:04:25Z"
+    mac: ENC[AES256_GCM,data:dCnyp//+qw4/kTrY2nWniNBP+c3hWfczc1UmdK+oTCJsv843JF72tCdTkqet5yT0d/jHa+2ibjwdewatdgrAYCwSsdUtJXJ/gFIL9+o75MvSgdxpU3OgS0iD5vzNlSVAvQs2VDiKEZuAxkjpvoaC1U4s9eVtyIo9jMCcqAfSB/A=,iv:X+DB155ZfevyE/y0vhsWtVDT+od/5fALjaPZa2WfGU0=,tag:TG60mY5pYJ8xMJ209QqbyA==,type:str]
+    pgp:
+        - created_at: "2026-08-07T15:04:25Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA+iIV7UXPYO1AQ/+Ou8STxFiL7XoCfFi8SfQV9u10LDNuajA8EBHWoDfpPh5
+            9tne2ZNkuMZwSNzGAE/ywgJQtKTy+bRVmxXvSEbge87knXqjHJ+4sR2SoT+K2BpL
+            PPDsj1NWVrb94GHusyxq/0FaHIN5LEXvFSa7dT13CToFoZ06a5Jz5LePec8NRvsm
+            VtmU58z7z0KmrsHhivmoF5+2BPOCXHxfMCKHnSuZlPM/5RTBIEI34B/Y01NItwGf
+            VSsqFjGw0GUdfE0mSMU9KrOVFRduAW+1moBTmDbOXRbvo4Lx6wiKsGnqxwt+t+u2
+            8MfF+udfbuxHL2CGismsSy0ypw7FTdLYhfeQyh7mmpfLyNokhP3KL4udCA4HhB8u
+            d3Y3j0ePkqYnENatSq8xSvAh5qzpel7JC4Spdq8YHFpiPlR+ez/qSkTCYkotQPiP
+            4x/2QaOx3zrEVE6F0J6hP05gWYEPdBEPh5SVEcxGgYcUkznRoDVHpltfPHKkWL66
+            6bSpx4aGSmx8EXhkosvR597XonLFcqCb5pIDt7q+UOYzq5rYHhmMKPGgkB/mDmFp
+            5dhyOXE952YL+mNk9xJMAM1RGrHOm10WFp77dkJyVgadCCq0cWElQSU/3rlSvt5W
+            hzPOl6Lm5C9COF8KASwwZtN+XclyKI3Qk046q/E0TkXisrRbNH5pKL5NsECql0jS
+            XAGv717CZ4iwACewnctBwTTCnWGE7lkEiG15sNMhMv1QKZmjBT5AT/uQvp0W/u1h
+            6bIbriAGLdBUxN1302K9N67/1aNY3nX2p4sPmQsz421k3fSf9tcBwKOC7J5m
+            =1bAq
+            -----END PGP MESSAGE-----
+          fp: 76AF39813C2297E8F98C542D42436A07A9BA1DE0
+    version: 3.13.1

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager.yml
@@ -8,6 +8,16 @@ route:
   group_interval: 5m
   repeat_interval: 6h
   routes:
+    # First, and never muted: this one is the heartbeat, not an alert. It goes
+    # to London rather than to Angus, and must keep flowing through quiet
+    # hours or the watchdog would fire every night at 23:00.
+    - receiver: watchdog
+      matchers:
+        - alertname = "Watchdog"
+      group_wait: 0s
+      group_interval: 1m
+      repeat_interval: 1m
+
     - receiver: telegram
       matchers:
         - severity = "critical"
@@ -32,6 +42,13 @@ time_intervals:
             end_time: '06:00'
 
 receivers:
+  # The URL carries the push token, so it comes from SOPS rather than sitting
+  # in this file — the repo is public.
+  - name: watchdog
+    webhook_configs:
+      - url_file: /etc/alertmanager-watchdog/push-url
+        send_resolved: false
+
   - name: telegram
     telegram_configs:
       - bot_token_file: /etc/alertmanager-secrets/bot-token

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
@@ -7,6 +7,7 @@ resources:
   - truenas-api-key.sops.yaml
   - loki-rustfs-creds.sops.yaml
   - alertmanager-telegram.sops.yaml
+  - alertmanager-watchdog.sops.yaml
 configurations:
   - nameref-helmrelease.yml
 configMapGenerator:

--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap.js
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap.js
@@ -21,8 +21,10 @@ socket.on("connect_error", (err) => done(1, `connect failed: ${err.message}`));
 
 socket.on("connect", () => {
     socket.emit("setup", username, password, (res) => {
+        // The username comes from the environment; interpolating it into the
+        // log is what CodeQL flags as clear-text logging of sensitive data.
         if (res.ok) {
-            return done(0, `created admin user '${username}'`);
+            return done(0, "created admin user");
         }
         // Server-side guard: re-running against a populated user table is the
         // expected steady state, not a failure.

--- a/terraform/london/main.tf
+++ b/terraform/london/main.tf
@@ -10,7 +10,7 @@ module "k8s-lon-1" {
   boot_disk_size    = "50"
   data_disk_storage = "local-lvm"
   network_bridge    = "vmbr0"
-  tags           = "base,kubernetes_master,kubernetes_worker"
+  tags           = "base,kubernetes_master,kubernetes_worker,watchdog"
 }
 
 module "dns-lon-1" {

--- a/terraform/uptime-kuma/main.tf
+++ b/terraform/uptime-kuma/main.tf
@@ -37,17 +37,26 @@ locals {
     loki  = { url = "https://loki.clinch-home.com" }
 
     "clincha.co.uk" = { url = "https://clincha.co.uk" }
+
+    # The other half of the mutual watch: London monitors hawkfield, hawkfield
+    # monitors London, so neither site can die quietly. Reached by IP over the
+    # site link — it deliberately has no ingress and no DNS name.
+    watchdog = {
+      url                   = "http://10.2.2.101:3001"
+      accepted_status_codes = ["200-299", "302"]
+    }
   }
 }
 
 resource "uptimekuma_monitor_http" "service" {
   for_each = local.monitors
 
-  name             = each.key
-  url              = each.value.url
-  interval         = 60
-  active           = true
-  notification_ids = [uptimekuma_notification_telegram.alert.id]
+  name                  = each.key
+  url                   = each.value.url
+  accepted_status_codes = try(each.value.accepted_status_codes, ["200-299"])
+  interval              = 60
+  active                = true
+  notification_ids      = [uptimekuma_notification_telegram.alert.id]
 }
 
 resource "uptimekuma_status_page" "all" {

--- a/terraform/watchdog/main.tf
+++ b/terraform/watchdog/main.tf
@@ -1,0 +1,60 @@
+resource "uptimekuma_notification_telegram" "alert" {
+  name       = "Watchdog Telegram"
+  bot_token  = var.telegram_bot_token
+  chat_id    = var.telegram_chat_id
+  is_active  = true
+  is_default = true
+}
+
+# The public path: DNS, the internet, the hawkfield router and the ingress all
+# have to work. This is the one that goes dark when the site does.
+resource "uptimekuma_monitor_http" "public" {
+  name             = "hawkfield public"
+  url              = "https://clincha.co.uk"
+  interval         = 60
+  active           = true
+  notification_ids = [uptimekuma_notification_telegram.alert.id]
+}
+
+locals {
+  # The private path, over the site-to-site link. Losing these while the public
+  # monitor stays up means the link broke, not the site.
+  tcp_targets = {
+    "hawkfield ingress" = { hostname = "10.1.2.205", port = 443 }
+    "hawkstore"         = { hostname = "10.1.2.10", port = 443 }
+    # All three control planes individually: hawk-1 carries the VIP and does
+    # not fail over, so one node down is not the same event as the cluster
+    # being gone.
+    "k8s-hawk-1 api" = { hostname = "10.1.2.101", port = 6443 }
+    "k8s-hawk-2 api" = { hostname = "10.1.2.102", port = 6443 }
+    "k8s-hawk-3 api" = { hostname = "10.1.2.103", port = 6443 }
+  }
+}
+
+resource "uptimekuma_monitor_tcp_port" "target" {
+  for_each = local.tcp_targets
+
+  name             = each.key
+  hostname         = each.value.hostname
+  port             = each.value.port
+  interval         = 60
+  active           = true
+  notification_ids = [uptimekuma_notification_telegram.alert.id]
+}
+
+# Dead-man's switch. Alertmanager pushes here every minute; five minutes of
+# silence means the alerting pipeline itself has died, which probing hawkfield
+# from outside would never reveal — the ingress can be perfectly healthy while
+# nothing is able to notify anyone.
+resource "uptimekuma_monitor_push" "alerting" {
+  name             = "hawkfield alerting heartbeat"
+  interval         = 300
+  max_retries      = 0
+  active           = true
+  notification_ids = [uptimekuma_notification_telegram.alert.id]
+}
+
+output "alerting_push_token" {
+  value     = uptimekuma_monitor_push.alerting.push_token
+  sensitive = true
+}

--- a/terraform/watchdog/providers.tf
+++ b/terraform/watchdog/providers.tf
@@ -1,0 +1,31 @@
+terraform {
+  backend "s3" {
+    bucket = "terraform"
+    endpoints = {
+      s3 = "http://10.1.2.10:30293"
+    }
+    key        = "watchdog.tfstate"
+    access_key = "terraform"
+
+    region                      = "main"
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    use_path_style              = true
+  }
+  required_providers {
+    uptimekuma = {
+      source  = "breml/uptimekuma"
+      version = "0.4.0"
+    }
+  }
+}
+
+# The London instance has no ingress and no DNS name — it is deliberately
+# reachable only by IP, so that nothing it monitors is in the path to it.
+provider "uptimekuma" {
+  endpoint = var.endpoint
+  username = var.username
+  password = var.password
+}

--- a/terraform/watchdog/variables.tf
+++ b/terraform/watchdog/variables.tf
@@ -1,0 +1,26 @@
+variable "endpoint" {
+  type    = string
+  default = "http://10.2.2.101:3001"
+}
+
+# Separate instance from terraform/uptime-kuma, so a separate account. Vault
+# item "uptime kuma (watchdog)".
+variable "username" {
+  type    = string
+  default = "clincha"
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
+}
+
+variable "telegram_bot_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "telegram_chat_id" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
## Why

Nothing currently notices if the hawkfield cluster dies or the site loses power. Alertmanager cannot report its own death — that is exactly how a completely broken Telegram integration sat unnoticed all morning (#432). An alert that never fires and an alerting stack that is dead look identical from inside.

## What London gives us

`k8s-lon-1` was a bare, idle Ubuntu VM at the other site. The property that matters:

| | hawkfield | London |
|---|---|---|
| Public IP | `185.23.254.226` | `45.145.49.206` |
| api.telegram.org | via hawkfield | direct, 46 ms |

**Separate internet egress**, so it can still shout when hawkfield is completely dark. It also has two independent paths in — the public internet, and the site-to-site link.

## Two mechanisms

They catch different things, so both are here:

**External probes** (London → hawkfield) catch the cluster or the whole site going away:
- `hawkfield public` — https://clincha.co.uk, the full public path: DNS, internet, router, ingress
- `hawkfield ingress`, `hawkstore`, and all three control planes over the site link

All three control planes are monitored individually because hawk-1 carries the VIP and does not fail over, so one node down is not the same event as the cluster being gone.

**Dead-man's switch** catches the monitoring stack dying while the ingress stays perfectly healthy — the thing probing can never see. A permanently-firing `Watchdog` alert (`expr: vector(1)`) is pushed to a uptime-kuma push monitor every minute; five minutes of silence fires.

**Mutual watching**: hawkfield's uptime-kuma now monitors London too, so neither site can fail quietly.

## Notes for review

- The `Watchdog` route is deliberately **first and never muted**. Routing it through the existing overnight mute would make the watchdog fire every night at 23:00.
- Its push URL carries a token and this repo is public, so it goes through SOPS. Alertmanager reads it with `url_file`, which I verified 0.33.1 supports via `amtool check-config`.
- The London instance deliberately has **no ingress and no DNS name** — reached by IP only, so nothing it monitors sits in the path to it.
- `UPTIME_KUMA_DB_TYPE=sqlite` is required: a fresh data dir otherwise parks on the database-setup wizard and serves HTML on the Socket.IO endpoint, so bootstrap cannot connect. The Helm chart hides this on hawkfield. SQLite is local disk here, not the NFS that forced hawkfield onto MariaDB.
- Two unrelated pre-existing long lines (`galaxy-requirements.yml`, `london.proxmox.yml`) are rewrapped rather than suppressed, because touching those files brings them into the changed-file yamllint job.

## Verified live

- Ansible role applied to k8s-lon-1 and **re-run clean at `changed=0`**
- uptime-kuma up on SQLite, admin bootstrapped, idempotent on re-run
- All 8 Terraform resources applied; monitors are live now
- `amtool check-config` and `promtool check rules` both pass on the new config
- `kubectl kustomize` builds the monitoring overlay
- yamllint and `ansible-lint --strict` (production profile) both clean

**Still to do after merge** (needs repo-secret access I do not have): add `WATCHDOG_ADMIN_PASSWORD` as a GitHub secret — it is in Bitwarden as `uptime kuma (watchdog)`. Without it the two new workflows will fail on their first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)