### PR TITLE
Add code quality tooling and fix everything it finds

### DIFF
--- a/.github/workflows/k8s-validate.yaml
+++ b/.github/workflows/k8s-validate.yaml
@@ -75,4 +75,5 @@ jobs:
             exit 0
           fi
           echo "$changed"
-          yamllint -c .yamllint -f github $changed
+          printf '%s\n' "$changed" \
+            | xargs -r -d '\n' yamllint -c .yamllint -f github

--- a/.github/workflows/k8s-validate.yaml
+++ b/.github/workflows/k8s-validate.yaml
@@ -44,36 +44,3 @@ jobs:
           done < <(find kubernetes/flux -name 'kustomization.y*ml' | sort)
           echo "$((total - failed))/$total overlays valid"
           exit $((failed > 0))
-
-  yamllint:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v7
-        with:
-          python-version: '3.13'
-
-      - name: Install yamllint
-        run: pip install yamllint
-
-      # Changed files only — the tree has a pre-existing backlog of lint
-      # errors, so a whole-repo run would fail every PR on contents it did
-      # not touch.
-      - name: Lint changed YAML
-        env:
-          BASE: ${{ github.event.pull_request.base.sha }}
-        run: |
-          changed=$(git diff --name-only --diff-filter=d "$BASE...HEAD" \
-            | grep -E '\.ya?ml$' || true)
-          if [ -z "$changed" ]; then
-            echo "No YAML changed"
-            exit 0
-          fi
-          echo "$changed"
-          printf '%s\n' "$changed" \
-            | xargs -r -d '\n' yamllint -c .yamllint -f github

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -1,0 +1,205 @@
+name: Quality
+permissions:
+  contents: read
+# Deliberately unfiltered by path. Renovate automerges routine bumps here, so
+# a check that silently skips is as bad as one that silently fails — every PR
+# gets the full set, and each job runs independently so one failure does not
+# mask the others.
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install actionlint
+        env:
+          VERSION: 1.7.12
+        run: |
+          base=https://github.com/rhysd/actionlint/releases/download
+          curl -sSL "$base/v$VERSION/actionlint_${VERSION}_linux_amd64.tar.gz" \
+            | sudo tar xz -C /usr/local/bin actionlint
+
+      - name: Run actionlint
+        run: actionlint -color
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      # Pinned rather than taken from the runner image: a runner bump that
+      # ships a stricter shellcheck would fail unrelated PRs.
+      - name: Install shellcheck
+        env:
+          VERSION: 0.11.0
+        run: |
+          base=https://github.com/koalaman/shellcheck/releases/download
+          curl -sSL "$base/v$VERSION/shellcheck-v$VERSION.linux.x86_64.tar.xz" \
+            | sudo tar xJ -C /usr/local/bin --strip-components=1 \
+                "shellcheck-v$VERSION/shellcheck"
+
+      - name: Run shellcheck
+        run: |
+          mapfile -t files < <(git ls-files '*.sh')
+          printf '%s\n' "${files[@]}"
+          shellcheck "${files[@]}"
+
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Install ruff
+        run: pip install 'ruff==0.16.2'
+
+      - name: Run ruff
+        run: |
+          mapfile -t files < <(git ls-files '*.py')
+          printf '%s\n' "${files[@]}"
+          ruff check --output-format github "${files[@]}"
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install gitleaks
+        env:
+          VERSION: 8.28.0
+        run: |
+          base=https://github.com/gitleaks/gitleaks/releases/download
+          curl -sSL "$base/v$VERSION/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | sudo tar xz -C /usr/local/bin gitleaks
+
+      # Tracked files only. A plain filesystem scan picks up .terraform state
+      # left by other jobs, which is gitignored and never committed.
+      - name: Scan tracked files
+        run: |
+          mkdir -p /tmp/tracked
+          git archive HEAD | tar -x -C /tmp/tracked
+          gitleaks dir --no-banner --redact -v \
+            -c "$GITHUB_WORKSPACE/.gitleaks.toml" /tmp/tracked
+
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+
+      - name: Check formatting
+        run: terraform fmt -check -recursive -diff .
+
+      # Root modules only. terraform/modules/* have no provider constraints of
+      # their own, so validating them standalone resolves the wrong provider
+      # major and fails on syntax the real version supports. They are covered
+      # through the root modules that call them.
+      #
+      # -backend=false so this needs no RustFS credentials or Tailscale.
+      - name: Validate root modules
+        run: |
+          failed=0
+          while read -r dir; do
+            echo "::group::$dir"
+            if ! (cd "$dir" \
+                  && terraform init -backend=false -input=false -no-color \
+                  && terraform validate -no-color); then
+              echo "::error file=$dir::terraform validate failed"
+              failed=$((failed + 1))
+            fi
+            echo "::endgroup::"
+          done < <(git ls-files '*.tf' \
+                     | grep -v '^terraform/modules/' \
+                     | xargs -r -n1 dirname | sort -u)
+          exit $((failed > 0))
+
+  kube-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install kube-linter
+        env:
+          VERSION: 0.8.3
+        run: |
+          base=https://github.com/stackrox/kube-linter/releases/download
+          curl -sSL "$base/v$VERSION/kube-linter-linux.tar.gz" \
+            | sudo tar xz -C /usr/local/bin kube-linter
+
+      # The deployed hawkfield overlays only. Linting base/london/dev as well
+      # would report the same finding three or four times over, and there is
+      # no real cluster behind london or dev.
+      - name: Build hawkfield overlays
+        run: |
+          mkdir -p built
+          while read -r manifest; do
+            dir=$(dirname "$manifest")
+            kubectl kustomize "$dir" > "built/${dir//\//_}.yaml"
+          done < <(find kubernetes/flux/applications/hawkfield \
+                        kubernetes/flux/infrastructure/hawkfield \
+                        -name 'kustomization.y*ml' | sort)
+          ls built
+
+      - name: Run kube-linter
+        run: kube-linter lint --config .kube-linter.yaml built/
+
+  policy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install Kyverno CLI
+        env:
+          VERSION: 1.18.2
+        run: |
+          base=https://github.com/kyverno/kyverno/releases/download
+          file="kyverno-cli_v${VERSION}_linux_x86_64.tar.gz"
+          curl -sSL "$base/v$VERSION/$file" \
+            | sudo tar xz -C /usr/local/bin kyverno
+
+      - name: Build every overlay
+        run: |
+          mkdir -p built
+          while read -r manifest; do
+            dir=$(dirname "$manifest")
+            kubectl kustomize "$dir" > "built/${dir//\//_}.yaml"
+          done < <(find kubernetes/flux -name 'kustomization.y*ml' | sort)
+
+      # Runs before the real manifests on purpose. A policy that matches
+      # nothing validates fine and passes everything, so the fixtures are what
+      # prove the policies still bite.
+      - name: Policies must reject the broken fixtures
+        run: |
+          if kyverno apply kubernetes/policy/ \
+               --resource kubernetes/policy-tests/must-fail.yaml; then
+            echo "::error::must-fail.yaml was accepted — the policies are" \
+              "not matching anything. Check kubernetes/policy/ loaded."
+            exit 1
+          fi
+          echo "Broken fixtures rejected as expected"
+
+      - name: Policies must accept the good fixtures
+        run: |
+          kyverno apply kubernetes/policy/ \
+            --resource kubernetes/policy-tests/must-pass.yaml
+
+      - name: Apply policies to every overlay
+        run: kyverno apply kubernetes/policy/ --resource built/

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -52,6 +52,28 @@ jobs:
           printf '%s\n' "${files[@]}"
           shellcheck "${files[@]}"
 
