### PR TITLE
Add the UniFi network dashboard, and dashboards as code (#444)

### DIFF
--- a/kubernetes/flux/infrastructure/base/monitoring/grafana-dashboards.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/grafana-dashboards.yml
@@ -1,0 +1,31 @@
+---
+# Dashboards as code. Grafana reads this provider on startup and rescans the
+# mounted directory on updateIntervalSeconds, so a dashboard edit reaches the
+# UI without a pod restart. The dashboard JSON itself is a configMapGenerator
+# in the site overlay.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-provider
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: grafana
+    app.kubernetes.io/part-of: kube-prometheus
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: flux
+        orgId: 1
+        folder: ''
+        type: file
+        # Provisioned dashboards are owned by git: the UI cannot edit them and
+        # deleting the file removes the dashboard. Dashboards created by hand
+        # in the UI are untouched — this provider only manages its own folder.
+        disableDeletion: false
+        allowUiUpdates: false
+        updateIntervalSeconds: 60
+        options:
+          path: /etc/grafana/dashboards
+          foldersFromFilesStructure: false

--- a/kubernetes/flux/infrastructure/base/monitoring/grafana.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/grafana.yml
@@ -74,6 +74,12 @@ spec:
               name: plugins
             - mountPath: /tmp
               name: tmp
+            - mountPath: /etc/grafana/provisioning/dashboards
+              name: dashboard-provider
+              readOnly: true
+            - mountPath: /etc/grafana/dashboards
+              name: dashboards
+              readOnly: true
       volumes:
         - name: grafana-storage
           nfs:
@@ -85,6 +91,12 @@ spec:
         - name: plugins
           emptyDir:
             medium: Memory
+        - name: dashboard-provider
+          configMap:
+            name: grafana-dashboard-provider
+        - name: dashboards
+          configMap:
+            name: grafana-dashboards
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/flux/infrastructure/base/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/kustomization.yml
@@ -14,5 +14,6 @@ resources:
   - prometheus.yml
   - alertmanager.yml
   - grafana.yml
+  - grafana-dashboards.yml
   - certificate.yml
   - ingress.yml

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/kustomization.yml
@@ -56,3 +56,7 @@ configMapGenerator:
     namespace: monitoring
     files:
       - up.conf
+  - name: grafana-dashboards
+    namespace: monitoring
+    files:
+      - unifi-network.json

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/unifi-network.json
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/unifi-network.json
@@ -1,0 +1,3996 @@
+{
+  "uid": "unifi-network",
+  "title": "UniFi Network",
+  "description": "Gateways, switches, access points and clients at both sites, polled from the UniFi consoles by unpoller.",
+  "tags": [
+    "unifi",
+    "network"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 42,
+  "refresh": "1m",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "site",
+        "label": "Site",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "afnx6ohyogi68e"
+        },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(unpoller_controller_up, site)",
+          "refId": "site"
+        },
+        "definition": "label_values(unpoller_controller_up, site)",
+        "refresh": 1,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": null,
+        "multi": true,
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": []
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Both sites",
+      "id": 1,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "stat",
+      "title": "Console reachable",
+      "id": 2,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_controller_up",
+          "refId": "A",
+          "legendFormat": "{{site}}",
+          "instant": true
+        }
+      ],
+      "description": "unpoller's view of each console. 0 means the poll is failing."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "stat",
+      "title": "WAN IP",
+      "id": 3,
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 4,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_port_port_speed_bps{port_num=\"5\"}",
+          "refId": "A",
+          "legendFormat": "{{site}} \u2014 {{port_ip}}",
+          "instant": true
+        }
+      ],
+      "description": "Public address on each gateway's WAN port. Both are static today and several things assume that, so a change here matters."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "stat",
+      "title": "Clients",
+      "id": 4,
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_site_stations",
+          "refId": "A",
+          "legendFormat": "{{site}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "stat",
+      "title": "Devices adopted",
+      "id": 5,
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "sum by (site) (unpoller_device_info)",
+          "refId": "A",
+          "legendFormat": "{{site}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "WAN throughput \u2014 both sites",
+      "id": 6,
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 15,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 6,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_wan_receive_rate_bytes * 8",
+          "refId": "A",
+          "legendFormat": "{{site}} down"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_wan_transmit_rate_bytes * 8",
+          "refId": "B",
+          "legendFormat": "{{site}} up"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Internet latency \u2014 both sites",
+      "id": 7,
+      "gridPos": {
+        "h": 4,
+        "w": 15,
+        "x": 0,
+        "y": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_site_latency_seconds",
+          "refId": "A",
+          "legendFormat": "{{site}}"
+        }
+      ],
+      "description": "Console's own reachability probe to the internet."
+    },
+    {
+      "type": "row",
+      "title": "WAN \u2014 $site",
+      "id": 8,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "panels": [],
+      "repeat": "site",
+      "repeatDirection": "h"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "WAN throughput",
+      "id": 9,
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 0,
+        "y": 10
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_wan_receive_rate_bytes{site=\"$site\"} * 8",
+          "refId": "A",
+          "legendFormat": "down"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_wan_transmit_rate_bytes{site=\"$site\"} * 8",
+          "refId": "B",
+          "legendFormat": "up"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "WAN utilisation against provisioned line rate",
+      "id": 10,
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 9,
+        "y": 10
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_wan_receive_rate_bytes{site=\"$site\"} * 8 / 1000 / on(site) group_left() unpoller_wan_provider_download_kbps * 100",
+          "refId": "A",
+          "legendFormat": "down %"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_wan_transmit_rate_bytes{site=\"$site\"} * 8 / 1000 / on(site) group_left() unpoller_wan_provider_upload_kbps * 100",
+          "refId": "B",
+          "legendFormat": "up %"
+        }
+      ],
+      "description": "Throughput as a share of what the ISP sells. The provisioned rate comes from the console's own WAN config, so it tracks a plan change."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "stat",
+      "title": "Provisioned down",
+      "id": 11,
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 10
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_wan_provider_download_kbps{site=\"$site\"} * 1000",
+          "refId": "A",
+          "legendFormat": "{{wan_name}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "stat",
+      "title": "Provisioned up",
+      "id": 12,
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 10
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_wan_provider_upload_kbps{site=\"$site\"} * 1000",
+          "refId": "A",
+          "legendFormat": "{{wan_name}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "stat",
+      "title": "WAN uptime",
+      "id": 13,
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 18,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 99
+              },
+              {
+                "color": "green",
+                "value": 99.9
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_wan_uptime_percentage{site=\"$site\"}",
+          "refId": "A",
+          "legendFormat": "{{wan_name}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "stat",
+      "title": "Uplink up for",
+      "id": 14,
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 21,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_uplink_uptime_seconds{site=\"$site\"} * on(name) group_left() (unpoller_device_info{type=\"udm\"} > 0)",
+          "refId": "A",
+          "legendFormat": "{{name}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Internet latency",
+      "id": 15,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 17
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_site_latency_seconds{site=\"$site\"}",
+          "refId": "A",
+          "legendFormat": "internet probe"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_uplink_latency_seconds{site=\"$site\",port=\"if!eth4\"}",
+          "refId": "B",
+          "legendFormat": "{{name}} uplink"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "WAN interface errors and drops",
+      "id": 16,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 17
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "pps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "rate(unpoller_device_wan_receive_errors_total{site=\"$site\"}[10m])",
+          "refId": "A",
+          "legendFormat": "rx errors"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "rate(unpoller_device_wan_transmit_errors_total{site=\"$site\"}[10m])",
+          "refId": "B",
+          "legendFormat": "tx errors"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "rate(unpoller_device_wan_receive_dropped_total{site=\"$site\"}[10m])",
+          "refId": "C",
+          "legendFormat": "rx dropped"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "rate(unpoller_device_wan_transmit_dropped_total{site=\"$site\"}[10m])",
+          "refId": "D",
+          "legendFormat": "tx dropped"
+        }
+      ],
+      "description": "Interface-level counters on the WAN port. This is not ISP path loss \u2014 unpoller exposes no such metric. Reachability is covered by the London watchdog instead."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Speedtest",
+      "id": 17,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 17
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_speedtest_download{site=\"$site\"} * 1000000",
+          "refId": "A",
+          "legendFormat": "download"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_speedtest_upload{site=\"$site\"} * 1000000",
+          "refId": "B",
+          "legendFormat": "upload"
+        }
+      ],
+      "description": "The console's own periodic speedtest, not a continuous measurement."
+    },
+    {
+      "type": "row",
+      "title": "Console and device health \u2014 $site",
+      "id": 18,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "panels": [],
+      "repeat": "site",
+      "repeatDirection": "h"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "CPU",
+      "id": 19,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_cpu_utilization_ratio{site=\"$site\"}",
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Memory",
+      "id": 20,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_memory_utilization_ratio{site=\"$site\"}",
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Temperature",
+      "id": 21,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_temperature_celsius{site=\"$site\"}",
+          "refId": "A",
+          "legendFormat": "{{name}} {{temp_area}}"
+        }
+      ],
+      "description": "Bristol was at 83 \u00b0C when the kit was inventoried, which is worth watching rather than reacting to."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Load average (1m)",
+      "id": 22,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_load_average_1{site=\"$site\"}",
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Device uptime",
+      "id": 23,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_uptime_seconds{site=\"$site\"}",
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "table",
+      "title": "Firmware",
+      "id": 24,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_info{site=\"$site\"}",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "job": true,
+              "instance": true,
+              "site_name": true,
+              "source": true,
+              "tag": true,
+              "id": true,
+              "serial": true,
+              "site": true
+            },
+            "renameByName": {
+              "name": "Device",
+              "model": "Model",
+              "version": "Firmware",
+              "ip": "IP",
+              "mac": "MAC",
+              "type": "Type"
+            }
+          }
+        }
+      ],
+      "description": "An upgradable device is not urgent, but a device on a much older release than its peers is worth a look."
+    },
+    {
+      "type": "row",
+      "title": "WiFi \u2014 $site",
+      "id": 25,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "panels": [],
+      "repeat": "site",
+      "repeatDirection": "h"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Clients per access point",
+      "id": 26,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 37
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "sum by (name) (unpoller_device_radio_stations{site=\"$site\"})",
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Channel utilisation per radio",
+      "id": 27,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 37
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 0.75
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_radio_channel_utilization_total_ratio{site=\"$site\"}",
+          "refId": "A",
+          "legendFormat": "{{name}} {{band}} GHz"
+        }
+      ],
+      "description": "Airtime in use. A radio sitting high here is congested regardless of how few clients it has."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Client transmit rate \u2014 the WiFi ceiling",
+      "id": 28,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 44
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "topk(12, unpoller_client_radio_transmit_rate_bps{site=\"$site\",wired=\"false\"})",
+          "refId": "A",
+          "legendFormat": "{{name}} \u2014 {{ap_name}} {{radio_proto}}"
+        }
+      ],
+      "description": "Negotiated PHY rate per client. This is the panel that would have shown the ~30 Mbps ceiling behind the 33.8 Mbps Plex remux stutter. Real throughput is roughly half the PHY rate."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Client signal",
+      "id": 29,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": -70
+              },
+              {
+                "color": "green",
+                "value": -60
+              }
+            ]
+          },
+          "unit": "dBm"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "topk(12, unpoller_client_radio_signal_db{site=\"$site\",wired=\"false\"})",
+          "refId": "A",
+          "legendFormat": "{{name}} \u2014 {{ap_name}}"
+        }
+      ],
+      "description": "Anything below about -70 dBm will be negotiating a low rate."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Transmit retries per radio",
+      "id": 30,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "pps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "rate(unpoller_device_stat_retries_tx_total{site=\"$site\"}[10m])",
+          "refId": "A",
+          "legendFormat": "{{name}} {{radio}}"
+        }
+      ],
+      "description": "Rising retries with steady client counts means interference."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Noise floor",
+      "id": 31,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 52
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dBm"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "avg by (ap_name) (unpoller_client_noise_db{site=\"$site\",wired=\"false\"})",
+          "refId": "A",
+          "legendFormat": "{{ap_name}}"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Switching \u2014 $site",
+      "id": 32,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "panels": [],
+      "repeat": "site",
+      "repeatDirection": "h"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Port throughput",
+      "id": 33,
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 59
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_port_receive_rate_bytes{site=\"$site\"} * 8",
+          "refId": "A",
+          "legendFormat": "{{name}} {{port_name}} rx"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_port_transmit_rate_bytes{site=\"$site\"} * 8",
+          "refId": "B",
+          "legendFormat": "{{name}} {{port_name}} tx"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "bargauge",
+      "title": "Port link speed",
+      "id": 34,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 59
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "maxVizHeight": 300,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_port_port_speed_bps{site=\"$site\"}",
+          "refId": "A",
+          "legendFormat": "{{name}} {{port_name}}",
+          "instant": true
+        }
+      ],
+      "description": "A port that has renegotiated down shows up here before anyone notices it as slowness."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Port errors and drops",
+      "id": 35,
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 67
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "pps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "rate(unpoller_device_port_receive_errors_total{site=\"$site\"}[10m])",
+          "refId": "A",
+          "legendFormat": "{{name}} {{port_name}} rx err"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "rate(unpoller_device_port_transmit_errors_total{site=\"$site\"}[10m])",
+          "refId": "B",
+          "legendFormat": "{{name}} {{port_name}} tx err"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "rate(unpoller_device_port_receive_dropped_total{site=\"$site\"}[10m])",
+          "refId": "C",
+          "legendFormat": "{{name}} {{port_name}} rx drop"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "rate(unpoller_device_port_transmit_dropped_total{site=\"$site\"}[10m])",
+          "refId": "D",
+          "legendFormat": "{{name}} {{port_name}} tx drop"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Aggregation uplink \u2014 Hawkfield",
+      "id": 36,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "LAG member throughput",
+      "id": 37,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 74
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 800000000
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_port_receive_rate_bytes{site=\"hawkfield\",name=\"USW Aggregation\",port_num=~\"7|8\"} * 8",
+          "refId": "A",
+          "legendFormat": "{{port_name}} rx"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_port_transmit_rate_bytes{site=\"hawkfield\",name=\"USW Aggregation\",port_num=~\"7|8\"} * 8",
+          "refId": "B",
+          "legendFormat": "{{port_name}} tx"
+        }
+      ],
+      "description": "The two LAG members individually. A single TCP flow cannot exceed one member, so a large transfer tops out at 1 Gbps even with both legs up."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "LAG utilisation against the 2 Gbps ceiling",
+      "id": 38,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 74
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "(sum(unpoller_device_port_receive_rate_bytes{site=\"hawkfield\",name=\"USW Aggregation\",port_num=~\"7|8\"}) + sum(unpoller_device_port_transmit_rate_bytes{site=\"hawkfield\",name=\"USW Aggregation\",port_num=~\"7|8\"})) * 8 / sum(unpoller_device_port_port_speed_bps{site=\"hawkfield\",name=\"USW Aggregation\",port_num=~\"7|8\"}) * 100",
+          "refId": "A",
+          "legendFormat": "utilisation"
+        }
+      ],
+      "description": "The 10G spine reaches the rest of the LAN through 2 Gbps. Traffic that stays on the aggregation switch is unaffected; anything north-south shares this."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "stat",
+      "title": "LAG members up",
+      "id": 39,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 82
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 2
+              },
+              {
+                "color": "green",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "count(unpoller_device_port_port_speed_bps{site=\"hawkfield\",name=\"USW Aggregation\",port_num=~\"7|8\"} > 0)",
+          "refId": "A",
+          "legendFormat": "members",
+          "instant": true
+        }
+      ],
+      "description": "Two. If this reads 1 the capacity has silently halved and every other panel still looks healthy."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "stat",
+      "title": "LAG capacity",
+      "id": 40,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 82
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "sum(unpoller_device_port_port_speed_bps{site=\"hawkfield\",name=\"USW Aggregation\",port_num=~\"7|8\"})",
+          "refId": "A",
+          "legendFormat": "capacity",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "bargauge",
+      "title": "Per-member link speed",
+      "id": 41,
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 82
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "maxVizHeight": 300,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_port_port_speed_bps{site=\"hawkfield\",name=\"USW Aggregation\",port_num=~\"7|8\"}",
+          "refId": "A",
+          "legendFormat": "{{port_name}}",
+          "instant": true
+        }
+      ],
+      "description": "1 Gbps per member is the ceiling: the Loft Switch's SFP ports are 1G only, so this is the hardware limit, not a fault."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Member balance",
+      "id": 42,
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 82
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "(unpoller_device_port_receive_rate_bytes{site=\"hawkfield\",name=\"USW Aggregation\",port_num=~\"7|8\"} + unpoller_device_port_transmit_rate_bytes{site=\"hawkfield\",name=\"USW Aggregation\",port_num=~\"7|8\"}) * 8",
+          "refId": "A",
+          "legendFormat": "{{port_name}} total"
+        }
+      ],
+      "description": "Both members carrying traffic means the hash is spreading flows. Sustained traffic on one leg only means it is pinning them."
+    },
+    {
+      "type": "row",
+      "title": "PoE \u2014 Hawkfield",
+      "id": 43,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 86
+      },
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "bargauge",
+      "title": "PoE draw per port",
+      "id": 44,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 87
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 12
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "maxVizHeight": 300,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_device_port_poe_watts{site=\"hawkfield\"} > 0",
+          "refId": "A",
+          "legendFormat": "{{name}} {{port_name}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "stat",
+      "title": "Total PoE draw",
+      "id": 45,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 8,
+        "y": 87
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watt",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "sum(unpoller_device_port_poe_watts{site=\"hawkfield\"})",
+          "refId": "A",
+          "legendFormat": "total",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "PoE draw against switch budget",
+      "id": 46,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 87
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "sum by (name) (unpoller_device_port_poe_watts{site=\"hawkfield\"}) / on(name) group_left() (unpoller_device_max_power_total > 0) * 100",
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ],
+      "description": "Against the switch's own PoE budget \u2014 95 W on the Loft Switch. Filtered to switches that supply PoE, so the aggregation switch is absent by design rather than missing."
+    },
+    {
+      "type": "row",
+      "title": "Clients \u2014 $site",
+      "id": 47,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 94
+      },
+      "panels": [],
+      "repeat": "site",
+      "repeatDirection": "h"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "stat",
+      "title": "Wired",
+      "id": 48,
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 95
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_topology_connections_wired{site=\"$site\"}",
+          "refId": "A",
+          "legendFormat": "wired",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "stat",
+      "title": "Wireless",
+      "id": 49,
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 95
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_topology_connections_wireless{site=\"$site\"}",
+          "refId": "A",
+          "legendFormat": "wireless",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "Clients by band",
+      "id": 50,
+      "gridPos": {
+        "h": 4,
+        "w": 9,
+        "x": 6,
+        "y": 95
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_topology_connections_by_band{site=\"$site\"}",
+          "refId": "A",
+          "legendFormat": "{{band}}"
+        }
+      ],
+      "description": "Band labels are the console's own: ng is 2.4 GHz, na is 5 GHz."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "timeseries",
+      "title": "DHCP pool utilisation",
+      "id": 51,
+      "gridPos": {
+        "h": 4,
+        "w": 9,
+        "x": 15,
+        "y": 95
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "unpoller_dhcp_utilization_percent{site=\"$site\"}",
+          "refId": "A",
+          "legendFormat": "{{network}}"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "afnx6ohyogi68e"
+      },
+      "type": "table",
+      "title": "Top talkers",
+      "id": 52,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 99
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "afnx6ohyogi68e"
+          },
+          "expr": "topk(10, (unpoller_client_receive_rate_bytes{site=\"$site\"} + unpoller_client_transmit_rate_bytes{site=\"$site\"}) * 8)",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true,
+              "site_name": true,
+              "source": true,
+              "tag": true,
+              "site": true,
+              "mac": true,
+              "oui": true,
+              "network": true,
+              "gw_name": true
+            },
+            "renameByName": {
+              "name": "Client",
+              "ip": "IP",
+              "ap_name": "Access point",
+              "wired": "Wired",
+              "Value": "Rate"
+            }
+          }
+        }
+      ],
+      "description": "Combined receive and transmit rate, wired and wireless."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #444. **Not merging this one — leaving it for you.**

