### PR TITLE
Ship UniFi console logs to Loki (#451)

### DIFF
--- a/Documentation/runbooks/unifi-network.md
+++ b/Documentation/runbooks/unifi-network.md
@@ -53,9 +53,8 @@ exposes; the box reads 67°C CPU / 71°C board. Do not treat 83°C as Bristol's 
 ## How the alert reaches you
 
 ```
-UniFi consoles (10.1.2.1, 10.2.2.1) → unpoller (60s cache) → Prometheus (30s scrape)
-       → alert rules → Alertmanager → Telegram (clincha_grafana_bot)
-
+UniFi consoles (10.1.2.1, 10.2.2.1) ┬→ unpoller (60s cache) → Prometheus (30s scrape)
+                                    │      → alert rules → Alertmanager → Telegram (clincha_grafana_bot)
                                     └→ syslog UDP 514 → 10.1.2.211 (alloy-syslog) → Loki
 ```
 
@@ -85,8 +84,15 @@ only console-side detail available without SSH.
 {job="unifi-syslog"}
 {job="unifi-syslog", site="hawkfield"}
 {job="unifi-syslog", site="london"}
+{job="unifi-syslog", severity=~"error|critical|alert|emergency"}
+{job="unifi-syslog", app="hostapd"}
 {job="unifi-syslog"} |= "Paddock"
 ```
+
+Four labels: `job`, `site`, `app` (the syslog tag — `hostapd`, `dnsmasq`, `kernel` …) and
+`severity`. The rfc3164 parser strips both the tag and the priority off the line before it reaches
+Loki, so `app` and `severity` are the only way to get at them — grepping the message body for a
+daemon name will not work.
 
 `site` is derived from the **source IP of the packet** (10.1.2.1 → `hawkfield`, 10.2.2.1 →
 `london`), not from the hostname the console reports. Anything else is labelled `unknown`, so

--- a/Documentation/runbooks/unifi-network.md
+++ b/Documentation/runbooks/unifi-network.md
@@ -55,7 +55,7 @@ exposes; the box reads 67°C CPU / 71°C board. Do not treat 83°C as Bristol's 
 ```
 UniFi consoles (10.1.2.1, 10.2.2.1) ┬→ unpoller (60s cache) → Prometheus (30s scrape)
                                     │      → alert rules → Alertmanager → Telegram (clincha_grafana_bot)
-                                    └→ syslog UDP 514 → 10.1.2.211 (alloy-syslog) → Loki
+                                    └→ syslog UDP 514 → 10.1.2.210 (alloy-syslog) → Loki
 ```
 
 unpoller **caches and serves; it does not poll on scrape**. Values are up to 60s stale, which is
@@ -76,7 +76,7 @@ posts and community dashboards all use the old prefix and will silently match no
 
 ## The console logs
 
-Both consoles forward Network-application syslog to `10.1.2.211:514`, a UDP listener on the
+Both consoles forward Network-application syslog to `10.1.2.210:514`, a UDP listener on the
 `alloy-syslog` pod that pushes straight to Loki. Start here when a rule above fires — it is the
 only console-side detail available without SSH.
 
@@ -89,39 +89,48 @@ only console-side detail available without SSH.
 {job="unifi-syslog"} |= "Paddock"
 ```
 
-Four labels: `job`, `site`, `app` (the syslog tag — `hostapd`, `dnsmasq`, `kernel` …) and
+Five labels: `job`, `site`, `host`, `app` (the syslog tag — `hostapd`, `dnsmasq`, `kernel` …) and
 `severity`. The rfc3164 parser strips both the tag and the priority off the line before it reaches
 Loki, so `app` and `severity` are the only way to get at them — grepping the message body for a
 daemon name will not work.
 
-`site` is derived from the **source IP of the packet** (10.1.2.1 → `hawkfield`, 10.2.2.1 →
-`london`), not from the hostname the console reports. Anything else is labelled `unknown`, so
-`{job="unifi-syslog", site="unknown"}` returning rows means a sender nobody has accounted for —
-or, if London went quiet at the same moment, that its packets are arriving NAT'd across the
-site-to-site link and need a port-per-console instead.
+`site` is derived from the **hostname in the message** — `Bristol` → `hawkfield`, `London` →
+`london`, anything else → `unknown`, with the reported name kept verbatim in `host` so an unknown
+sender can be identified from the label set alone.
+
+**It is deliberately not the packet source IP.** London reaches Hawkfield over a Tailscale subnet
+route and the Bristol gateway SNATs it, so London's packets arrive with source `10.1.2.1` — the
+same address Bristol's own packets carry. Source-IP rules would have labelled the entire London
+stream `hawkfield` and nothing would have looked wrong. Verified 2026-08-10 by capturing UDP from
+both consoles on `k8s-hawk-2`.
+
+So `{job="unifi-syslog", site="unknown"}` returning rows means a console was renamed, or a sender
+nobody has accounted for; check `host` to tell which.
 
 ### Caveats worth knowing before you trust a gap
 
 - **UDP, so loss is silent.** UniFi's `ubios-udapi-server` has exactly one `transport()` literal
   and it is `udp`; there is no TCP setting to pick. An empty window is not evidence that nothing
   happened. Accepted deliberately — do not read absence as an all-clear.
-- **A rollout drops a few seconds.** The Service is `externalTrafficPolicy: Local` on a
-  single-replica Deployment, which is what preserves the source IP; while the pod moves, the VIP
-  is not announced.
+- **A rollout drops a few seconds.** Single-replica Deployment; while the pod moves, nothing is
+  listening.
 - **Network application only.** This is not the UDM's own UniFi OS journal — `unifi-core`, mongo
   and kernel messages stay on the box and still need SSH.
 - **RFC3164.** UniFi emits BSD-format syslog, so the listener sets `syslog_format = "rfc3164"`.
-  Alloy's default is rfc5424 and would mangle every message.
+  Alloy's default is rfc5424 and would mangle every message. Note the consoles set
+  `ts_format(iso)` globally in `/etc/syslog-ng/syslog-ng.conf`, which is why `/var/log/messages`
+  on the box carries ISO timestamps — it does **not** apply to the `network()` destination, whose
+  wire format is a plain BSD stamp (`<30>Aug 10 15:38:25 Bristol udapi-probe: …`, captured).
 
 Console-side the setting is Network → Settings → System → **Remote logging**, persisted as the
 `rsyslogd` document in each console's Mongo: `enabled: true`, `this_controller: false` (true means
-"keep them here"), `ip: 10.1.2.211`, `port: 514`.
+"keep them here"), `ip: 10.1.2.210`, `port: 514`.
 
 If the stream stops, check the pod before the consoles:
 
 ```bash
 kubectl -n monitoring logs deploy/alloy-syslog --tail=50
-kubectl -n monitoring get svc alloy-syslog-unifi
+kubectl -n monitoring get svc alloy-syslog
 ```
 
 The TrueNAS stream (`{job="truenas-syslog"}`) is a separate TCP listener on `10.1.2.210` in the