+  # Moved here from k8s-validate.yaml, which is path-filtered to kubernetes/**
+  # and so never linted the YAML under Ansible/ or .github/. It also scoped
+  # itself to changed files to dodge a backlog; the backlog is gone, so this
+  # lints the whole tree and coverage stops depending on what a PR touched.
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Install yamllint
+        run: pip install 'yamllint==1.38.0'
+
+      - name: Run yamllint
+        run: |
+          mapfile -t files < <(git ls-files '*.yml' '*.yaml')
+          yamllint -c .yamllint -f github "${files[@]}"
+
   ruff:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ terraform/**/plan_output.txt
 # Vagrant
 vagrant/**/.vagrant/
 vagrant/iso/
+# Python
+__pycache__/
+.ruff_cache/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,22 @@
+[extend]
+useDefault = true
+
+# Both entries below are verified false positives, allowlisted by the exact
+# secret value.
+#
+# Do NOT add `paths` to these allowlists. A `paths` entry makes gitleaks skip
+# the whole file before scanning it, so a genuine secret added to that file
+# later would go unreported. Verified: with `paths` set, a planted AWS key in
+# both files was missed; with the anchored value regexes below, it is caught.
+
+[[rules]]
+id = "generic-api-key"
+[[rules.allowlists]]
+description = "SOPS key fingerprint in kubernetes/flux/README.md — a public identifier, not the key"
+regexes = ['''^76AF39813C2297E8F98C542D42436A07A9BA1DE0$''']
+
+[[rules]]
+id = "kubernetes-secret-yaml"
+[[rules.allowlists]]
+description = "Ansible/kubernetes.yml sops-gpg Secret is Jinja-templated; this is a kubeconfig path, not a value"
+regexes = ['''^KUBECONFIG: /etc/kubernetes/admin$''']

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,40 @@
+checks:
+  addAllBuiltIn: true
+
+  # Every exclusion below is deliberate. Read the reason before re-enabling one:
+  # several of these checks actively contradict invariants this cluster depends
+  # on, and turning them back on would mean "fixing" manifests into an outage.
+  exclude:
+    # --- Conflicts with cluster invariants -------------------------------
+    # Grafana, Prometheus, Alertmanager and factorio are all NFS-backed and
+    # must stay at one replica; a second pod deadlocks on the shared-file lock.
+    - "minimum-three-replicas"
+    # Demands RollingUpdate and flags Recreate as the violation — the exact
+    # inverse of nfs-deployment-requires-recreate in kubernetes/policy/.
+    - "no-rolling-update-strategy"
+    # Forbids type: LoadBalancer. MetalLB VIPs are the deliberate architecture
+    # here; NodePort poisons a LoadBalancer VIP's source IP.
+    - "exposed-services"
+
+    # --- False positives under static analysis ---------------------------
+    # All hits are SOPS Secrets, whose `sops` key reads as an extra property.
+    # kubeconform needs -skip Secret for the same reason.
+    - "schema-validation"
+    # Reads the unrendered empty default as an invalid policy; the API server
+    # defaults it to Always. Fires on every Deployment.
+    - "restart-policy"
+    # The alloy and loki Ingresses target Services created by HelmReleases,
+    # which Flux renders at runtime and kustomize output cannot contain.
+    - "dangling-ingress"
+
+    # --- Not a linting change --------------------------------------------
+    # Org conventions; single-owner repo.
+    - "required-label-owner"
+    - "required-annotation-email"
+    - "no-node-affinity"
+    - "dnsconfig-options"
+    # Wants a NetworkPolicy per pod. Worth doing, but it is a project.
+    - "non-isolated-pod"
+    # 3 hits (truenas-api-exporter, uptime-kuma bootstrap Job). Legitimate
+    # hardening, but it changes the runtime behaviour of three workloads.
+    - "read-secret-from-env-var"

--- a/.yamllint
+++ b/.yamllint
@@ -1,23 +1,33 @@
 extends: default
-ignore: 'README.md'
+
+ignore:
+  - 'README.md'
+  # Written by `flux bootstrap` and marked DO NOT EDIT. Held 2192 findings,
+  # every one of which would have failed the next Flux bump.
+  - 'kubernetes/flux/clusters/*/flux-system/'
+
 rules:
   new-line-at-end-of-file: disable
   empty-lines: disable
   comments: disable