## Dashboards as code

Grafana had no provisioning mechanism at all: all ten existing dashboards live only in the
NFS-backed SQLite, created through the API. #444 asks for this dashboard to come from the Flux
repo, so this adds the missing piece — a file provider (`grafana-dashboard-provider`) plus a
`configMapGenerator` of dashboard JSON, mounted at `/etc/grafana/dashboards`.

The provider only manages dashboards in its own path, so **the ten existing dashboards are
untouched**. It rescans every 60s, so a dashboard edit reaches the UI without a pod restart.
Provisioned dashboards are read-only in the UI, which is the point — git owns this one.

Note this rolls Grafana once, on the `Recreate` strategy it already has for the bleve NFS lock.

## The dashboard

`unifi-network`, 8 rows / 44 panels. A `site` variable drives **per-site repeated rows** for
WAN, console health, WiFi, switching and clients — the two sites are very different shapes and
a flat grid would be half-empty for London. Two rows deliberately do **not** repeat:
`Aggregation uplink — Hawkfield` and `PoE — Hawkfield`, because that hardware only exists at
one site. A row that says so beats one that renders blank whenever London is selected.

Panels against the issue's list:

| Asked for | Panel |
|---|---|
| WAN throughput per site | `WAN throughput`, plus utilisation against the provisioned line rate |
| ISP latency | `Internet latency` — console probe + gateway uplink |
| Packet loss | **Not available** — see below |
| WAN uptime, WAN IP | `WAN uptime`, `Uplink up for`, `WAN IP` stat |
| Console CPU/mem/temp/load | `Console and device health` row, temperature thresholded at 80/90 °C |
| Per-AP clients, channel utilisation, TX rate | `WiFi` row |
| Per-port throughput, errors, PoE | `Switching` row + `PoE` row |
| The 2 Gbps LAG | `Aggregation uplink` row, five panels |
| Clients by site and type, top talkers | `Clients` row |