--- a/Documentation/runbooks/unifi-network.md
+++ b/Documentation/runbooks/unifi-network.md
@@ -55,6 +55,8 @@ exposes; the box reads 67°C CPU / 71°C board. Do not treat 83°C as Bristol's 
 ```
 UniFi consoles (10.1.2.1, 10.2.2.1) → unpoller (60s cache) → Prometheus (30s scrape)
        → alert rules → Alertmanager → Telegram (clincha_grafana_bot)
+
+                                    └→ syslog UDP 514 → 10.1.2.211 (alloy-syslog) → Loki
 ```
 
 unpoller **caches and serves; it does not poll on scrape**. Values are up to 60s stale, which is
@@ -67,9 +69,57 @@ why no rule here has a `for` shorter than 5m.
 - Console credentials: Bitwarden `unifipoller (Bristol)` / `unifipoller (London)` — read-only
   local accounts, verified as such
 - Dashboard: Grafana uid `unifi-network`
+- Logs: `kubernetes/flux/infrastructure/hawkfield/monitoring/config-syslog.alloy` and
+  `base/monitoring/alloy-syslog.yml`
 
 Metric names are prefixed **`unpoller_`, not `unifi_`** — renamed in unpoller v3. Older blog
 posts and community dashboards all use the old prefix and will silently match nothing.
