### PR TITLE
Automerge routine Renovate bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,8 +21,11 @@
     }
   ],
   "dependencyDashboard": false,
-  "prConcurrentLimit": 3,
-  "prHourlyLimit": 2,
+  "minimumReleaseAge": "3 days",
+  "platformAutomerge": false,
+  "automergeStrategy": "squash",
+  "prConcurrentLimit": 6,
+  "prHourlyLimit": 4,
   "ignorePaths": [
     "**/gotk-components.yaml"
   ],
@@ -36,6 +39,11 @@
       "description": "busybox is pinned to no tag, python is a deliberate interpreter pin, and homepage is built and pushed by hand",
       "matchPackageNames": ["busybox", "python", "docker.io/clincha/homepage"],
       "enabled": false
+    },
+    {
+      "description": "Routine bumps merge themselves once CI is green and the release is 3 days old; majors are left for review",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Patch, minor and digest bumps now merge themselves once CI is green. Majors still
open a PR and wait for review.

## What changed

- `automerge: true` on `matchUpdateTypes: [minor, patch, digest]`
- `minimumReleaseAge: "3 days"` — nothing merges until a release has survived three
  days upstream. This is the main guard now that nobody reads the PRs.
- `prConcurrentLimit` 3 → 6, `prHourlyLimit` 2 → 4. Not cosmetic: a PR waiting out
  its three stability days occupies a concurrency slot the whole time, so the old
  limit of 3 would have been permanently full and silently created nothing.
- `platformAutomerge: false` — the repo has `allow_auto_merge: false`, so Renovate
  merges via its own API path.
- `automergeStrategy: squash`.

## Verified, not assumed

Nothing was outdated at the time of writing, so a dry run had no decision to make.
Pushed a throwaway branch with three deliberately stale pins and read Renovate's
real per-branch verdict (`rebaseWhen=auto` conversion is the only readable signal):

| Update | Verdict |
| --- | --- |
| prometheus patch `v2.55.0` → `v2.55.1` | automerge |
| ingress-nginx **helm chart** minor `4.14.0` → `4.15.1` | automerge |
| prometheus major `v2` → `v3.13.2` | held for review |

Also confirmed up front:

- The PAT already has **Commit statuses: read and write**, which `minimumReleaseAge`
  requires — without it Renovate reports the misleading `Repository has changed
  during renovation` and creates nothing. Probed with a real status write.
- No pre-existing yamllint **errors** in any file Renovate can edit (only
  `document-start` warnings, which don't fail the job). Under automerge a stale lint
  error would stall a PR silently, since the dependency dashboard is off.

## Worth knowing

Renovate disables automerge for a PR whose exact title it has merged before, as
revert-loop protection. That's what makes the ingress-nginx row above need
`recreateWhen: always` to test — it won't affect real bumps, whose titles are new.

## Trade-off

clincha's CI is `kustomize build | kubeconform` plus yamllint. That proves a manifest
parses; it does not prove the image tag exists or the pod starts. Minors on
metallb, ingress-nginx and cert-manager will now reach the cluster unreviewed.
Chosen deliberately over a narrower rule that kept the network path manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)