## Verification

Every panel query was executed against live Prometheus before committing — **114 query
executions across 44 panels for both sites, all returning series.** The JSON was also POSTed to
the live Grafana under a scratch uid to confirm it parses at schemaVersion 42 with the row
repeats and variable intact, then deleted; Grafana is back to its original ten dashboards.

## Three things worth flagging

1. **The LAG question in the issue is answered: both members are passing traffic**, so the hash
   is spreading flows rather than pinning them to one leg. Distribution is uneven (roughly 3:1
   at the time of checking), which is normal for a per-flow hash with few large flows. The
   `Member balance` panel makes a future change visible. A single TCP flow still cannot exceed
   1 Gbps, and the panel description says so.

2. **No optics panel.** Every `unpoller_device_port_sfp_*` reading is 0 on both switches —
   temperature, rx power, voltage — because those SFP/SFP+ links are direct-attach copper,
   which carries no digital diagnostics. A transceiver panel could never have data, so that
   slot shows PoE draw against the switch's own budget instead (Loft Switch: 34.2 W of 95 W).

3. **Packet loss is not available.** unpoller exposes no ISP path-loss metric. The closest are
   the WAN interface error and drop counters, which are on the panel and honestly labelled as
   interface-level rather than path loss. Actual reachability is the London watchdog's job
   (#433). Worth deciding whether #445 wants a real loss probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)