+
+## The console logs
+
+Both consoles forward Network-application syslog to `10.1.2.211:514`, a UDP listener on the
+`alloy-syslog` pod that pushes straight to Loki. Start here when a rule above fires — it is the
+only console-side detail available without SSH.
+
+```logql
+{job="unifi-syslog"}
+{job="unifi-syslog", site="hawkfield"}
+{job="unifi-syslog", site="london"}
+{job="unifi-syslog"} |= "Paddock"
+```
+
+`site` is derived from the **source IP of the packet** (10.1.2.1 → `hawkfield`, 10.2.2.1 →
+`london`), not from the hostname the console reports. Anything else is labelled `unknown`, so
+`{job="unifi-syslog", site="unknown"}` returning rows means a sender nobody has accounted for —
+or, if London went quiet at the same moment, that its packets are arriving NAT'd across the
+site-to-site link and need a port-per-console instead.
+
+### Caveats worth knowing before you trust a gap
+
+- **UDP, so loss is silent.** UniFi's `ubios-udapi-server` has exactly one `transport()` literal
+  and it is `udp`; there is no TCP setting to pick. An empty window is not evidence that nothing
+  happened. Accepted deliberately — do not read absence as an all-clear.
+- **A rollout drops a few seconds.** The Service is `externalTrafficPolicy: Local` on a
+  single-replica Deployment, which is what preserves the source IP; while the pod moves, the VIP
+  is not announced.
+- **Network application only.** This is not the UDM's own UniFi OS journal — `unifi-core`, mongo
+  and kernel messages stay on the box and still need SSH.
+- **RFC3164.** UniFi emits BSD-format syslog, so the listener sets `syslog_format = "rfc3164"`.
+  Alloy's default is rfc5424 and would mangle every message.
+
+Console-side the setting is Network → Settings → System → **Remote logging**, persisted as the
+`rsyslogd` document in each console's Mongo: `enabled: true`, `this_controller: false` (true means
+"keep them here"), `ip: 10.1.2.211`, `port: 514`.
+
+If the stream stops, check the pod before the consoles:
+
+```bash
+kubectl -n monitoring logs deploy/alloy-syslog --tail=50
+kubectl -n monitoring get svc alloy-syslog-unifi
+```
+
+The TrueNAS stream (`{job="truenas-syslog"}`) is a separate TCP listener on `10.1.2.210` in the
+same pod, so it flowing while UniFi does not narrows the fault to the UDP path or the consoles.
 
 ## The one alert that cannot come from Hawkfield
 

--- a/kubernetes/flux/infrastructure/base/monitoring/alloy-syslog.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/alloy-syslog.yml
@@ -38,6 +38,9 @@ spec:
             - name: syslog-tcp
               containerPort: 1514
               protocol: TCP
+            - name: syslog-udp
+              containerPort: 1514
+              protocol: UDP
             - name: http
               containerPort: 12345
               protocol: TCP
@@ -103,3 +106,30 @@ spec:
       port: 514
       targetPort: syslog-tcp
       protocol: TCP
+---
+# Its own VIP rather than a port on the Service above: the UniFi stream is
+# labelled by source IP, which needs externalTrafficPolicy: Local, and MetalLB
+# only shares an address between services that are all Cluster or select the
+# same pods. 10.1.2.210 is shared with graphite-exporter-ingest, so it is
+# neither.
+apiVersion: v1
+kind: Service
+metadata:
+  name: alloy-syslog-unifi
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: alloy-syslog
+    app.kubernetes.io/component: syslog
+    app.kubernetes.io/part-of: kube-prometheus
+  annotations:
+    metallb.io/loadBalancerIPs: 10.1.2.211
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  selector:
+    app.kubernetes.io/name: alloy-syslog
+  ports:
+    - name: syslog-udp
+      port: 514
+      targetPort: syslog-udp
+      protocol: UDP

--- a/kubernetes/flux/infrastructure/base/monitoring/alloy-syslog.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/alloy-syslog.yml
@@ -106,29 +106,6 @@ spec:
       port: 514
       targetPort: syslog-tcp
       protocol: TCP
----
-# Its own VIP rather than a port on the Service above: the UniFi stream is
-# labelled by source IP, which needs externalTrafficPolicy: Local, and MetalLB
-# only shares an address between services that are all Cluster or select the
-# same pods. 10.1.2.210 is shared with graphite-exporter-ingest, so it is
-# neither.
-apiVersion: v1
-kind: Service
-metadata:
-  name: alloy-syslog-unifi
-  namespace: monitoring
-  labels:
-    app.kubernetes.io/name: alloy-syslog
-    app.kubernetes.io/component: syslog
-    app.kubernetes.io/part-of: kube-prometheus
-  annotations:
-    metallb.io/loadBalancerIPs: 10.1.2.211
-spec:
-  type: LoadBalancer
-  externalTrafficPolicy: Local
-  selector:
-    app.kubernetes.io/name: alloy-syslog
-  ports:
     - name: syslog-udp
       port: 514
       targetPort: syslog-udp

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/config-syslog.alloy
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/config-syslog.alloy
@@ -16,6 +16,50 @@ loki.source.syslog "truenas" {
     forward_to = [loki.write.local.receiver]
 }
 