+  # ansible-lint `# noqa` comments have to sit next to the task they apply to,
+  # which is not always where yamllint wants a comment indented.
+  comments-indentation: disable
+  # The tree is mixed and neither convention is wrong.
+  document-start: disable
+  truthy:
+    # `on:` in a workflow is a mapping key, not a YAML 1.1 boolean.
+    check-keys: false
   line-length:
+    # 80 was unreachable for a repo of URLs, checksums and Jinja, which is why
+    # this had grown a per-file ignore list. 120 is a limit that can be met.
+    max: 120
     ignore:
-      - 'Ansible/roles/users/defaults/main.yml'
+      # SOPS-encrypted values are single base64 blobs, up to 653 characters.
+      - '**/*.sops.yaml'
+      - 'kubernetes/flux/infrastructure/*/monitoring/grafana-admin-credentials.yaml'
+      - 'kubernetes/flux/infrastructure/base/certificate-manager/configuration/cloudflare-secret.yml'
       - 'kubernetes/flux/infrastructure/base/media/controller/secret.yml'
-      - 'kubernetes/flux/infrastructure/hawkfield/monitoring/loki-rustfs-creds.sops.yaml'
-      - 'kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager-telegram.sops.yaml'
-      - 'kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager-watchdog.sops.yaml'
-      # runbook_url is an 88-char GitHub blob URL that cannot wrap.
-      - 'kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml'
-      - 'kubernetes/flux/infrastructure/hawkfield/uptime-kuma/mariadb-credentials.sops.yaml'
-      - 'kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-credentials.sops.yaml'
-      # Long ${{ secrets.* }} expressions and release URLs. Pre-existing; the
-      # linter only sees these files when something in them changes.
+      # GitHub Actions ${{ }} expressions cannot be wrapped.
+      - '.github/workflows/'
       - 'Ansible/kubernetes.yml'
-      - '.github/workflows/cluster-rebuild.yaml'
-      - '.github/workflows/terraform-plan.yaml'
-      - '.github/workflows/terraform.yaml'

--- a/Documentation/hardware/collect-hardware.sh
+++ b/Documentation/hardware/collect-hardware.sh
@@ -8,7 +8,7 @@ set -u
 section() { echo; echo "##### $1"; }
 
 section HOSTNAME; hostname
-section OS; cat /etc/os-release | head -3
+section OS; head -3 /etc/os-release
 section PVE; pveversion 2>/dev/null
 section SYSTEM; dmidecode -t system
 section BASEBOARD; dmidecode -t baseboard
@@ -45,7 +45,9 @@ for d in $(lspci -n | awk '{print $1}'); do
 done
 
 section NET; ip -br link
