### PR TITLE
Correct the unpoller scrape rationale and interval (#443)

### DIFF
--- a/kubernetes/flux/infrastructure/base/monitoring/unpoller.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/unpoller.yml
@@ -53,8 +53,9 @@ spec:
           readinessProbe:
             tcpSocket:
               port: metrics
-          # tcpSocket, not /metrics: unpoller polls both consoles on every
-          # HTTP scrape, so an HTTP probe would double the load on the UDMs.
+          # tcpSocket, not /metrics: unpoller serves a cache it refreshes on
+          # its own timer, so an HTTP probe would spend a full serialisation
+          # of ~4200 series every 30s to learn what a connect already proves.
           livenessProbe:
             tcpSocket:
               port: metrics

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
@@ -26,11 +26,14 @@ scrape_configs:
     scrape_interval: 60s
     static_configs:
       - targets: ['truenas-api-exporter.monitoring.svc:9113']
-  # UniFi consoles at both sites via unpoller. It polls both UDMs on every
-  # scrape, so poll gently and allow for the London round trip.
+  # UniFi consoles at both sites via unpoller. It refreshes its own cache on a
+  # 60s timer and serves that cache, so a scrape costs the UDMs nothing and
+  # returns in ~50ms. Scraped at 30s rather than 60s because two independent
+  # 60s cycles drift in and out of phase, which would alias a refresh away and
+  # leave gaps of up to two minutes in what is meant to catch WiFi and WAN
+  # transients.
   - job_name: unifi
-    scrape_interval: 60s
-    scrape_timeout: 30s
+    scrape_interval: 30s
     static_configs:
       - targets: ['unpoller.monitoring.svc:9130']
     metric_relabel_configs:


### PR DESCRIPTION
Found while verifying #446/#447 on the cluster. Comment-accuracy fix plus the interval change it implies.

## What I got wrong

Both #446 comments said unpoller polls both UDMs on every Prometheus scrape, and justified
the 60s interval, the 30s timeout and the `tcpSocket` probe on that basis.

It does not. unpoller refreshes an internal cache on a 60s timer and serves that cache.
It exposes this directly — sampling `unpoller_prometheus_cache_age_seconds` off the live
pod every 8s:

```
54.7  2.7  10.7  18.8  26.8  34.8  42.9  50.9  59.0  7.1
```

The age climbs to ~60s and resets, on its own clock, regardless of when it is scraped.
Scrapes return in ~50ms, which is the other tell — nowhere near two HTTPS controller polls.

## Why it matters

A 60s scrape against a 60s refresh is two independent cycles beating against each other.
They drift in and out of phase, so a refresh can be aliased away and leave up to two
minutes between distinct samples — on exactly the WiFi bitrate and WAN throughput series
this collector exists to catch. Now 30s, which bounds it.

The 30s `scrape_timeout` is gone too; it was allowing for a London round trip that never
happens on the scrape path.

The `tcpSocket` probe stays, but for the real reason: an HTTP probe would serialise ~4,200
series every 30s to learn what a TCP connect already proves. It just is not the
UDM-protection measure I claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)