### PR TITLE
Label the adopted UniFi devices, and recover the daemon (#451)

### DIFF
--- a/Documentation/runbooks/unifi-network.md
+++ b/Documentation/runbooks/unifi-network.md
@@ -74,29 +74,37 @@ why no rule here has a `for` shorter than 5m.
 Metric names are prefixed **`unpoller_`, not `unifi_`** — renamed in unpoller v3. Older blog
 posts and community dashboards all use the old prefix and will silently match nothing.
 
-## The console logs
+## The UniFi logs
 
-Both consoles forward Network-application syslog to `10.1.2.210:514`, a UDP listener on the
-`alloy-syslog` pod that pushes straight to Loki. Start here when a rule above fires — it is the
-only console-side detail available without SSH.
+Every UniFi device forwards syslog to `10.1.2.210:514`, a UDP listener on the `alloy-syslog` pod
+that pushes straight to Loki. Start here when a rule above fires — it is the only device-side
+detail available without SSH.
+
+**It is not just the consoles.** Enabling remote logging on a console enables it on everything
+that console has adopted, so the stream is both gateways plus all nine Hawkfield APs and switches.
+That is the useful half: `hostapd` and `stahtd` lines are what explain a WiFi alert. It is also
+around 1.2M lines/day, most of it AP `kernel` driver chatter and the consoles' `LAN_LOCAL`
+firewall logging — kept deliberately (Angus, 2026-08-11), so do not "fix" the volume.
 
 ```logql
 {job="unifi-syslog"}
 {job="unifi-syslog", site="hawkfield"}
 {job="unifi-syslog", site="london"}
 {job="unifi-syslog", severity=~"error|critical|alert|emergency"}
-{job="unifi-syslog", app="hostapd"}
-{job="unifi-syslog"} |= "Paddock"
+{job="unifi-syslog", daemon="hostapd"}
+{job="unifi-syslog", host="Paddock"}
 ```
 
-Five labels: `job`, `site`, `host`, `app` (the syslog tag — `hostapd`, `dnsmasq`, `kernel` …) and
-`severity`. The rfc3164 parser strips both the tag and the priority off the line before it reaches
-Loki, so `app` and `severity` are the only way to get at them — grepping the message body for a
-daemon name will not work.
+Five labels: `job`, `site`, `host` (the reporting device), `daemon` and `severity`.
 
-`site` is derived from the **hostname in the message** — `Bristol` → `hawkfield`, `London` →
-`london`, anything else → `unknown`, with the reported name kept verbatim in `host` so an unknown
-sender can be identified from the label set alone.
+`daemon` is **not** the syslog tag, because on this kit the tag is useless: the consoles emit their
+hostname a second time where the tag belongs, so the parser finds no tag at all, and the APs put
+`<mac>,<model>` there. It is recovered from the first token of the message body instead. Lines that
+open with a bracket — the firewall's `LAN_LOCAL` rules — have no daemon and carry no such label.
+
+`site` is derived from the **hostname in the message**: `London` → `london`, the ten known
+Hawkfield devices → `hawkfield`, anything else → `unknown`, with the reported name kept verbatim in
+`host`.
 
 **It is deliberately not the packet source IP.** London reaches Hawkfield over a Tailscale subnet
 route and the Bristol gateway SNATs it, so London's packets arrive with source `10.1.2.1` — the
@@ -104,8 +112,15 @@ same address Bristol's own packets carry. Source-IP rules would have labelled th
 stream `hawkfield` and nothing would have looked wrong. Verified 2026-08-10 by capturing UDP from
 both consoles on `k8s-hawk-2`.
 
-So `{job="unifi-syslog", site="unknown"}` returning rows means a console was renamed, or a sender
-nobody has accounted for; check `host` to tell which.
+So `{job="unifi-syslog", site="unknown"}` returning rows means a device was renamed, a new one was
+adopted, or a sender nobody has accounted for; check `host` and add it to the alternation in
+`config-syslog.alloy`.
+
+⚠️ **A device adopted at London will land on `unknown`, and that is the best available answer.**
+Its packets are SNAT'd to Bristol's address like the London console's, and nothing inside a syslog
+message says which site it came from — so an unrecognised name genuinely cannot be attributed.
+Resist the temptation to default the catch-all to `hawkfield`: it would be right today and
+silently wrong the moment Angus puts an AP in the flat.
 
 ### Caveats worth knowing before you trust a gap
 
@@ -114,8 +129,8 @@ nobody has accounted for; check `host` to tell which.
   happened. Accepted deliberately — do not read absence as an all-clear.
 - **A rollout drops a few seconds.** Single-replica Deployment; while the pod moves, nothing is
   listening.
-- **Network application only.** This is not the UDM's own UniFi OS journal — `unifi-core`, mongo
-  and kernel messages stay on the box and still need SSH.
+- **Not the UniFi OS journal.** The gateways' own `unifi-core`, mongo and UniFi OS kernel messages
+  stay on the box and still need SSH. AP `kernel` lines do arrive; UDM ones do not.
 - **RFC3164.** UniFi emits BSD-format syslog, so the listener sets `syslog_format = "rfc3164"`.
   Alloy's default is rfc5424 and would mangle every message. Note the consoles set
   `ts_format(iso)` globally in `/etc/syslog-ng/syslog-ng.conf`, which is why `/var/log/messages`

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/config-syslog.alloy
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/config-syslog.alloy
@@ -25,17 +25,23 @@ loki.source.syslog "truenas" {
 loki.relabel "unifi" {
     forward_to = []
 
-    rule {
-        source_labels = ["__syslog_message_hostname"]
-        regex         = "Bristol"
-        target_label  = "site"
-        replacement   = "hawkfield"
-    }
+    // Enabling remote logging on a console enables it on everything it has
+    // adopted, so most of this stream is APs and switches rather than the
+    // consoles. Each device reports its own name with spaces stripped. London
+    // is matched first and has no adopted devices of its own; add one there and
+    // it lands on `unknown` below, because its packets are SNAT'd to Bristol's
+    // address and nothing in them says which site they came from.
     rule {
         source_labels = ["__syslog_message_hostname"]
         regex         = "London"
         target_label  = "site"
         replacement   = "london"
+    }
+    rule {
+        source_labels = ["__syslog_message_hostname"]
+        regex         = "Bristol|FirstFloorLanding|Hall|Kitchen|LivingRoom|LoftLanding|LoftSwitch|MasterBedroom|Paddock|USW-Aggregation"
+        target_label  = "site"
+        replacement   = "hawkfield"
     }
     rule {
         source_labels = ["site"]
@@ -50,17 +56,30 @@ loki.relabel "unifi" {
         target_label  = "host"
     }
 
-    // The rfc3164 parser strips the priority and the tag off the line, so
-    // without these the daemon and severity are unrecoverable from the message
-    // body. Both are bounded sets.
-    rule {
-        source_labels = ["__syslog_message_app_name"]
-        target_label  = "app"
-    }
     rule {
         source_labels = ["__syslog_message_severity"]
         target_label  = "severity"
     }
+}
+
+// The daemon is not in the rfc3164 tag: the consoles emit their hostname a
+// second time where the tag belongs, so the parser finds no tag at all, and the
+// APs put "<mac>,<model>" there instead. Either way the real daemon is the
+// first token of the message body, which is what this recovers. The optional
+// leading word absorbs the consoles' duplicated hostname; lines that open with
+// a bracket (the firewall's LAN_LOCAL rules) have no daemon and get no label.
+loki.process "unifi" {
+    stage.regex {
+        expression = "^(?:[A-Za-z0-9-]+ )?(?P<daemon>[A-Za-z0-9._@-]+)(?:\\[\\d+\\])?: "
+    }
+
+    stage.labels {
+        values = {
+            daemon = "",
+        }
+    }
+
+    forward_to = [loki.write.local.receiver]
 }
 
 loki.source.syslog "unifi" {
@@ -76,7 +95,7 @@ loki.source.syslog "unifi" {
         }
     }
     relabel_rules = loki.relabel.unifi.rules
-    forward_to    = [loki.write.local.receiver]
+    forward_to    = [loki.process.unifi.receiver]
 }
 
 loki.write "local" {


### PR DESCRIPTION
Follow-up to #452, from turning the consoles on and watching what actually arrived.

## Every adopted device forwards, not just the consoles

Enabling remote logging on a console enables it on everything that console has adopted. The stream is both gateways **plus all nine Hawkfield APs and switches** — `Kitchen`, `Hall`, `MasterBedroom`, `LivingRoom`, `FirstFloorLanding`, `LoftLanding`, `Paddock`, `LoftSwitch`, `USW-Aggregation`. Every one of them was landing on the `unknown` catch-all, which is 65% of the stream:

```
 hawkfield Bristol            2998 lines/10m
 unknown   FirstFloorLanding  1020
 unknown   LivingRoom          956
 unknown   Kitchen             931
 …
```

They are now matched by name. `unknown` should stay empty; if it doesn't, a device was renamed or newly adopted.

**The catch-all deliberately does not default to `hawkfield`.** That would be correct today and silently wrong the moment a device is adopted at London — its packets are SNAT'd to Bristol's address, and nothing inside a syslog message says which site it came from. An unrecognised name genuinely cannot be attributed, so it says so.

## `app` was not the daemon

#452 added `app` from the rfc3164 tag so the daemon would be greppable. On this kit the tag never contains it:

```
<13>Aug 11 06:59:23 Bristol Bristol syswrapper[1185548]: mtk_rrm_scan radio done
                            ^^^^^^^ hostname repeated where the tag belongs → no tag parses
<30>Aug 11 07:05:29 LivingRoom 18e82941ac6e,UAP-nanoHD-6.7.54+15663: hostapd[9284]: rai0: STA …
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ APs put mac,model there
```

So `app` was empty on every console line and a device id on every AP line. It is replaced by `daemon`, recovered from the first token of the message body, which handles both shapes and the tagless firewall lines.

## Volume

~1.2M lines/day, making UniFi Loki's largest source by roughly 2.5×. Mostly AP `kernel` driver chatter (44%) and `LAN_LOCAL` firewall logging (38%). I asked; **Angus chose to keep everything**, so there is no drop stage here on purpose.

## Verification

Replayed captured datagrams — console daemon line, console firewall line, London console, AP `hostapd`, AP `kernel`, switch, and an invented `NewLondonAP` — through `grafana/alloy` v1.18.1 against this branch's config:

```
{daemon="wevent",  host="Bristol",         severity="informational", site="hawkfield"}
{                  host="Bristol",         severity="notice",        site="hawkfield"}   # LAN_LOCAL, no daemon
{                  host="London",          severity="notice",        site="london"}
{daemon="hostapd", host="LivingRoom",      severity="informational", site="hawkfield"}
{daemon="kernel",  host="LivingRoom",      severity="warning",       site="hawkfield"}
{daemon="switch",  host="USW-Aggregation", severity="informational", site="hawkfield"}
{                  host="NewLondonAP",     severity="informational", site="unknown"}
```

No parse errors; all overlays build.

Refs #451
