### PR TITLE
Label the UniFi series that carry no console URL (#443)

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
@@ -45,3 +45,28 @@ scrape_configs:
         regex: 'https://10\.2\.2\.1'
         target_label: site
         replacement: london
+      # unpoller_port_forward_* and unpoller_wan_* carry no `source` at all,
+      # so the rules above leave them site-less. The pairs below read as
+      # "site still empty AND <fallback label> says Hawkfield", because an
+      # unset label contributes nothing before the `;` separator; a series
+      # already carrying a site cannot re-match. Each fallback matches
+      # Hawkfield by name and treats any other value as London, so renaming
+      # the London site — which #443 recommends — cannot silently strand
+      # its series. A third site would need a rule of its own.
+      - source_labels: [site, site_name]
+        regex: ';Hawkfield Lodge.*'
+        target_label: site
+        replacement: hawkfield
+      - source_labels: [site, site_name]
+        regex: ';.+'
+        target_label: site
+        replacement: london
+      # WAN config series identify themselves only by ISP.
+      - source_labels: [site, wan_name]
+        regex: ';Truespeed'
+        target_label: site
+        replacement: hawkfield
+      - source_labels: [site, wan_name]
+        regex: ';.+'
+        target_label: site
+        replacement: london


### PR DESCRIPTION
Follow-up to #446, found while verifying the deployment against #443's "done when" clause.

`up{job="unifi"} == 1` and 4,137 series carry a correct `site`, but 86 do not:

- **`unpoller_wan_*`** — no `source` and no `site_name`; only `wan_name` (the ISP).
  These hold the provisioned line rates — Truespeed 900 Mbps at Bristol, G.Network
  725 Mbps at London — which is what lets #444 plot WAN throughput as a percentage of
  capacity rather than a bare byte rate.
- **`unpoller_port_forward_*`** — has `site_name` but no `source`.
- `go_*` / `process_*` — unpoller's own runtime. Correctly left site-less.

Adds two fallback pairs, `site_name` then `wan_name`. Each reads as "site still empty
AND this label says Hawkfield", which works because an unset label contributes nothing
before the `;` separator, so a series that already has a site cannot re-match.

Each fallback matches Hawkfield by name and treats any other value as London. That is
deliberate: #443 recommends giving the London site a real description instead of
"Default", and a rule that matched the literal string "Default" would silently strand
London's series the moment Angus does it. A third site would need its own rule.

Verified by replaying all six rules over representative label sets, including a renamed
London site:

| series | site |
|---|---|
| device @ Bristol | `hawkfield` |
| device @ London | `london` |
| port_forward @ Hawkfield | `hawkfield` |
| port_forward @ London *(renamed)* | `london` |
| wan Truespeed | `hawkfield` |
| wan G.Network | `london` |
| `go_goroutines` | *(none)* |

🤖 Generated with [Claude Code](https://claude.com/claude-code)