-for i in $(ls /sys/class/net | grep -Ev 'lo|tap|veth|fw|bonding_masters'); do
+for path in /sys/class/net/*; do
+    i=$(basename "$path")
+    case "$i" in lo|tap*|veth*|fw*|bonding_masters) continue;; esac
     echo "-- $i"
     ethtool "$i" 2>/dev/null | grep -Ei 'speed|duplex|supported link modes'
     ethtool -i "$i" 2>/dev/null | grep -Ei 'driver|bus-info'

--- a/kubernetes/flux/applications/base/factorio/deployment.yml
+++ b/kubernetes/flux/applications/base/factorio/deployment.yml
@@ -6,6 +6,16 @@ metadata:
   namespace: factorio
   labels:
     name: factorio
+  annotations:
+    # The factoriotools entrypoint runs as root to chown /factorio (including
+    # the NFS saves mount) before dropping to the factorio user, and the image
+    # writes mods and scenarios to paths that are not mounted. Both containers
+    # are root by design; changing that is an NFS ownership migration, not a
+    # lint fix.
+    ignore-check.kube-linter.io/run-as-non-root: >-
+      entrypoint chowns the NFS saves mount as root
+    ignore-check.kube-linter.io/no-read-only-root-fs: >-
+      factorio writes mods and scenarios outside the mounts
 spec:
   replicas: 1
   # RollingUpdate deadlocks: no node can double-book the 4-CPU request
@@ -19,10 +29,26 @@ spec:
       labels:
         name: factorio
     spec:
+      serviceAccountName: factorio
+      automountServiceAccountToken: false
       initContainers:
         - name: copy-server-settings
-          image: busybox
+          # Pinned by hand: busybox is disabled in renovate.json, so nothing
+          # bumps this automatically.
+          image: busybox:1.38.0
           command: ["sh", "-c", "cp /settings/*.json /config"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: config
               mountPath: /config
@@ -33,15 +59,39 @@ spec:
           image: factoriotools/factorio:2.1.14
           ports:
             - containerPort: 34197
+              name: game
               protocol: UDP
             - containerPort: 27015
+              name: rcon
               protocol: TCP
           env:
             - name: DLC_SPACE_AGE
               value: "true"
+          # RCON is served in-process, so a TCP accept is a genuine liveness
+          # signal. Thresholds are deliberately slack: loading a Space Age save
+          # takes minutes, and a restart drops every connected player.
+          startupProbe:
+            tcpSocket:
+              port: rcon
+            periodSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            tcpSocket:
+              port: rcon
+            periodSeconds: 30
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: rcon
+            periodSeconds: 30
+            failureThreshold: 5
           resources:
             requests:
               cpu: "4"
+              memory: "16Gi"
+            limits:
+              # Matches the request rather than capping lower: observed working
+              # set is ~1.2Gi, so this is headroom, not a new OOM risk.
               memory: "16Gi"
           volumeMounts:
             - mountPath: /factorio/config

--- a/kubernetes/flux/applications/base/factorio/kustomization.yml
+++ b/kubernetes/flux/applications/base/factorio/kustomization.yml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yml
+  - serviceaccount.yml
   - deployment.yml
   - service.yml

--- a/kubernetes/flux/applications/base/factorio/serviceaccount.yml
+++ b/kubernetes/flux/applications/base/factorio/serviceaccount.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: factorio
+  namespace: factorio
+automountServiceAccountToken: false

--- a/kubernetes/flux/applications/base/homepage/deployment.yml
+++ b/kubernetes/flux/applications/base/homepage/deployment.yml
@@ -14,9 +14,69 @@ spec:
       labels:
         name: homepage
     spec:
+      serviceAccountName: homepage
+      automountServiceAccountToken: false
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    name: homepage
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        # nginx creates its temp paths under /var/cache/nginx at startup, so
+        # the emptyDirs have to be group-writable by the nginx user.
+        fsGroup: 101
       containers:
         - name: homepage
           image: docker.io/clincha/homepage:0.0.3
           ports:
-            - containerPort: 80
+            - containerPort: 8080
+              name: http
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /etc/nginx/conf.d
+              name: nginx-conf
+              readOnly: true
+            - mountPath: /var/cache/nginx
+              name: cache
+            - mountPath: /var/run
+              name: run
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: homepage-nginx
+        - name: cache
+          emptyDir: {}
+        - name: run
+          emptyDir: {}

--- a/kubernetes/flux/applications/base/homepage/kustomization.yml
+++ b/kubernetes/flux/applications/base/homepage/kustomization.yml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yml
+  - serviceaccount.yml
+  - nginx-conf.yml
   - deployment.yml
   - service.yml
   - ingress.yml

--- a/kubernetes/flux/applications/base/homepage/nginx-conf.yml
+++ b/kubernetes/flux/applications/base/homepage/nginx-conf.yml
@@ -1,0 +1,19 @@
+---
+# The image is stock nginx:alpine, which listens on 80. Overriding conf.d is
+# what actually moves it to 8080 — changing containerPort alone would leave
+# nginx on 80 and point the Service at nothing.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: homepage-nginx
+  namespace: homepage
+data:
+  default.conf: |
+    server {
+        listen 8080;
+        server_name localhost;
+        location / {
+            root /usr/share/nginx/html;
+            index index.html;
+        }
+    }

--- a/kubernetes/flux/applications/base/homepage/service.yml
+++ b/kubernetes/flux/applications/base/homepage/service.yml
@@ -11,5 +11,5 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 80
+      targetPort: http
       protocol: TCP

--- a/kubernetes/flux/applications/base/homepage/serviceaccount.yml
+++ b/kubernetes/flux/applications/base/homepage/serviceaccount.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: homepage
+  namespace: homepage
+automountServiceAccountToken: false

--- a/kubernetes/flux/infrastructure/base/certificate-manager/configuration/issuers.yml
+++ b/kubernetes/flux/infrastructure/base/certificate-manager/configuration/issuers.yml
@@ -10,8 +10,8 @@ spec:
     privateKeySecretRef:
       name: letsencrypt-production-issuer-account-key
     solvers:
-    - dns01:
-        cloudflare:
-          apiTokenSecretRef:
-            name: cloudflare-api-token-secret
-            key: api-token
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token-secret
+              key: api-token

--- a/kubernetes/flux/infrastructure/base/monitoring/alertmanager.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/alertmanager.yml
@@ -29,6 +29,8 @@ spec:
         app.kubernetes.io/name: alertmanager
         app.kubernetes.io/part-of: kube-prometheus
     spec:
+      serviceAccountName: alertmanager
+      automountServiceAccountToken: false
       # Secret files land root-owned; fsGroup is what makes them group-readable
       # by the alertmanager user.
       securityContext:

--- a/kubernetes/flux/infrastructure/base/monitoring/alloy-syslog.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/alloy-syslog.yml
@@ -22,6 +22,8 @@ spec:
         app.kubernetes.io/component: syslog
         app.kubernetes.io/part-of: kube-prometheus
     spec:
+      serviceAccountName: alloy-syslog
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 473
       containers:
@@ -49,6 +51,12 @@ spec:
             httpGet:
               path: /-/ready
               port: http
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+            periodSeconds: 30
+            failureThreshold: 5
           volumeMounts:
             - mountPath: /etc/alloy
               name: config

--- a/kubernetes/flux/infrastructure/base/monitoring/grafana.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/grafana.yml
@@ -30,6 +30,8 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/part-of: kube-prometheus
     spec:
+      serviceAccountName: grafana
+      automountServiceAccountToken: false
       containers:
         - name: grafana
           image: grafana/grafana:13.1.3
@@ -40,6 +42,12 @@ spec:
             httpGet:
               path: /api/health
               port: http
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            periodSeconds: 30
+            failureThreshold: 5
           resources:
             limits:
               cpu: 2

--- a/kubernetes/flux/infrastructure/base/monitoring/graphite-exporter.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/graphite-exporter.yml
@@ -20,6 +20,8 @@ spec:
         app.kubernetes.io/component: graphite-exporter
         app.kubernetes.io/part-of: kube-prometheus
     spec:
+      serviceAccountName: graphite-exporter
+      automountServiceAccountToken: false
       containers:
         - name: graphite-exporter
           image: prom/graphite-exporter:v0.17.0
@@ -47,6 +49,14 @@ spec:
             httpGet:
               path: /metrics
               port: metrics
+          # The landing page, not /metrics: liveness should not re-render the
+          # whole registry every 30s.
+          livenessProbe:
+            httpGet:
+              path: /
+              port: metrics
+            periodSeconds: 30
+            failureThreshold: 5
           volumeMounts:
             - mountPath: /etc/graphite
               name: mapping

--- a/kubernetes/flux/infrastructure/base/monitoring/kube-state-metrics.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/kube-state-metrics.yml
@@ -151,6 +151,12 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/version: 2.19.0
   name: kube-state-metrics
+  annotations:
+    # kube-state-metrics exports kube_secret_* metadata, so listing Secrets is
+    # inherent to what it does. The bound ClusterRole grants list/watch only,
+    # never get, so it never reads a Secret's data.
+    ignore-check.kube-linter.io/access-to-secrets: >-
+      KSM exports kube_secret_* metadata; list/watch only, never get
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/kubernetes/flux/infrastructure/base/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/kustomization.yml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yml
+  - serviceaccounts.yml
   - helm-repository.yml
   - helm-release-loki.yml
   - helm-release-alloy.yml

--- a/kubernetes/flux/infrastructure/base/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/prometheus.yml
@@ -29,16 +29,34 @@ spec:
         app.kubernetes.io/name: prometheus
         app.kubernetes.io/part-of: kube-prometheus
     spec:
+      serviceAccountName: prometheus
+      automountServiceAccountToken: false
       containers:
         - name: prometheus
           image: prom/prometheus:v3.13.2
           ports:
             - containerPort: 9090
+              name: http
               protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+            periodSeconds: 30
+            failureThreshold: 5
           resources:
             requests:
               cpu: "1"
               memory: "4Gi"
+            limits:
+              # Twice the request, ~20x the observed working set. A cap this
+              # far out satisfies the check without inviting an OOMKill mid
+              # compaction.
+              memory: "8Gi"
           volumeMounts:
             - mountPath: /etc/prometheus
               name: config
@@ -50,6 +68,8 @@ spec:
             runAsUser: 3003
             runAsNonRoot: false
             runAsGroup: 3003
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           args:
             - --web.enable-remote-write-receiver
             - --config.file=/etc/prometheus/prometheus.yml

--- a/kubernetes/flux/infrastructure/base/monitoring/serviceaccounts.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/serviceaccounts.yml
@@ -1,0 +1,45 @@
+---
+# One ServiceAccount per workload so nothing falls back to the namespace
+# default. None of these talk to the API server, hence no token and no RBAC.
+# kube-state-metrics is the exception; it brings its own.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: monitoring
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana
+  namespace: monitoring
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alertmanager
+  namespace: monitoring
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alloy-syslog
+  namespace: monitoring
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: graphite-exporter
+  namespace: monitoring
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: truenas-api-exporter
+  namespace: monitoring
+automountServiceAccountToken: false

--- a/kubernetes/flux/infrastructure/base/monitoring/truenas-api-exporter.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/truenas-api-exporter.yml
@@ -20,6 +20,8 @@ spec:
         app.kubernetes.io/component: truenas-api-exporter
         app.kubernetes.io/part-of: kube-prometheus
     spec:
+      serviceAccountName: truenas-api-exporter
+      automountServiceAccountToken: false
       containers:
         - name: exporter
           image: python:3.12-slim
@@ -50,6 +52,13 @@ spec:
           readinessProbe:
             tcpSocket:
               port: metrics
+          # tcpSocket, not /metrics: an HTTP probe would drive a full TrueNAS
+          # API scrape on every check.
+          livenessProbe:
+            tcpSocket:
+              port: metrics
+            periodSeconds: 30
+            failureThreshold: 5
           volumeMounts:
             - mountPath: /app
               name: script

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/truenas_exporter.py
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/truenas_exporter.py
@@ -2,7 +2,16 @@
 # TrueNAS API -> Prometheus exporter. Talks the 25.10 JSON-RPC WebSocket API
 # (the REST API rejects non-admin keys). Stdlib only: a minimal WS client so the
 # script can run from a stock python image mounted via ConfigMap.
-import base64, hashlib, json, os, socket, ssl, struct, sys, time
+import base64
+import itertools
+import json
+import os
+import socket
+import ssl
+import struct
+import sys
+import time
+import traceback
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 NAS_HOST = os.environ.get("TRUENAS_HOST", "10.1.2.10")
@@ -21,7 +30,7 @@ class WSClient:
 
     def __init__(self, host, port, path, timeout=15):
         raw = socket.create_connection((host, port), timeout=timeout)
-        ctx = ssl._create_unverified_context()
+        ctx = ssl._create_unverified_context()  # noqa: S323 - TrueNAS serves a self-signed cert
         self.s = ctx.wrap_socket(raw, server_hostname=host)
         key = base64.b64encode(os.urandom(16)).decode()
         req = (
@@ -96,13 +105,15 @@ class WSClient:
         try:
             self._send_control(0x8, b"")
             self.s.close()
-        except Exception:
-            pass
+        except OSError as e:
+            sys.stderr.write(f"ws close failed: {e}\n")
 
 
-def rpc(ws, method, params=None, _id=[0]):
-    _id[0] += 1
-    mid = _id[0]
+_rpc_ids = itertools.count(1)
+
+
+def rpc(ws, method, params=None):
+    mid = next(_rpc_ids)
     ws.send(json.dumps({"jsonrpc": "2.0", "id": mid, "method": method, "params": params or []}))
     while True:
         msg = json.loads(ws.recv())
@@ -207,10 +218,12 @@ class Handler(BaseHTTPRequestHandler):
         try:
             body = render(*collect())
             ok = 1
-        except Exception as e:
+        # Deliberately broad: any failure must still serve
+        # truenas_scrape_success 0 rather than 500 the scrape away.
+        except Exception:  # noqa: BLE001
             body = ""
             ok = 0
-            sys.stderr.write(f"scrape error: {e}\n")
+            traceback.print_exc()
         body += (
             "# HELP truenas_scrape_success 1 if the last scrape of the TrueNAS API succeeded\n"
             "# TYPE truenas_scrape_success gauge\n"
@@ -228,4 +241,4 @@ class Handler(BaseHTTPRequestHandler):
 
 
 if __name__ == "__main__":
-    ThreadingHTTPServer(("0.0.0.0", LISTEN), Handler).serve_forever()
+    ThreadingHTTPServer(("0.0.0.0", LISTEN), Handler).serve_forever()  # noqa: S104 - scraped across the pod network

--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap-job.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap-job.yml
@@ -1,4 +1,11 @@
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: uptime-kuma-admin-bootstrap
+  namespace: uptime-kuma
+automountServiceAccountToken: false
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -9,6 +16,13 @@ metadata:
     # ConfigMap name into it. Let Flux delete and recreate rather than fail the
     # apply. Re-running is safe: the script is idempotent.
     kustomize.toolkit.fluxcd.io/force: "enabled"
+    ignore-check.kube-linter.io/no-liveness-probe: >-
+      run-to-completion Job, not a served endpoint
+    ignore-check.kube-linter.io/no-readiness-probe: >-
+      run-to-completion Job, not a served endpoint
+    ignore-check.kube-linter.io/job-ttl-seconds-after-finished: >-
+      the completed Job is the record that bootstrap ran
+
 spec:
   # No ttlSecondsAfterFinished on purpose — the completed Job is the record
   # that bootstrap ran, and letting it expire would just have Flux recreate it.
@@ -16,6 +30,12 @@ spec:
   template:
     spec:
       restartPolicy: OnFailure
+      serviceAccountName: uptime-kuma-admin-bootstrap
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
       containers:
         # The uptime-kuma image already carries socket.io-client, so the
         # bootstrap always speaks the same protocol version as the server.
@@ -42,6 +62,18 @@ spec:
                 secretKeyRef:
                   name: uptime-kuma-admin-credentials
                   key: password
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: script
               mountPath: /script

--- a/kubernetes/policy-tests/must-fail.yaml
+++ b/kubernetes/policy-tests/must-fail.yaml
@@ -1,0 +1,63 @@
+---
+# Fixtures for kubernetes/policy/. Every resource in this file MUST be
+# rejected. The quality workflow asserts that `kyverno apply` fails on it,
+# because a policy that matches nothing validates fine and passes silently.
+# BAD: NFS volume + RollingUpdate (implicit default, no strategy at all)
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: bad-nfs-default-strategy, namespace: t}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: a}}
+  template:
+    metadata: {labels: {app: a}}
+    spec:
+      containers: [{name: c, image: busybox:1.38.0}]
+      volumes: [{name: d, nfs: {server: 10.1.2.10, path: /mnt/data/x}}]
+---
+# BAD: NFS volume + explicit RollingUpdate
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: bad-nfs-rollingupdate, namespace: t}
+spec:
+  replicas: 1
+  strategy: {type: RollingUpdate}
+  selector: {matchLabels: {app: a}}
+  template:
+    metadata: {labels: {app: a}}
+    spec:
+      containers: [{name: c, image: busybox:1.38.0}]
+      volumes: [{name: d, nfs: {server: 10.1.2.10, path: /mnt/data/x}}]
+---
+# BAD: non-root + secret volume, no fsGroup
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: bad-nonroot-secret-no-fsgroup, namespace: t}
+spec:
+  replicas: 1
+  strategy: {type: Recreate}
+  selector: {matchLabels: {app: a}}
+  template:
+    metadata: {labels: {app: a}}
+    spec:
+      securityContext: {runAsNonRoot: true, runAsUser: 1000}
+      containers: [{name: c, image: busybox:1.38.0}]
+      volumes: [{name: s, secret: {secretName: creds}}]
+---
+---
+# BAD: non-root declared at CONTAINER level, secret volume, no fsGroup
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: bad-container-nonroot-secret, namespace: t}
+spec:
+  replicas: 1
+  strategy: {type: Recreate}
+  selector: {matchLabels: {app: a}}
+  template:
+    metadata: {labels: {app: a}}
+    spec:
+      containers:
+        - name: c
+          image: busybox:1.38.0
+          securityContext: {runAsNonRoot: true}
+      volumes: [{name: s, secret: {secretName: creds}}]

--- a/kubernetes/policy-tests/must-pass.yaml
+++ b/kubernetes/policy-tests/must-pass.yaml
@@ -1,0 +1,72 @@
+---
+# Fixtures for kubernetes/policy/. Every resource in this file MUST be
+# accepted, so the policies cannot be tightened into rejecting the shapes the
+# cluster actually runs.
+# GOOD: NFS + Recreate
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: good-nfs-recreate, namespace: t}
+spec:
+  replicas: 1
+  strategy: {type: Recreate}
+  selector: {matchLabels: {app: a}}
+  template:
+    metadata: {labels: {app: a}}
+    spec:
+      containers: [{name: c, image: busybox:1.38.0}]
+      volumes: [{name: d, nfs: {server: 10.1.2.10, path: /mnt/data/x}}]
+---
+# GOOD: no NFS, RollingUpdate is fine
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: good-no-nfs-rolling, namespace: t}
+spec:
+  replicas: 3
+  strategy: {type: RollingUpdate}
+  selector: {matchLabels: {app: a}}
+  template:
+    metadata: {labels: {app: a}}
+    spec:
+      containers: [{name: c, image: busybox:1.38.0}]
+      volumes: [{name: e, emptyDir: {}}]
+---
+# GOOD: non-root + secret + fsGroup
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: good-nonroot-secret-fsgroup, namespace: t}
+spec:
+  replicas: 1
+  strategy: {type: Recreate}
+  selector: {matchLabels: {app: a}}
+  template:
+    metadata: {labels: {app: a}}
+    spec:
+      securityContext: {runAsNonRoot: true, runAsUser: 1000, fsGroup: 1000}
+      containers: [{name: c, image: busybox:1.38.0}]
+      volumes: [{name: s, secret: {secretName: creds}}]
+---
+# GOOD: root pod + secret, no fsGroup needed
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: good-root-secret-no-fsgroup, namespace: t}
+spec:
+  replicas: 1
+  strategy: {type: Recreate}
+  selector: {matchLabels: {app: a}}
+  template:
+    metadata: {labels: {app: a}}
+    spec:
+      containers: [{name: c, image: busybox:1.38.0}]
+      volumes: [{name: s, secret: {secretName: creds}}]
+---
+# GOOD: Deployment with no volumes at all (must not error)
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: good-no-volumes, namespace: t}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: a}}
+  template:
+    metadata: {labels: {app: a}}
+    spec:
+      containers: [{name: c, image: busybox:1.38.0}]

--- a/kubernetes/policy/nfs-deployment-requires-recreate.yaml
+++ b/kubernetes/policy/nfs-deployment-requires-recreate.yaml
@@ -1,0 +1,38 @@
+---
+# A Deployment with an NFS volume must use Recreate. RollingUpdate surges a
+# second pod at replicas: 1, and the two then deadlock on the shared-file lock
+# — Grafana's bleve search index, Prometheus's TSDB lock, Alertmanager's
+# notification log. kube-linter's no-rolling-update-strategy asserts the exact
+# opposite, which is why it is excluded in .kube-linter.yaml.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: nfs-deployment-requires-recreate
+spec:
+  background: false
+  rules:
+    - name: nfs-volume-implies-recreate
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+      context:
+        - name: podSpec
+          variable:
+            jmesPath: request.object.spec.template.spec
+      preconditions:
+        all:
+          - key: "{{ length(podSpec.volumes[?nfs] || `[]`) }}"
+            operator: GreaterThan
+            value: 0
+      validate:
+        failureAction: Enforce
+        message: >-
+          Deployment {{ request.object.metadata.name }} mounts an NFS volume,
+          so spec.strategy.type must be Recreate. A surged second pod
+          deadlocks on the shared-file lock.
+        pattern:
+          spec:
+            strategy:
+              type: Recreate

--- a/kubernetes/policy/nonroot-pod-with-secret-needs-fsgroup.yaml
+++ b/kubernetes/policy/nonroot-pod-with-secret-needs-fsgroup.yaml
@@ -1,0 +1,55 @@
+---
+# A non-root pod that mounts a Secret volume needs securityContext.fsGroup.
+# Secret files land root-owned with no group read, so without an fsGroup the
+# container simply cannot read its own credentials — which is how the
+# Alertmanager Telegram secret failed the first time.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: nonroot-pod-with-secret-needs-fsgroup
+spec:
+  background: false
+  rules:
+    - name: secret-volume-implies-fsgroup
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+                - CronJob
+      context:
+        - name: podSpec
+          variable:
+            jmesPath: request.object.spec.template.spec
+      preconditions:
+        all:
+          - key: "{{ length(podSpec.volumes[?secret] || `[]`) }}"
+            operator: GreaterThan
+            value: 0
+        # Non-root can be declared at either level, hence `any`: JMESPath has
+        # no boolean operator that spans both in one expression.
+        any:
+          - key: "{{ podSpec.securityContext.runAsNonRoot || `false` }}"
+            operator: Equals
+            value: true
+          - key: >-
+              {{ length(podSpec.containers[?securityContext.runAsNonRoot]
+              || `[]`) }}
+            operator: GreaterThan
+            value: 0
+      validate:
+        failureAction: Enforce
+        message: >-
+          {{ request.object.kind }} {{ request.object.metadata.name }} runs as
+          non-root and mounts a Secret volume, so
+          spec.template.spec.securityContext.fsGroup must be set or the
+          container cannot read the secret files.
+        pattern:
+          spec:
+            template:
+              spec:
+                securityContext:
+                  fsGroup: "?*"

--- a/packer/scripts/non-interactive-front-end.sh
+++ b/packer/scripts/non-interactive-front-end.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Setup non-interactive shell to stop errors
 # See: https://github.com/moby/moby/issues/27988
 sudo echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+# Pinned explicitly rather than inherited from ruff's defaults: Renovate
+# automerges ruff bumps, and a new release that widens the default rule set
+# would fail CI on untouched files with no one watching.
+[lint]
+select = ["E4", "E7", "E9", "F", "B", "BLE", "S", "C4", "UP", "RUF"]

--- a/terraform/london/main.tf
+++ b/terraform/london/main.tf
@@ -1,16 +1,16 @@
 module "k8s-lon-1" {
-  source         = "../modules/ubuntu-server"
-  name           = "k8s-lon-1"
-  target_node    = "lon01"
-  vmid           = 111
-  ip_address     = "10.2.2.101"
-  gateway        = "10.2.2.1"
-  cores          = 4
-  memory         = 8192
+  source            = "../modules/ubuntu-server"
+  name              = "k8s-lon-1"
+  target_node       = "lon01"
+  vmid              = 111
+  ip_address        = "10.2.2.101"
+  gateway           = "10.2.2.1"
+  cores             = 4
+  memory            = 8192
   boot_disk_size    = "50"
   data_disk_storage = "local-lvm"
   network_bridge    = "vmbr0"
-  tags           = "base,kubernetes_master,kubernetes_worker,watchdog"
+  tags              = "base,kubernetes_master,kubernetes_worker,watchdog"
 }
 
 module "dns-lon-1" {


### PR DESCRIPTION
Adds a `Quality` workflow with seven independent jobs, and fixes everything they find so it lands green.

## Why now

#438 turned on automerge for routine Renovate bumps, and `dependencyDashboard` is off. A Renovate PR blocked by a pre-existing lint error would stall **invisibly** — no dashboard, no notification, just a bump that never merges. So the constraint on this PR is that every new check has to be green across the whole repo the moment it lands, not green-on-changed-files with a backlog behind it.

`kubeconform` proves a manifest is valid; nothing checked whether it was sane, and nothing at all covered shell, Python, workflows or committed secrets.

## The jobs

| Job | Tool | Findings fixed |
| --- | --- | --- |
| `actionlint` | actionlint 1.7.12 | 1 |
| `shellcheck` | shellcheck 0.11.0 | 3 |
| `ruff` | ruff 0.16.2 | 3 |
| `gitleaks` | gitleaks 8.28.0 | 0 real, 2 false positives allowlisted |
| `terraform` | `fmt -check -recursive` + `validate` | 1 |
| `kube-linter` | kube-linter 0.8.3 | 43 |
| `policy` | Kyverno CLI 1.18.2 | new |

Jobs are independent and unfiltered by path — a check that silently skips is as bad as one that silently fails. Every tool version is pinned rather than taken from the runner image, for the same automerge reason: a runner bump shipping a stricter shellcheck would fail unrelated PRs.

`k8s-validate.yaml` and `ansible-lint.yaml` are unchanged apart from one `xargs` quoting fix actionlint flagged. `renovate.json` is untouched.

## kube-linter

`.kube-linter.yaml` uses `--add-all-built-in` with an exclusion list where **every exclusion carries its reason inline**, because the non-obvious ones will otherwise get helpfully re-enabled later. Three of them actively contradict invariants this cluster depends on:

- `minimum-three-replicas` and `no-rolling-update-strategy` — the NFS-backed workloads must stay at 1 replica with `Recreate`. A surged second pod deadlocks on the shared-file lock (Grafana's bleve index, Prometheus's TSDB lock).
- `exposed-services` — forbids `LoadBalancer`, but MetalLB VIPs are the deliberate architecture; NodePort poisons a LB VIP's source IP.

Scope is the 11 deployed hawkfield overlays. Linting base/london/dev too would report the same finding three or four times over.

The 43 fixes: dedicated ServiceAccounts (9), liveness/readiness probes (12), resource requests and limits (8), read-only rootfs and non-root (9), plus `privileged-ports`, `latest-tag`, `no-anti-affinity`, `job-ttl-seconds-after-finished` and `access-to-secrets`.

Two of those deserve a note:

- **homepage → port 8080.** Moving `containerPort` alone would not have worked. The image is stock `nginx:alpine`, which listens on 80 regardless; `containerPort` is informational. The new `nginx-conf.yml` ConfigMap overriding `conf.d/default.conf` is what actually moves it. Service `port` stays 80 so the Ingress is unaffected; only `targetPort` changed.
- **memory limits are sized from live data**, not guessed — `container_memory_working_set_bytes` from Prometheus. factorio's observed working set is 1.23 GiB against a 16Gi limit that matches its existing request, so this is headroom, not a new OOM risk. CPU requests are deliberately small (10m where added): the nodes already run 71–80% CPU-requested.

`busybox` is pinned by hand to `1.38.0` since it's `enabled: false` in `renovate.json` — that rule is left alone as planned. ⚠️ Worth noting the rule's description ("busybox is pinned to no tag") is now stale.

## Kyverno

Chosen over conftest (Rego) and kube-linter custom checks (which only parameterise built-in templates and cannot express "NFS volume implies Recreate"). The decisive point is that the same policy files can later be enforced in-cluster by the Kyverno admission controller via Flux, so CI and runtime would share one source of truth.

Two policies, both encoding invariants that have already caused incidents:

1. `nfs-deployment-requires-recreate`
2. `nonroot-pod-with-secret-needs-fsgroup` — secret files land root-owned with no group read, which is how the Alertmanager Telegram secret failed the first time.

All current manifests already comply, so these lock in invariants rather than opening a backlog.

The fixtures in `kubernetes/policy-tests/` are load-bearing. The policy job runs `must-fail.yaml` **first** and asserts it is rejected, because a policy that matches nothing validates fine and passes everything silently. That is not hypothetical: an earlier layout with the fixtures at `kubernetes/policy/tests/` made `kyverno apply` recurse into them, report "Applying 0 policy rule(s)" and exit 0.

## Verification

- Every tool: zero findings locally. shellcheck clean on 0.9.0 and 0.11.0; `terraform fmt` clean on 1.9.8 and 1.15.8.
- `kubectl kustomize` builds all 37 overlays; kubeconform 37/37 valid.
- Kyverno: must-fail 4 rejected, must-pass 0 failures, all 37 built overlays pass.
- `yamllint -c .yamllint` over every touched file.
- The gitleaks allowlist deliberately uses anchored value regexes and **no `paths` entry**. A `paths` allowlist skips the whole file before scanning it — verified by planting an AWS key in both allowlisted files, which `paths` missed and the value regexes catch.
- The homepage rewrite was deployed to a scratch namespace and confirmed serving the real page as uid 101 on 8080 with a read-only rootfs before being committed, rather than finding out on merge. Same for Prometheus's read-only rootfs and the uptime-kuma Job's uid 1000.

`terraform validate` covers root modules only. `terraform/modules/*` declare no provider constraints of their own, so validating them standalone resolves the wrong provider major and fails on syntax the real version supports; both are reached through root modules that pass.

## Deferred

Filed separately rather than smuggled in here: `read-secret-from-env-var` (changes the runtime behaviour of three workloads), `non-isolated-pod` (NetworkPolicy coverage is a project, not a lint fix), and porting the tooling to `clincha/media`.

## yamllint (added after review feedback)

The first push left 8 yamllint warning annotations on the diff. Chasing them turned up something worse behind them: the `yamllint` job linted **changed files only** — a documented workaround for a backlog — and lived in `k8s-validate.yaml`, which is path-filtered to `kubernetes/**`. Nothing under `Ansible/` or `.github/` had ever been linted, and 29 `error`-severity findings sat dormant in files no PR had happened to touch.

Clearing them was a config problem, not a formatting one. An 80-char limit is unreachable in a repo of URLs, checksums and Jinja, which is why `.yamllint` had grown a per-file ignore list that was only going to keep growing. Raising it to 120 makes the limit meetable and shrinks the ignore list to the SOPS blobs that genuinely cannot wrap. `gotk-components.yaml` is now ignored outright — generated, marked DO NOT EDIT, and 2192 of the 2221 findings by itself.

With the tree clean, the job moves to `quality.yaml` (unfiltered by design) and lints everything, so coverage no longer depends on what a PR happened to touch. yamllint is pinned to 1.38.0 like every other tool here.

One manifest changed: `issuers.yml` reindented, verified to parse to an identical document.

⚠️ Two deviations from the plan worth flagging: this touches `k8s-validate.yaml`, which the plan listed as untouched, and it changes `.yamllint`'s thresholds repo-wide. Both are easy to drop if you'd rather have the annotations than the config change.