+// Site comes from the transport source IP, not the device-reported hostname:
+// both consoles are UDMs that may self-report identically, and a rename would
+// silently relabel the stream. The address arrives bare, no :port — verified
+// against alloy v1.18.1. Relabel regexes are fully anchored, so .1 will not
+// match .100.
+loki.relabel "unifi_site" {
+    forward_to = []
+
+    rule {
+        source_labels = ["__syslog_connection_ip_address"]
+        regex         = "10\\.1\\.2\\.1"
+        target_label  = "site"
+        replacement   = "hawkfield"
+    }
+    rule {
+        source_labels = ["__syslog_connection_ip_address"]
+        regex         = "10\\.2\\.2\\.1"
+        target_label  = "site"
+        replacement   = "london"
+    }
+    rule {
+        source_labels = ["site"]
+        regex         = "^$"
+        target_label  = "site"
+        replacement   = "unknown"
+    }
+}
+
+loki.source.syslog "unifi" {
+    listener {
+        // UniFi's remote syslog is UDP-only and BSD-framed: ubios-udapi-server
+        // renders transport("udp") with no flags(syslog-protocol), and exposes
+        // no setting to change either.
+        address       = "0.0.0.0:1514"
+        protocol      = "udp"
+        syslog_format = "rfc3164"
+        labels        = {
+            job = "unifi-syslog",
+        }
+    }
+    relabel_rules = loki.relabel.unifi_site.rules
+    forward_to    = [loki.write.local.receiver]
+}
+
 loki.write "local" {
     endpoint {
         url = "http://loki-gateway.monitoring.svc/loki/api/v1/push"

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/config-syslog.alloy
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/config-syslog.alloy
@@ -16,23 +16,24 @@ loki.source.syslog "truenas" {
     forward_to = [loki.write.local.receiver]
 }
 
-// Site comes from the transport source IP, not the device-reported hostname:
-// both consoles are UDMs that may self-report identically, and a rename would
-// silently relabel the stream. The address arrives bare, no :port — verified
-// against alloy v1.18.1. Relabel regexes are fully anchored, so .1 will not
-// match .100.
+// Site comes from the hostname in the message, not the packet source IP:
+// London reaches Hawkfield over a Tailscale subnet route and the Bristol
+// gateway SNATs it, so both consoles arrive as 10.1.2.1 and source-IP rules
+// would label London as hawkfield. The consoles self-report distinctly
+// ("Bristol" / "London"); a rename lands on the unknown catch-all below rather
+// than silently relabelling the stream.
 loki.relabel "unifi" {
     forward_to = []
 
     rule {
-        source_labels = ["__syslog_connection_ip_address"]
-        regex         = "10\\.1\\.2\\.1"
+        source_labels = ["__syslog_message_hostname"]
+        regex         = "Bristol"
         target_label  = "site"
         replacement   = "hawkfield"
     }
     rule {
-        source_labels = ["__syslog_connection_ip_address"]
-        regex         = "10\\.2\\.2\\.1"
+        source_labels = ["__syslog_message_hostname"]
+        regex         = "London"
         target_label  = "site"
         replacement   = "london"
     }
@@ -41,6 +42,12 @@ loki.relabel "unifi" {
         regex         = "^$"
         target_label  = "site"
         replacement   = "unknown"
+    }
+
+    // Kept so an unknown site can be identified from the label set alone.
+    rule {
+        source_labels = ["__syslog_message_hostname"]
+        target_label  = "host"
     }
 
     // The rfc3164 parser strips the priority and the tag off the line, so

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/config-syslog.alloy
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/config-syslog.alloy
@@ -21,7 +21,7 @@ loki.source.syslog "truenas" {
 // silently relabel the stream. The address arrives bare, no :port — verified
 // against alloy v1.18.1. Relabel regexes are fully anchored, so .1 will not
 // match .100.
-loki.relabel "unifi_site" {
+loki.relabel "unifi" {
     forward_to = []
 
     rule {
@@ -42,6 +42,18 @@ loki.relabel "unifi_site" {
         target_label  = "site"
         replacement   = "unknown"
     }
+
+    // The rfc3164 parser strips the priority and the tag off the line, so
+    // without these the daemon and severity are unrecoverable from the message
+    // body. Both are bounded sets.
+    rule {
+        source_labels = ["__syslog_message_app_name"]
+        target_label  = "app"
+    }
+    rule {
+        source_labels = ["__syslog_message_severity"]
+        target_label  = "severity"
+    }
 }
 
 loki.source.syslog "unifi" {
@@ -56,7 +68,7 @@ loki.source.syslog "unifi" {
             job = "unifi-syslog",
         }
     }
-    relabel_rules = loki.relabel.unifi_site.rules
+    relabel_rules = loki.relabel.unifi.rules
     forward_to    = [loki.write.local.receiver]
 }
 


### PR DESCRIPTION
Adds the missing half of the UniFi instrumentation: metrics and 14 alert rules landed in #443–#445, but a firing rule had nothing in Grafana to correlate against.

## What changed

- `config-syslog.alloy` — a second `loki.source.syslog` listener on UDP 1514 parsing `rfc3164`, plus a `loki.relabel "unifi"` block. UniFi's `ubios-udapi-server` renders exactly one `transport()` literal (`udp`) with no `flags(syslog-protocol)`, so UDP and BSD framing are forced, not chosen.
- `alloy-syslog.yml` — UDP `containerPort: 1514`, and UDP 514 added to the existing Service on `10.1.2.210`.
- `Documentation/runbooks/unifi-network.md` — LogQL entrypoints, the label scheme, and the caveats worth knowing before reading a gap as an all-clear.

Five labels: `job`, `site`, `host`, `app` (the syslog tag) and `severity`. The rfc3164 parser strips the tag and the priority off the line, so `app` and `severity` are the only way to get at them.

## Source-IP labelling was wrong, and would have failed silently

The original design took `site` from `__syslog_connection_ip_address`, on the reasoning that the network sets the source IP while a device-reported hostname can be renamed. **Testing it on the real consoles showed that does not hold here.** London reaches Hawkfield over a Tailscale subnet route (`10.1.2.102 dev tailscale0 src 100.76.120.17`) and the Bristol gateway SNATs it, so London's packets arrive with source `10.1.2.1` — the same address Bristol's own packets carry. Captured on `k8s-hawk-2`:

```
15:33:15 IP 10.1.2.1.39645 > 10.1.2.102.5514: UDP   # sent from London (10.2.2.1)
15:33:16 IP 10.1.2.1.41711 > 10.1.2.102.5514: UDP   # sent from Bristol (10.1.2.1)
```

Every London line would have been labelled `site="hawkfield"` and nothing would have looked broken. This is open question 2 on the issue, answered: yes, it NATs.

So `site` now comes from the message hostname, which the two consoles do report distinctly (`Bristol` / `London`), with the reported name kept verbatim in `host`. A rename lands on the `unknown` catch-all rather than silently relabelling the stream — it fails visibly, which the source-IP scheme no longer could.

That also removes the reason for the second Service: nothing depends on the client IP any more, so `externalTrafficPolicy: Local` and the extra `10.1.2.211` VIP are gone and UDP 514 simply joins the existing Service. `graphite-exporter-ingest` already shares `.210` with TCP+UDP 9109, so mixed-protocol on that address is proven.

## Two other things verified rather than assumed

**The wire format is genuinely RFC3164.** The consoles set `ts_format(iso)` globally in `/etc/syslog-ng/syslog-ng.conf` — which is why `/var/log/messages` on the box carries ISO timestamps — and that would have broken a strict rfc3164 parser. It does not apply to the `network()` destination. Confirmed by running a throwaway syslog-ng on Bristol with the console's own global options and capturing the result:

```
<30>Aug 10 15:38:25 Bristol udapi-probe: WIRE FORMAT PROBE alpha
```

**The config was run, not just built.** `grafana/alloy` v1.18.1 — the deployed version — against the actual file from this branch, fed the captured datagram plus a London line, a renamed console and a tagless kernel line:

```
{app="udapi-probe", host="Bristol",    job="unifi-syslog", severity="informational", site="hawkfield"}
{app="hostapd",     host="London",     job="unifi-syslog", severity="error",         site="london"}
{app="foo",         host="RenamedBox", job="unifi-syslog", severity="informational", site="unknown"}
{app="kernel",      host="Bristol",    job="unifi-syslog", severity="informational", site="hawkfield"}
```

No parse errors. All 37 overlays build; kubeconform strict and yamllint clean.

## Not in this PR

Console-side `rsyslogd` writes on both UDMs (`ip: 10.1.2.210`, `port: 514`, `this_controller: false`), the Grafana logs panel (dashboards live on the NFS volume, not in git), and confirming both streams live in Loki. Those follow once this is merged and the listener exists.

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)
