### PR TITLE
Collect UniFi console metrics with unpoller (#443)

### DIFF
--- a/kubernetes/flux/infrastructure/base/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/kustomization.yml
@@ -10,6 +10,7 @@ resources:
   - graphite-exporter.yml
   - alloy-syslog.yml
   - truenas-api-exporter.yml
+  - unpoller.yml
   - prometheus.yml
   - alertmanager.yml
   - grafana.yml

--- a/kubernetes/flux/infrastructure/base/monitoring/serviceaccounts.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/serviceaccounts.yml
@@ -43,3 +43,10 @@ metadata:
   name: truenas-api-exporter
   namespace: monitoring
 automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: unpoller
+  namespace: monitoring
+automountServiceAccountToken: false

--- a/kubernetes/flux/infrastructure/base/monitoring/unpoller.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/unpoller.yml
@@ -1,0 +1,99 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unpoller
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: unpoller
+    app.kubernetes.io/component: unpoller
+    app.kubernetes.io/part-of: kube-prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: unpoller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: unpoller
+        app.kubernetes.io/component: unpoller
+        app.kubernetes.io/part-of: kube-prometheus
+    spec:
+      serviceAccountName: unpoller
+      automountServiceAccountToken: false
+      containers:
+        - name: unpoller
+          image: ghcr.io/unpoller/unpoller:v3.4.1
+          args: ["--config", "/etc/unpoller/up.conf"]
+          env:
+            # Passwords stay out of the ConfigMap: unpoller overlays
+            # UP_UNIFI_CONTROLLER_<n>_* onto the matching [[unifi.controller]]
+            # block, indexed in file order — Bristol 0, London 1.
+            - name: UP_UNIFI_CONTROLLER_0_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: unifi-poller-credentials
+                  key: bristol-password
+            - name: UP_UNIFI_CONTROLLER_1_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: unifi-poller-credentials
+                  key: london-password
+          ports:
+            - name: metrics
+              containerPort: 9130
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+          # tcpSocket, not /metrics: unpoller polls both consoles on every
+          # HTTP scrape, so an HTTP probe would double the load on the UDMs.
+          livenessProbe:
+            tcpSocket:
+              port: metrics
+            periodSeconds: 30
+            failureThreshold: 5
+          volumeMounts:
+            - mountPath: /etc/unpoller
+              name: config
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: config
+          configMap:
+            name: unpoller-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: unpoller
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: unpoller
+    app.kubernetes.io/component: unpoller
+    app.kubernetes.io/part-of: kube-prometheus
+spec:
+  selector:
+    app.kubernetes.io/name: unpoller
+  ports:
+    - name: metrics
+      port: 9130
+      targetPort: metrics
+      protocol: TCP

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
@@ -8,6 +8,7 @@ resources:
   - loki-rustfs-creds.sops.yaml
   - alertmanager-telegram.sops.yaml
   - alertmanager-watchdog.sops.yaml
+  - unifi-poller-credentials.sops.yaml
 configurations:
   - nameref-helmrelease.yml
 configMapGenerator:
@@ -51,3 +52,7 @@ configMapGenerator:
     namespace: monitoring
     files:
       - truenas_exporter.py
+  - name: unpoller-config
+    namespace: monitoring
+    files:
+      - up.conf

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
@@ -26,3 +26,22 @@ scrape_configs:
     scrape_interval: 60s
     static_configs:
       - targets: ['truenas-api-exporter.monitoring.svc:9113']
+  # UniFi consoles at both sites via unpoller. It polls both UDMs on every
+  # scrape, so poll gently and allow for the London round trip.
+  - job_name: unifi
+    scrape_interval: 60s
+    scrape_timeout: 30s
+    static_configs:
+      - targets: ['unpoller.monitoring.svc:9130']
+    metric_relabel_configs:
+      # Neither label unpoller emits is a usable site key: `source` is the
+      # console URL and `site_name` is the console's own description, which
+      # is still "Default (default)" at London. Derive `site` from the URL.
+      - source_labels: [source]
+        regex: 'https://10\.1\.2\.1'
+        target_label: site
+        replacement: hawkfield
+      - source_labels: [source]
+        regex: 'https://10\.2\.2\.1'
+        target_label: site
+        replacement: london

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/unifi-poller-credentials.sops.yaml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/unifi-poller-credentials.sops.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: unifi-poller-credentials
+    namespace: monitoring
+type: Opaque
+stringData:
+    bristol-password: ENC[AES256_GCM,data:QNBl7Fujw56yTOdOFdMy/0XD5Fq8Ewop,iv:fzNNvff3+WBqGDAFW6brYegvMVO/QG6CIpCoKpVvnj4=,tag:B1DMlEKCsNm61a/LSNfeLQ==,type:str]
+    london-password: ENC[AES256_GCM,data:Zn3KCHZDfcHkHCsLQDIx6gsnja9yKiaY,iv:fGvwPZg7y4bG8zp5JQ6VjVfoLOQHjBbg/WTtM7NAcJM=,tag:3DhdqYryD4RYB6u+Z7DfSQ==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-10T07:22:47Z"
+    mac: ENC[AES256_GCM,data:Bkce9yOwu6j+yWZjSJ8TxA2hQcrVM6I79Vi1jBmOC7tBxIQSQj8kRjtCYhP3ZLr+7kCn5zHQmnkks5PkDhPnYrFuLJepU9l/SmEIs5pbRrIPKqyt1Tx8c5/1Fpk2YO+xjFOoq/9MHa3Gr8RFi9GmOWOcOWLFKua/L9YRk19rkfw=,iv:i7ixnlBxj3X+WlOcU3h/bbxwwP+dP9zY8ZTua6ZN35g=,tag:wWF8VMNMsk8LkA5MLGOglA==,type:str]
+    pgp:
+        - created_at: "2026-08-10T07:22:47Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA+iIV7UXPYO1ARAApg7Ab3uXr9sLMeKLy8aEvggdkx46MLw0wEy2YaGgFL1p
+            65YuPw1i4e0Fv3whEs6QF+aoucvrV7fefe2MNuJps6msd7d30k7MsM+xYbQl647q
+            4s/L90LbCrivdKzChCmGsthF4S0Ja7Ge66QuOvgjxNEhV+YOizIdln5BeFWFIVjh
+            30Z1FUUSxOQsDCXQjQhZmCkgBtFnPIGuRk9NfZuM6A5jPTeI0T1GkgB8WPODwRvS
+            0u/2c+QdXNMxNXl+uC5trfjDR5Dq69pBvLcuR8GZ6mavRjM59irGq7BburO1uAUT
+            G7u8jQ5kEkgkxvUjIFIvqV+akloeCdyCx239SU90g0qJgriJCM56K4Ro3CsZy4nB
+            8gZFKebNJg8D54pXdPM1dLaQt50ImJHnmSAYVb977Uw/SwJ+J7vNySfX32B6Khm0
+            Gs9b12rwW1koovX/NjW9eGo2ukinJWsOZIajVX2bDlKj2suZCwVV8+jeyEt2UCi3
+            63lH8nsKEM8TQlpktMtnRy9l8lnEPz8lzYWdGp24f++4vW+1ipZxG1wEV77HAbWB
+            LozqqA9nkVkGozXj5Aq4kBhhqmejcopFGCaNrJTnKUNq1yT4OWbU+WmtHOJRg3Vl
+            ChNUkfHzXKQHoYHebIEqgWu3hpxLXTsndmfUfFMwJFPeKORVvJwGeW4WRp4cD4jS
+            XAGFaEetNyuVRuIgkkcajkQ+cdV7HG1j9N8+9vX7ExuX9RTLvSq0ZOe2+EpMITsS
+            AFG6Tz8ut7/1pPmVzLh891OnnQ6QNJdeB7gym3+Sgll7wOKGtX3A2sc2mVw3
+            =PuMq
+            -----END PGP MESSAGE-----
+          fp: 76AF39813C2297E8F98C542D42436A07A9BA1DE0
+    version: 3.13.1

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/up.conf
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/up.conf
@@ -1,0 +1,33 @@
+[poller]
+  quiet = true
+
+[prometheus]
+  http_listen = "0.0.0.0:9130"
+  report_errors = false
+
+[influxdb]
+  disable = true
+
+[loki]
+  disable = true
+
+[unifi]
+  dynamic = false
+
+# Controller order is load-bearing: UP_UNIFI_CONTROLLER_<n>_PASS binds by index.
+[[unifi.controller]]
+  url = "https://10.1.2.1"
+  user = "unifipoller"
+  sites = ["all"]
+  save_sites = true
+  save_dpi = false
+  # UDMs serve a self-signed certificate.
+  verify_ssl = false
+
+[[unifi.controller]]
+  url = "https://10.2.2.1"
+  user = "unifipoller"
+  sites = ["all"]
+  save_sites = true
+  save_dpi = false
+  verify_ssl = false


### PR DESCRIPTION
Closes #443 (collection half of the UniFi gateway observability milestone).

## The credential question

Angus created a local `unifipoller` account on each console. Verified before building anything:

| | Bristol (10.1.2.1) | London (10.2.2.1) |
|---|---|---|
| `POST /api/auth/login` | 200 | 200 |
| `/api/users/self` role | `custom`, `network.management: [readonly]` | same |
| `stat/device` | 200 — 10 devices | 200 — 1 device |
| `cmd/sitemgr get-admins` | 403 | 403 |
| `/api/integrations` | 403 `ACTION_FORBIDDEN` | 403 `ACTION_FORBIDDEN` |

So these are genuine read-only local accounts. That resolves the over-privilege problem
recorded in the issue: the two Integration API keys were `role: "admin"` on both sites and
owned by Angus's personal admin account. This exporter can read everything and change nothing.
**The API keys are now unused and should be revoked** — see the follow-up note below.

## Does unpoller work against Network 10.5?

Yes. Spiked v3.4.1 against both consoles before writing manifests:

- Authenticates with the local accounts and resolves `10.5.67` (via a sysinfo fallback —
  `server_version` is absent from `/status` on this firmware).
- **4,146 series** across both sites.
- Four endpoints are gone in 10.5 (`stat/status`, `stat/active`, `stat/ups-devices`,
  `magicsitetositevpn`). unpoller logs each and carries on; none feed the metrics #443 asks for.

Every series in the issue's "done when" clause is present:

| Requirement | Series |
|---|---|
| WAN throughput | `unpoller_device_wan_receive_rate_bytes` / `..._transmit_rate_bytes` |
| Gateway CPU / memory | `unpoller_device_cpu_utilization_ratio`, `unpoller_device_memory_*` |
| Gateway temperature | `unpoller_device_temperature_celsius` (Bristol CPU 64.4 °C, board 68 °C) |
| Per-AP client counts | `unpoller_device_radio_stations`, `unpoller_device_vap_satisfaction_stations` |
| Per-port switch counters | `unpoller_device_port_receive_*` / `transmit_*`, `port_speed_bps`, PoE watts |

`unpoller_client_radio_transmit_rate_bps` is also there, which is the series that would have
made the Plex remux WiFi-ceiling incident a five-minute diagnosis.

Note the metric prefix is `unpoller_`, not the `unifi_` that older docs and dashboards use —
renamed in v3. #444 will need dashboards written against the new names.

## Shape

- `base/monitoring/unpoller.yml` — Deployment + Service, modelled on `truenas-api-exporter`:
  own ServiceAccount, no API token, non-root with a numeric UID (the image defaults to root),
  read-only rootfs, all capabilities dropped, `tcpSocket` probes so a health check does not
  drive a full poll of both UDMs.
- Config split: unpoller 3.4.1 refuses to start without a config file, so the controller list
  is a ConfigMap and only the passwords come from the SOPS secret as
  `UP_UNIFI_CONTROLLER_<n>_PASS`. **Controller order in `up.conf` is load-bearing** — the env
  vars bind by index. Env rather than a mounted secret also keeps the pod clear of the
  non-root fsGroup trap.
- The ConfigMap goes through `configMapGenerator`, so its name hash changes with the content
  and a config edit actually rolls the pod, rather than reconciling green while the process
  keeps its old config.
- Scrape job at 60s with a 30s timeout — unpoller polls both consoles on every scrape, and
  London is across the site-to-site link.
- `site` label derived from the console URL in `metric_relabel_configs`, giving `hawkfield`
  and `london`.

## Follow-ups (not in this PR)

1. **Revoke the two `Monitoring` Integration API keys.** Nothing uses them now, and they are
   full admin on both sites via a personal account. Only Angus can do this.
2. **London's site description is still "Default".** Both read-only accounts and Dave's own
   console account can only read, so this needs Angus in the UI. The `site` label above means
   the dashboard does not depend on it, but it is worth fixing for the console itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)