### PR TITLE
Alert on the UniFi network telemetry (#445)

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -225,3 +225,32 @@ jobs:
 
       - name: Apply policies to every overlay
         run: kyverno apply kubernetes/policy/ --resource built/
+
+  alert-rules:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      # Pinned to the version the cluster runs. promtool accepts PromQL that a
+      # different Prometheus would reject, so a floating version would validate
+      # rules the deployment cannot evaluate.
+      - name: Install promtool
+        env:
+          VERSION: 3.13.2
+        run: |
+          base=https://github.com/prometheus/prometheus/releases/download
+          curl -sSL "$base/v$VERSION/prometheus-$VERSION.linux-amd64.tar.gz" \
+            | sudo tar xz -C /usr/local/bin --strip-components=1 \
+                "prometheus-$VERSION.linux-amd64/promtool"
+
+      - name: Check rules parse
+        run: |
+          promtool check rules \
+            kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
+
+      # The tests assert that the recorded idle values fire nothing. Thresholds
+      # here were guessed off three hours of data, so this is what catches a
+      # rule that would page at baseline and get muted.
+      - name: Run rule unit tests
+        run: promtool test rules kubernetes/alert-rule-tests/*.yaml

--- a/Documentation/runbooks/unifi-network.md
+++ b/Documentation/runbooks/unifi-network.md
@@ -1,0 +1,258 @@
+# Runbook: UniFi network alerts
+
+Covers the alerts built on the unpoller series from clincha#443, delivered to Telegram by
+Alertmanager, plus the one network alert that cannot come from Hawkfield at all.
+
+## The alerts
+
+| Alert | Severity | Fires when |
+| --- | --- | --- |
+| `UniFiConsoleUnreachable` | critical | `unpoller_controller_up == 0` for 5m |
+| `UniFiPollerRefreshFailing` | warning | 3+ refresh failures in 15m, sustained 5m |
+| `UniFiWanLatencyHigh` | warning | WAN latency over 100ms for 15m |
+| `UniFiInternetDropping` | warning | 3+ WAN drops in an hour |
+| `UniFiAggregationLagMemberDown` | warning | fewer than 2 live members on the 2×1G LAG, for 10m |
+| `UniFiAggregationLagMemberSlow` | warning | a LAG member negotiates below 1G, for 10m |
+| `UniFiDevicesDisconnected` | warning | `unpoller_site_disconnected > 0` for 10m |
+| `UniFiDeviceRebooting` | warning | 3+ uptime resets in an hour |
+| `UniFiDeviceTemperatureHigh` | warning | any sensor over 85°C for 15m |
+| `UniFiDeviceTemperatureCritical` | critical | any sensor over 90°C for 5m |
+| `UniFiDeviceCpuHigh` | warning | CPU over 90% for 30m |
+| `UniFiPoeBudgetHigh` | warning | PoE draw over 80% of the switch budget, for 30m |
+| `UniFiSwitchPortErrors` | warning | over 1 error/s on a port for 15m |
+| `UniFiWifiChannelUtilisationHigh` | warning | 5GHz channel over 75% utilised for 30m |
+
+Alerts carry `site` (`hawkfield` or `london`) and, where the metric has one, `name` — the device
+name rather than its MAC.
+
+## The thresholds are guesses. Treat them as provisional
+
+#443 had been collecting for **three hours** when these rules were written, so not one threshold
+is derived from a baseline. Each is set clear of observed idle:
+
+| Signal | Observed idle (2026-08-10) | Threshold |
+| --- | --- | --- |
+| Bristol temperature | 67°C CPU / 71°C board | 85 warning, 90 critical |
+| London temperature | 74°C CPU / 77°C board | 85 warning, 90 critical |
+| Device CPU | 0.4–16.6% | 90% |
+| WAN latency | 3–4ms | 100ms |
+| 5GHz channel utilisation | peaks 55% (Kitchen) | 75% |
+| Loft Switch PoE | 35.4W of a 95W budget | 80% of budget |
+
+Revisit all of them once there are a couple of weeks of data. If one turns out to be noise, move
+the threshold — do not mute the alert.
+
+**Gateway memory has no rule at all.** Both UDMs idle at 83–86% memory utilisation, so a
+conventional ">80%" rule fires the moment it lands and ">95%" has no evidence behind it. The
+gateway is covered by CPU, temperature and `UniFiDeviceRebooting` instead, the last of which is
+what an out-of-memory event actually looks like from outside.
+
+Note also that the 83°C figure quoted in #445 for Bristol does not match any sensor the poller
+exposes; the box reads 67°C CPU / 71°C board. Do not treat 83°C as Bristol's baseline.
+
+## How the alert reaches you
+
+```
+UniFi consoles (10.1.2.1, 10.2.2.1) → unpoller (60s cache) → Prometheus (30s scrape)
+       → alert rules → Alertmanager → Telegram (clincha_grafana_bot)
+```
+
+unpoller **caches and serves; it does not poll on scrape**. Values are up to 60s stale, which is
+why no rule here has a `for` shorter than 5m.
+
+- Rules: `kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml`
+- Routing: `kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager.yml`
+- Collector: `kubernetes/flux/infrastructure/base/monitoring/unpoller.yml` and
+  `hawkfield/monitoring/up.conf`
+- Console credentials: Bitwarden `unifipoller (Bristol)` / `unifipoller (London)` — read-only
+  local accounts, verified as such
+- Dashboard: Grafana uid `unifi-network`
+
+Metric names are prefixed **`unpoller_`, not `unifi_`** — renamed in unpoller v3. Older blog
+posts and community dashboards all use the old prefix and will silently match nothing.
+
+## The one alert that cannot come from Hawkfield
+
+**Hawkfield cannot alert on the loss of its own WAN.** Prometheus, Alertmanager and the only
+route to Telegram all sit behind it. Every rule above goes silent in exactly the event you most
+want to hear about.
+
+That alert is the `hawkfield gateway` monitor on the London watchdog
+(`terraform/watchdog/main.tf`), which probes **10.1.2.1:443 over the site-to-site link**, not the
+WAN IP. The WAN IP drops ICMP and opens only 443, and that 443 is the ingress port-forward — so
+probing `185.23.254.226` would only duplicate the existing `hawkfield public` monitor rather than
+isolate the WAN.
+
+Hawkfield has a single WAN and the VPN rides it, so one probe covers WAN loss, site-link loss and
+a site power cut. Read it alongside the public monitor:
+
+| `hawkfield gateway` | `hawkfield public` | Means |
+| --- | --- | --- |
+| down | down | WAN, site-to-site link, or site power |
+| up | down | ingress, the cluster, or the port-forward |
+| down | up | site-to-site link only — the site is fine and reachable publicly |
+
+If **both** sites go dark at once, nothing alerts. That is a known and accepted gap.
+
+## Quiet hours
+
+Warnings are muted 23:00–06:00 Europe/London; criticals are never muted. Muting suppresses, it
+does not queue — a warning that fires *and resolves* inside the window is never announced.
+
+Only `UniFiConsoleUnreachable` and `UniFiDeviceTemperatureCritical` are critical, so those two
+are the only network rules that will wake you. Everything else waits for 06:00. The London
+watchdog notifies through its own Telegram path and is not subject to this mute at all.
+
+## Triage
+
+### `UniFiConsoleUnreachable`
+
+The summary deliberately does not claim the console is down, because from Hawkfield the two cases
+are indistinguishable — the poller sits at Hawkfield, so London going unreachable could equally
+be the site-to-site link.
+
+```bash
+# Which console, and is it the box or the path?
+curl -sk https://10.1.2.1/api/system | jq .        # Bristol, answers unauthenticated
+curl -sk https://10.2.2.1/api/system | jq .        # London, over the site link
+
+# If London is unreachable, check whether anything else at London answers
+ping -c3 10.2.2.101
+```
+
+Bristol unreachable while the cluster is up means the console itself. London unreachable while
+`10.2.2.101` also fails to answer means the link, not the console. Check the watchdog's own view
+before concluding anything about London.
+
+If both consoles report unreachable simultaneously, suspect the poller rather than two
+independent console failures:
+
+```bash
+kubectl -n monitoring logs deploy/unpoller --tail=50
+kubectl -n monitoring get pods -l app=unpoller
+```
+
+### `UniFiDevicesDisconnected`
+
+The alert is site-and-subsystem level and does not name the device, because whether an offline
+device is dropped from the export or merely reported stale has not been confirmed against a real
+outage. Name it by comparing against the adopted count and the device list:
+
+```promql
+# which subsystem, how many
+unpoller_site_disconnected > 0
+
+# every device the poller can currently see, by name
+unpoller_device_info
+
+# devices seen two hours ago but not now
+max_over_time(unpoller_device_uptime_seconds[2h]) unless unpoller_device_uptime_seconds
+```
+
+Hawkfield should show 10 devices: the Bristol UDM, `Loft Switch`, `USW Aggregation`, and seven
+APs (`Hall`, `Kitchen`, `Living Room`, `Master Bedroom`, `First Floor Landing`, `Loft Landing`,
+`Paddock`). London has the console only.
+
+`Paddock` is an outbuilding AP and the most likely to drop for reasons that are not a fault.
+
+### `UniFiAggregationLagMemberDown` — read this one carefully
+
+This is the alert most likely to catch something nothing else would.
+
+`USW Aggregation` carries the 10G spine: the cluster nodes and hawkstore hang off ports 2–6 at
+10G. Its uplink to the rest of the LAN is a **two-member LAG on ports 7/8 into Loft Switch ports
+25/26, negotiating 1 Gbps per member** — the USL24P's SFP ports are 1G-only, so 2 Gbps is as fast
+as the hardware goes. That is not a fault.
+
+Lose one member and north-south capacity halves to 1 Gbps **silently**. Traffic that stays on the
+aggregation switch is unaffected, so NFS between the cluster and the NAS still runs at 10G and
+looks perfectly healthy. Anything crossing the uplink degrades. From every other panel this
+presents as "the NAS is slow" or "Plex is buffering" — which is the shape of the last two
+incidents in this estate.
+
+```promql
+# per-member negotiated speed; expect two series at 1e9
+unpoller_device_port_port_speed_bps{name="USW Aggregation", port_num=~"7|8"}
+
+# throughput per member — are both actually passing traffic?
+rate(unpoller_device_port_receive_bytes_total{name="USW Aggregation", port_num=~"7|8"}[5m])
+```
+
+Check the physical SFP and the patch at both ends before assuming a switch fault. A LAG running
+on one leg reports no error anywhere else.
+
+Note that a two-member LAG does not split a single TCP flow, so one heavy transfer sees 1 Gbps
+even when both members are healthy. Do not read that as a fault.
+
+### Temperature alerts
+
+Bristol sits in the loft; London is in the Solon Road flat and runs the hotter of the two. Both
+are UDM gen 1 with passive cooling, so ambient temperature moves them directly — a warning during
+a heatwave is more likely to be the room than the box.
+
+```promql
+unpoller_device_temperature_celsius
+max_over_time(unpoller_device_temperature_celsius[7d])
+```
+
+Check airflow and dust before anything else. A gateway that is both hot and rebooting
+(`UniFiDeviceRebooting`) is a hardware conversation, not a tuning one.
+
+### `UniFiSwitchPortErrors`
+
+Almost always a cable, an SFP, or a duplex mismatch — in that order of likelihood.
+
+```promql
+rate(unpoller_device_port_receive_errors_total[15m]) > 0
+rate(unpoller_device_port_transmit_errors_total[15m]) > 0
+unpoller_device_port_sfp_rx_power   # for the 10G SFP+ ports
+```
+
+Falling `sfp_rx_power` on a port that is throwing errors points at the optic or the fibre.
+
+### `UniFiWifiChannelUtilisationHigh`
+
+5GHz only. 2.4GHz is deliberately not alerted on: it already peaks over 50% at idle here from
+neighbouring networks and IoT devices, and there is nothing actionable to do about it.
+
+This is the signal that would have shown the ~30 Mbps WiFi ceiling behind the 33.8 Mbps Plex
+remux stuttering, months before it was diagnosed by hand.
+
+```promql
+unpoller_device_radio_channel_utilization_total_ratio{band="5"}
+unpoller_device_radio_channel{band="5"}     # are two APs sharing a channel?
+unpoller_device_radio_stations{band="5"}    # client count per radio
+```
+
+## Changing the alerts
+
+```bash
+# rules
+kubectl -n monitoring exec -i deploy/prometheus -- sh -c 'cat > /tmp/r.yml && promtool check rules /tmp/r.yml' \
+  < kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
+
+# unit tests, which run in CI too
+promtool test rules kubernetes/alert-rule-tests/unifi-network.yaml
+```
+
+Rules land through Flux. A green reconcile means the ConfigMap changed, **not** that Prometheus
+reloaded it — confirm against <https://prometheus.clinch-home.com/rules> before believing a
+change is live.
+
+## Known noise sources
+
+- **Paddock AP** — outbuilding, most likely to disconnect for benign reasons.
+- **2.4GHz utilisation** — over 50% at idle. Not alerted on, and should stay that way.
+- **Gateway memory at 83–86%** — normal for a UDM. Not alerted on.
+- **Firmware updates** — `unpoller_device_upgradable` exists and is 0 across the estate, but
+  there is no rule. An informational alert has no severity that routes anywhere except the
+  unmuted default, so it would arrive overnight. Add it as a dashboard panel instead.
+
+## Not yet covered
+
+- **Both sites dark simultaneously.** Hawkfield and London watch each other; nothing watches the
+  pair. A deliberate choice — do not re-propose a third-party dead-man's switch without asking.
+- **Per-client alerting.** Client series exist (`unpoller_client_*`) but a per-client alert on a
+  home network is noise by construction.
+- **Verification against real conditions.** See the verification note on #445 — several rules
+  here have only ever been exercised against replayed series, not an induced fault.

--- a/kubernetes/alert-rule-tests/unifi-network.yaml
+++ b/kubernetes/alert-rule-tests/unifi-network.yaml
@@ -1,0 +1,318 @@
+---
+# Unit tests for the UniFi alert rules (clincha#445).
+#
+# Every threshold in these rules was a guess — #443 had run for three hours when
+# they were written. The most valuable test here is the last one: it replays the
+# real idle values recorded on 2026-08-10 and asserts that nothing fires. A rule
+# that pages at baseline gets muted, and a muted rule is worse than no rule.
+rule_files:
+  - ../flux/infrastructure/hawkfield/monitoring/alert-rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    name: console goes unreachable
+    input_series:
+      - series: 'unpoller_controller_up{site="hawkfield", source="https://10.1.2.1"}'
+        values: '1 1 1 0 0 0 0 0 0 0 0 0'
+    alert_rule_test:
+      # Down since t=3m. Not yet 5m at t=7m, so it must still be silent.
+      - eval_time: 7m
+        alertname: UniFiConsoleUnreachable
+        exp_alerts: []
+      - eval_time: 9m
+        alertname: UniFiConsoleUnreachable
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              site: hawkfield
+              source: https://10.1.2.1
+            exp_annotations:
+              summary: 'UniFi console unreachable from the poller — console, or the path to it'
+              runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+  # The alert the milestone exists for. One member dying halves north-south
+  # capacity while every other panel stays green.
+  - interval: 1m
+    name: an aggregation LAG member drops
+    input_series:
+      - series: >-
+          unpoller_device_port_port_speed_bps{site="hawkfield", name="USW Aggregation", port_num="7",
+          port_name="SFP+ 7"}
+        values: '1e9+0x20'
+      - series: >-
+          unpoller_device_port_port_speed_bps{site="hawkfield", name="USW Aggregation", port_num="8",
+          port_name="SFP+ 8"}
+        values: '1e9 1e9 1e9 0+0x20'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: UniFiAggregationLagMemberDown
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: UniFiAggregationLagMemberDown
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              site: hawkfield
+              name: USW Aggregation
+            exp_annotations:
+              summary: 'aggregation LAG down to 1 of 2 members — uplink capacity halved'
+              runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+  - interval: 1m
+    name: a LAG member negotiates below 1G
+    input_series:
+      - series: >-
+          unpoller_device_port_port_speed_bps{site="hawkfield", name="USW Aggregation", port_num="7",
+          port_name="SFP+ 7"}
+        values: '1e8+0x20'
+      - series: >-
+          unpoller_device_port_port_speed_bps{site="hawkfield", name="USW Aggregation", port_num="8",
+          port_name="SFP+ 8"}
+        values: '1e9+0x20'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: UniFiAggregationLagMemberSlow
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              site: hawkfield
+              name: USW Aggregation
+              port_num: '7'
+              port_name: SFP+ 7
+            exp_annotations:
+              summary: 'LAG member negotiated 100000000 bps, below the expected 1G'
+              runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+      # Both members still count as live, so the member-down rule stays quiet —
+      # a degraded member is a different event from a missing one.
+      - eval_time: 15m
+        alertname: UniFiAggregationLagMemberDown
+        exp_alerts: []
+
+  - interval: 1m
+    name: an AP disconnects
+    input_series:
+      - series: 'unpoller_site_disconnected{site="hawkfield", subsystem="wlan", status="ok"}'
+        values: '0 0 0 1+0x20'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: UniFiDevicesDisconnected
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              site: hawkfield
+              subsystem: wlan
+              status: ok
+            exp_annotations:
+              summary: '1 wlan device(s) disconnected'
+              runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+  - interval: 1m
+    name: a gateway overheats
+    input_series:
+      - series: >-
+          unpoller_device_temperature_celsius{site="london", name="London", temp_area="Local", temp_type="board"}
+        values: '88+0x30'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: UniFiDeviceTemperatureHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              site: london
+              name: London
+              temp_area: Local
+              temp_type: board
+            exp_annotations:
+              summary: 'Local at 88.0°C for 15 minutes'
+              runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+      # 88 is over the warning line but under the critical one.
+      - eval_time: 20m
+        alertname: UniFiDeviceTemperatureCritical
+        exp_alerts: []
+
+  # PoE headroom on the USL24P. The aggregation switch is in the series set on
+  # purpose: it has no PoE and reports a budget of 0, which would divide into
+  # +Inf and alert forever if the rule did not filter it out.
+  - interval: 1m
+    name: PoE draw approaches the switch budget
+    input_series:
+      - series: 'unpoller_device_port_poe_watts{site="hawkfield", name="Loft Switch", port_num="1"}'
+        values: '40+0x40'
+      - series: 'unpoller_device_port_poe_watts{site="hawkfield", name="Loft Switch", port_num="2"}'
+        values: '40+0x40'
+      - series: 'unpoller_device_max_power_total{site="hawkfield", name="Loft Switch", type="usw"}'
+        values: '95+0x40'
+      - series: 'unpoller_device_max_power_total{site="hawkfield", name="USW Aggregation", type="usw"}'
+        values: '0+0x40'
+      - series: 'unpoller_device_port_poe_watts{site="hawkfield", name="USW Aggregation", port_num="1"}'
+        values: '0+0x40'
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: UniFiPoeBudgetHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              site: hawkfield
+              name: Loft Switch
+            exp_annotations:
+              summary: 'PoE draw at 84.21% of the switch budget'
+              runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+  # 2.4GHz is in the series set to prove the band filter holds: it sits above
+  # the threshold throughout and must never produce an alert.
+  - interval: 1m
+    name: 5GHz saturates but 2.4GHz is ignored
+    input_series:
+      - series: >-
+          unpoller_device_radio_channel_utilization_total_ratio{site="hawkfield", name="Kitchen", band="5", radio="na"}
+        values: '0.85+0x40'
+      - series: >-
+          unpoller_device_radio_channel_utilization_total_ratio{site="hawkfield", name="Paddock", band="2.4",
+          radio="ng"}
+        values: '0.95+0x40'
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: UniFiWifiChannelUtilisationHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              site: hawkfield
+              name: Kitchen
+              band: '5'
+              radio: na
+            exp_annotations:
+              summary: '5GHz channel 85% utilised for 30 minutes'
+              runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+  - interval: 1m
+    name: WAN latency climbs
+    input_series:
+      - series: 'unpoller_site_latency_seconds{site="hawkfield", subsystem="www", status="ok"}'
+        values: '0.25+0x20'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: UniFiWanLatencyHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              site: hawkfield
+              subsystem: www
+              status: ok
+            exp_annotations:
+              summary: 'WAN latency 250ms sustained over 15 minutes'
+              runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+  # The one that matters most. Real values recorded from the estate at idle on
+  # 2026-08-10, replayed for 45 minutes. If any rule fires here, its threshold
+  # is wrong and it will be muted within a week.
+  - interval: 1m
+    name: nothing fires at recorded idle
+    input_series:
+      - series: 'unpoller_controller_up{site="hawkfield", source="https://10.1.2.1"}'
+        values: '1+0x50'
+      - series: 'unpoller_controller_up{site="london", source="https://10.2.2.1"}'
+        values: '1+0x50'
+      - series: 'unpoller_site_latency_seconds{site="hawkfield", subsystem="www", status="ok"}'
+        values: '0.004+0x50'
+      - series: 'unpoller_site_latency_seconds{site="london", subsystem="www", status="ok"}'
+        values: '0.003+0x50'
+      - series: 'unpoller_site_disconnected{site="hawkfield", subsystem="wlan", status="ok"}'
+        values: '0+0x50'
+      - series: 'unpoller_site_intenet_drops_total{site="hawkfield", subsystem="www", status="ok"}'
+        values: '1+0x50'
+      - series: >-
+          unpoller_device_temperature_celsius{site="hawkfield", name="Bristol", temp_area="CPU", temp_type="cpu"}
+        values: '66.75+0x50'
+      - series: >-
+          unpoller_device_temperature_celsius{site="hawkfield", name="Bristol", temp_area="Local", temp_type="board"}
+        values: '70+0x50'
+      # The hottest thing in the estate. It must not page at rest.
+      - series: 'unpoller_device_temperature_celsius{site="london", name="London", temp_area="CPU", temp_type="cpu"}'
+        values: '72.375+0x50'
+      - series: >-
+          unpoller_device_temperature_celsius{site="london", name="London", temp_area="Local", temp_type="board"}
+        values: '75+0x50'
+      - series: 'unpoller_device_cpu_utilization_ratio{site="hawkfield", name="Bristol", type="udm"}'
+        values: '0.166+0x50'
+      - series: 'unpoller_device_cpu_utilization_ratio{site="hawkfield", name="Loft Switch", type="usw"}'
+        values: '0.151+0x50'
+      # Kitchen 5GHz peaked at 0.55 in the first three hours of collection —
+      # the closest any idle signal gets to its threshold.
+      - series: >-
+          unpoller_device_radio_channel_utilization_total_ratio{site="hawkfield", name="Kitchen", band="5", radio="na"}
+        values: '0.55+0x50'
+      - series: >-
+          unpoller_device_radio_channel_utilization_total_ratio{site="hawkfield", name="Paddock", band="2.4",
+          radio="ng"}
+        values: '0.51+0x50'
+      - series: 'unpoller_device_port_poe_watts{site="hawkfield", name="Loft Switch", port_num="1"}'
+        values: '35.36+0x50'
+      - series: 'unpoller_device_max_power_total{site="hawkfield", name="Loft Switch", type="usw"}'
+        values: '95+0x50'
+      - series: 'unpoller_device_max_power_total{site="hawkfield", name="USW Aggregation", type="usw"}'
+        values: '0+0x50'
+      - series: >-
+          unpoller_device_port_port_speed_bps{site="hawkfield", name="USW Aggregation", port_num="7",
+          port_name="SFP+ 7"}
+        values: '1e9+0x50'
+      - series: >-
+          unpoller_device_port_port_speed_bps{site="hawkfield", name="USW Aggregation", port_num="8",
+          port_name="SFP+ 8"}
+        values: '1e9+0x50'
+      - series: 'unpoller_device_uptime_seconds{site="hawkfield", name="Bristol", type="udm"}'
+        values: '703403+60x50'
+      - series: >-
+          unpoller_device_port_receive_errors_total{site="hawkfield", name="Loft Switch", port_num="1",
+          port_name="Port 1"}
+        values: '0+0x50'
+      - series: >-
+          unpoller_device_port_transmit_errors_total{site="hawkfield", name="Loft Switch", port_num="1",
+          port_name="Port 1"}
+        values: '0+0x50'
+      - series: 'unpoller_prometheus_refresh_failures_total{site="hawkfield"}'
+        values: '0+0x50'
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: UniFiConsoleUnreachable
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiPollerRefreshFailing
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiWanLatencyHigh
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiInternetDropping
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiAggregationLagMemberDown
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiAggregationLagMemberSlow
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiDevicesDisconnected
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiDeviceRebooting
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiDeviceTemperatureHigh
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiDeviceTemperatureCritical
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiDeviceCpuHigh
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiPoeBudgetHigh
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiSwitchPortErrors
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiWifiChannelUtilisationHigh
+        exp_alerts: []

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
@@ -33,3 +33,184 @@ groups:
         annotations:
           summary: 'stuck in CrashLoopBackOff for over 15 minutes'
           runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/pod-restarts.md
+
+  # unpoller serves a 60s cache rather than polling on scrape, so every value
+  # here is up to a minute stale. Nothing below has a `for` shorter than 5m,
+  # which keeps that staleness well inside the noise.
+  #
+  # Hawkfield cannot alert on the loss of its own WAN — Prometheus, Alertmanager
+  # and Telegram's only egress all sit behind it. That alert comes from the
+  # London watchdog instead (terraform/watchdog).
+  - name: unifi-reachability
+    rules:
+      # Cannot tell "the console is down" from "the path to it is down": the
+      # poller runs at Hawkfield, so London going unreachable could equally be
+      # the site-to-site link. The runbook discriminates; the summary does not
+      # pretend to.
+      - alert: UniFiConsoleUnreachable
+        expr: unpoller_controller_up == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'UniFi console unreachable from the poller — console, or the path to it'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+      - alert: UniFiPollerRefreshFailing
+        expr: increase(unpoller_prometheus_refresh_failures_total[15m]) >= 3
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'unpoller failed {{ $value | printf "%.0f" }} refreshes in 15m — series are going stale'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+  - name: unifi-wan
+    rules:
+      # Both sites idle at 3-4 ms, so 100 ms is well clear of normal without
+      # being so high that it only fires once the line is unusable.
+      - alert: UniFiWanLatencyHigh
+        expr: unpoller_site_latency_seconds{subsystem="www"} > 0.1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'WAN latency {{ $value | humanizeDuration }} sustained over 15 minutes'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+      - alert: UniFiInternetDropping
+        expr: increase(unpoller_site_intenet_drops_total[1h]) >= 3
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'WAN dropped {{ $value | printf "%.0f" }} times in the last hour'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+  # The aggregation switch carries the 10G spine but uplinks to the Loft Switch
+  # over a 2x1G LAG on ports 7/8 — the USL24P's SFP ports are 1G-only. Lose a
+  # member and north-south capacity halves to 1 Gbps while every other panel and
+  # every other alert still reads healthy. Nothing else in the estate sees this.
+  #
+  # Total loss of the switch is deliberately not handled here; that surfaces as
+  # UniFiDevicesDisconnected rather than as a second copy of this alert.
+  - name: unifi-aggregation-lag
+    rules:
+      - alert: UniFiAggregationLagMemberDown
+        expr: |
+          count by (site, name) (
+            unpoller_device_port_port_speed_bps{name="USW Aggregation", port_num=~"7|8"} > 0
+          ) < 2
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'aggregation LAG down to {{ $value | printf "%.0f" }} of 2 members — uplink capacity halved'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+      - alert: UniFiAggregationLagMemberSlow
+        expr: unpoller_device_port_port_speed_bps{name="USW Aggregation", port_num=~"7|8"} > 0 < 1e9
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'LAG member negotiated {{ $value | printf "%.0f" }} bps, below the expected 1G'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+  - name: unifi-devices
+    rules:
+      # Site-level rather than per-device: unpoller reports a disconnected count
+      # per subsystem, which is a fact it publishes directly, whereas naming the
+      # device depends on whether an offline device is dropped from the export
+      # or merely reported stale. The runbook has the query that names it.
+      - alert: UniFiDevicesDisconnected
+        expr: unpoller_site_disconnected > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: '{{ $value | printf "%.0f" }} {{ $labels.subsystem }} device(s) disconnected'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+      # Catches a device that re-adopts in a loop, which the disconnected count
+      # misses whenever the flap settles between two refreshes.
+      - alert: UniFiDeviceRebooting
+        expr: resets(unpoller_device_uptime_seconds[1h]) >= 3
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'rebooted {{ $value | printf "%.0f" }} times in the last hour'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+  # Thresholds here are deliberate guesses. #443 had run for three hours when
+  # these were written, so each one is set clear of the observed idle rather
+  # than derived from a baseline, and is meant to be revisited against real
+  # data. Gateway memory has no rule at all: the UDMs idle at 83-86% and any
+  # static threshold would either fire immediately or never fire in time.
+  - name: unifi-health
+    rules:
+      # Observed idle: Bristol 67 CPU / 71 board, London 74 CPU / 77 board.
+      - alert: UniFiDeviceTemperatureHigh
+        expr: unpoller_device_temperature_celsius > 85
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: '{{ $labels.temp_area }} at {{ $value | printf "%.1f" }}°C for 15 minutes'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+      - alert: UniFiDeviceTemperatureCritical
+        expr: unpoller_device_temperature_celsius > 90
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: '{{ $labels.temp_area }} at {{ $value | printf "%.1f" }}°C — thermal, check airflow'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+      - alert: UniFiDeviceCpuHigh
+        expr: unpoller_device_cpu_utilization_ratio > 0.9
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'CPU at {{ $value | humanizePercentage }} for 30 minutes'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+      # max_power_total is 0 on the aggregation switch, which has no PoE at all,
+      # so filter it out rather than dividing by zero into +Inf.
+      - alert: UniFiPoeBudgetHigh
+        expr: |
+          sum by (site, name) (unpoller_device_port_poe_watts)
+            / on (site, name) (max by (site, name) (unpoller_device_max_power_total > 0))
+            > 0.8
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'PoE draw at {{ $value | humanizePercentage }} of the switch budget'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+      - alert: UniFiSwitchPortErrors
+        expr: |
+          rate(unpoller_device_port_receive_errors_total[15m]) > 1
+            or rate(unpoller_device_port_transmit_errors_total[15m]) > 1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: '{{ $value | printf "%.1f" }} errors/s on {{ $labels.port_name }} — suspect cable or SFP'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+      # 5 GHz only. 2.4 GHz is congested by neighbours and IoT and already peaks
+      # over 50% at idle here, so alerting on it would be noise you cannot act
+      # on. 5 GHz is where the 33.8 Mbps Plex remux ceiling lives.
+      - alert: UniFiWifiChannelUtilisationHigh
+        expr: unpoller_device_radio_channel_utilization_total_ratio{band="5"} > 0.75
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: '5GHz channel {{ $value | humanizePercentage }} utilised for 30 minutes'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alertmanager.yml
@@ -3,7 +3,10 @@ global:
 
 route:
   receiver: telegram
-  group_by: ['alertname', 'namespace']
+  # `site` and `name` are absent on the pod alerts, which groups them exactly as
+  # before. Without them every UniFi alert of one name collapses into a single
+  # group, so seven APs dropping would arrive as one message naming none of them.
+  group_by: ['alertname', 'namespace', 'site', 'name']
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 6h
@@ -55,13 +58,23 @@ receivers:
         chat_id_file: /etc/alertmanager-secrets/chat-id
         parse_mode: HTML
         send_resolved: true
+        # Pod alerts identify by namespace/pod, UniFi alerts by site/device —
+        # they share no labels, so the subject line has to branch. Without this
+        # every network alert renders as a bare "/".
         message: |-
           {{ if eq .Status "firing" }}🔴 <b>FIRING</b>
           {{- else }}✅ <b>RESOLVED</b>
           {{- end }} — {{ .CommonLabels.alertname }}
           {{ range .Alerts -}}
-          <b>{{ .Labels.namespace }}/{{ .Labels.pod }}</b>
+          {{ if .Labels.namespace }}<b>{{ .Labels.namespace }}/{{ .Labels.pod }}</b>
           {{- if .Labels.container }} ({{ .Labels.container }})
+          {{- end }}
+          {{- else if .Labels.name }}<b>{{ .Labels.site }} / {{ .Labels.name }}</b>
+          {{- if .Labels.port_name }} ({{ .Labels.port_name }})
+          {{- end }}
+          {{- else if .Labels.site }}<b>{{ .Labels.site }}</b>
+          {{- if .Labels.subsystem }} ({{ .Labels.subsystem }})
+          {{- end }}
           {{- end }}
           {{ .Annotations.summary }}
           {{- if .Annotations.runbook_url }}

--- a/terraform/watchdog/main.tf
+++ b/terraform/watchdog/main.tf
@@ -22,6 +22,17 @@ locals {
   tcp_targets = {
     "hawkfield ingress" = { hostname = "10.1.2.205", port = 443 }
     "hawkstore"         = { hostname = "10.1.2.10", port = 443 }
+    # The Bristol gateway itself. Hawkfield cannot alert on the loss of its own
+    # WAN — Prometheus, Alertmanager and the only route to Telegram are all
+    # behind it — so this probe is that alert (clincha#445).
+    #
+    # It targets the LAN address over the site-to-site link rather than the WAN
+    # IP: 185.23.254.226 drops ICMP and opens only 443, which is the ingress
+    # port-forward, so probing it would just duplicate "hawkfield public".
+    # Hawkfield has a single WAN and the VPN rides it, so WAN loss, site-link
+    # loss and a power cut all take this down together. Read it against the
+    # public monitor — both down is the site, public alone is the ingress.
+    "hawkfield gateway" = { hostname = "10.1.2.1", port = 443 }
     # All three control planes individually: hawk-1 carries the VIP and does
     # not fail over, so one node down is not the same event as the cluster
     # being gone.


### PR DESCRIPTION
Closes #445.

Fourteen rules over the unpoller series from #443, routed through the existing Alertmanager → Telegram path, with a runbook at `Documentation/runbooks/unifi-network.md`.

## The thresholds are guesses, deliberately

#443 had been collecting for **three hours** when these were written. Not one threshold is derived from a baseline — each is set clear of observed idle, and the runbook records what idle actually was so they can be revisited:

| Signal | Observed idle | Threshold |
| --- | --- | --- |
| Bristol temperature | 67°C CPU / 71°C board | 85 warning, 90 critical |
| London temperature | 74°C CPU / 77°C board | 85 warning, 90 critical |
| Device CPU | 0.4–16.6% | 90% |
| WAN latency | 3–4 ms | 100 ms |
| 5GHz channel utilisation | peaks 55% (Kitchen) | 75% |
| Loft Switch PoE | 35.4 W of 95 W | 80% of budget |

Two findings worth knowing: **the 83°C quoted in #445 for Bristol does not match any sensor** — it reads 67°C CPU / 71°C board. **London is the hot one** at 74/77. And **2.4GHz already peaks over 50% at idle**, so it is deliberately not alerted on; only 5GHz is.

**Gateway memory gets no rule at all.** Both UDMs idle at 83–86%, so ">80%" fires the moment it lands and ">95%" has no evidence behind it. CPU, temperature and uptime resets cover the gateway instead — the last being what an OOM looks like from outside.

## The LAG rule

The one most likely to catch something nothing else would. `USW Aggregation` carries the 10G spine but uplinks to the Loft Switch over 2×1G on ports 7/8. Lose a member and north-south capacity halves silently — NFS between cluster and NAS still runs at 10G and looks perfectly healthy, while anything crossing the uplink degrades and presents as "the NAS is slow" or "Plex is buffering".

## Two changes outside the rules

Both required, or the alerts arrive unreadable:

1. **The Telegram template hardcoded `namespace`/`pod`.** UniFi alerts carry `site`/`name`, so every one would have rendered as a bare `/`. It now branches; pod alerts render exactly as before.
2. **`group_by` gains `site` and `name`.** Without them every UniFi alert of one name collapses into a single group — seven APs dropping would arrive as one message naming none of them. Both labels are absent on pod alerts, so those group unchanged.

## The WAN alert cannot come from Hawkfield

Prometheus, Alertmanager and the only route to Telegram all sit behind the Hawkfield WAN. So that alert is a new watchdog monitor from London.

It probes **`10.1.2.1` over the site-to-site link, not the WAN IP** — probing from London showed `185.23.254.226` drops ICMP and opens only 443, and that 443 *is* the ingress port-forward. A monitor on it would have duplicated `hawkfield public` rather than isolated the WAN. Hawkfield has a single WAN and the VPN rides it, so one probe covers WAN loss, site-link loss and a power cut; read against the public monitor it separates those from an ingress failure. Table in the runbook.

## Verification

`promtool` unit tests, now run in CI pinned to the cluster's Prometheus version (3.13.2), covering nine scenarios. The last replays the recorded idle values and asserts **nothing fires** — a rule that pages at baseline gets muted, and a muted rule is worse than no rule. It also proves the 2.4GHz exclusion and that the PoE rule filters the zero-budget aggregation switch instead of dividing into `+Inf`.

The tests caught a real bug: `WAN latency {{ $value | printf "%.0f" }}ms` formatted a seconds value, so a 250 ms latency rendered as "0ms". Now `humanizeDuration`.

Rendering checked end to end against a local Alertmanager 0.33.1 and a fake Telegram — all four label shapes plus the existing pod alert:

```
🔴 FIRING — UniFiAggregationLagMemberDown
hawkfield / USW Aggregation
aggregation LAG down to 1 of 2 members — uplink capacity halved
Runbook

🔴 FIRING — UniFiDevicesDisconnected
hawkfield (wlan)
1 wlan device(s) disconnected
Runbook

🔴 FIRING — PodCrashLooping
media/plex-abc (plex)
stuck in CrashLoopBackOff for over 15 minutes
Runbook
```

## Still outstanding

- **No rule has fired against an induced fault yet.** Per the plan agreed on the issue: LAG member down and device offline are safe to induce live and should be, before this is called done. WAN down and overtemp stay on replayed series.
- **Device-offline does not name the device.** It uses `unpoller_site_disconnected`, which unpoller publishes directly, rather than series disappearance — whether an offline device is dropped from the export or reported stale is unconfirmed until something actually goes down. The runbook has the query that names it.
- **Firmware alerts omitted.** `unpoller_device_upgradable` exists and is 0 estate-wide, but an informational severity routes nowhere except the unmuted default, so it would arrive overnight. Better as a dashboard panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)