### PR TITLE
storage: move monitoring and factorio data to the SSD userstore pool

### DIFF
--- a/Documentation/hawkstore-accounts.md
+++ b/Documentation/hawkstore-accounts.md
@@ -21,9 +21,9 @@ almost every GID in 3003–3022 was also a *different* account's UID; that is ho
 | clincha | 3000 | clincha | 3000 | human, SMB |
 | cclinch | 3001 | cclinch | 3001 | human, SMB |
 | hawkprint | 3002 | hawkprint | 3002 | printer/scanner, SMB |
-| prometheus | 3003 | prometheus | 3003 | `/mnt/data/prometheus` |
+| prometheus | 3003 | prometheus | 3003 | `/mnt/userstore/prometheus` |
 | ansible | 3004 | ansible | 3004 | |
-| grafana | 3005 | grafana | 3005 | `/mnt/data/grafana` |
+| grafana | 3005 | grafana | 3005 | `/mnt/userstore/grafana` |
 | dave | 3006 | dave | 3006 | FULL_ADMIN, owns the API key |
 | nasexporter | 3007 | nasexporter | 3007 | bound to privilege `nas-exporter-readonly` |
 | tautulli | 3008 | media | 3011 | |
@@ -36,8 +36,8 @@ almost every GID in 3003–3022 was also a *different* account's UID; that is ho
 | asta | 3015 | asta | 3015 | human, SMB — treat as fixed |
 | immich | 3016 | media | 3011 | |
 | ombi | 3017 | media | 3011 | |
-| loki | 3018 | loki | 3018 | `/mnt/data/loki` |
-| uptimekuma | 3019 | uptimekuma | 3019 | `/mnt/data/uptime-kuma` |
+| loki | 3018 | loki | 3018 | `/mnt/userstore/loki` |
+| uptimekuma | 3019 | uptimekuma | 3019 | `/mnt/userstore/uptime-kuma` |
 | s3 | 3020 | s3 | 3020 | rustfs, `/mnt/userstore/s3` |
 
 Shared/auxiliary groups: `media(3011)`, `printing(3023)` (clincha, hawkprint — owns

--- a/Documentation/hawkstore/backup-policy.md
+++ b/Documentation/hawkstore/backup-policy.md
@@ -103,7 +103,7 @@ Two things on the box look stale by every automatic measure and are kept anyway.
 Angus under #408 on 2026-08-07 and both answers were *keep* — treat them as settled rather than
 re-raising them at the next audit.
 
-**Old Factorio save directories.** The live deployment mounts only `/mnt/data/factorio/2026`.
+**Old Factorio save directories.** The live deployment mounts only `/mnt/userstore/factorio/2026`.
 Alongside it sit `saves`, `spaceage`, `runsmart`, `speedrun`, `proposal` and `config` — 872 MB
 across worlds last touched between May 2025 and October 2025. Every file except `saves/space.zip`
 is an `_autosaveN.zip`, so for each of those worlds the autosaves are the only copy there is.

--- a/Documentation/runbooks/pod-restarts.md
+++ b/Documentation/runbooks/pod-restarts.md
@@ -93,7 +93,7 @@ the mute back to 07:00 rather than widening the alert threshold.
    ```
 
    Or use the Alertmanager UI. Silences survive restarts — they are on NFS at
-   `/mnt/data/alertmanager`.
+   `/mnt/userstore/alertmanager`.
 
 ## Worked example: Grafana, 2026-08-06
 
@@ -103,7 +103,7 @@ itself stayed up and served normally.
 Cause: two Grafana pods existed. Renovate bumped `13.1.1 → 13.1.2`, and the Deployment used the
 default `RollingUpdate` strategy. With `replicas: 1`, `maxSurge: 25%` rounds *up* to 1, so
 Kubernetes started the new pod before removing the old one. Both mount the same NFS directory
-`/mnt/data/grafana`, and Grafana's bleve unified-search index takes an exclusive lock:
+`/mnt/userstore/grafana`, and Grafana's bleve unified-search index takes an exclusive lock:
 
 ```
 level=error msg="index is locked by another process"

--- a/kubernetes/flux/applications/base/factorio/deployment.yml
+++ b/kubernetes/flux/applications/base/factorio/deployment.yml
@@ -103,7 +103,7 @@ spec:
           emptyDir: {}
         - name: saves
           nfs:
-            path: /mnt/data/factorio/2026
+            path: /mnt/userstore/factorio/2026
             server: 10.1.2.10
         - name: server-settings
           configMap:

--- a/kubernetes/flux/infrastructure/base/monitoring/alertmanager.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/alertmanager.yml
@@ -99,7 +99,7 @@ spec:
             defaultMode: 0440
         - name: data
           nfs:
-            path: /mnt/data/alertmanager
+            path: /mnt/userstore/alertmanager
             server: 10.1.2.10
 ---
 apiVersion: v1

--- a/kubernetes/flux/infrastructure/base/monitoring/grafana.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/grafana.yml
@@ -77,7 +77,7 @@ spec:
       volumes:
         - name: grafana-storage
           nfs:
-            path: /mnt/data/grafana
+            path: /mnt/userstore/grafana
             server: 10.1.2.10
         - name: tmp
           emptyDir:

--- a/kubernetes/flux/infrastructure/base/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/prometheus.yml
@@ -79,7 +79,7 @@ spec:
       volumes:
         - name: data
           nfs:
-            path: /mnt/data/prometheus/
+            path: /mnt/userstore/prometheus/
             server: 10.1.2.10
         - name: config
           configMap:

--- a/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
+++ b/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
@@ -49,7 +49,7 @@ spec:
       - name: storage
         nfs:
           server: 10.1.2.10
-          path: /mnt/data/uptime-kuma
+          path: /mnt/userstore/uptime-kuma
     additionalVolumeMounts:
       - name: storage
         mountPath: /app/data

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/loki-values.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/loki-values.yml
@@ -65,7 +65,7 @@ singleBinary:
     - name: storage
       nfs:
         server: 10.1.2.10
-        path: /mnt/data/loki
+        path: /mnt/userstore/loki
   extraVolumeMounts:
     - name: storage
       mountPath: /var/loki


### PR DESCRIPTION
Companion to clincha/media#70. Both follow the Plex migration (media#67, merged in media#69).

## Why

Plex's config on the HDD `data` pool measured **2063 ms** fsync during the 2026-08-15 incident and **10-12 ms** after moving to the SSD `userstore` mirror. Prometheus and Loki are the write-heavy things still left on `data`; Grafana and Alertmanager are small but latency-sensitive, and Grafana's bleve index on that pool already has its own runbook entry.

## What moves

| app | dataset | size | new path |
|---|---|---|---|
| prometheus | `data/prometheus` | 13.1 G | `/mnt/userstore/prometheus/` |
| grafana | `data/grafana` | 88 M | `/mnt/userstore/grafana` |
| loki | `data/loki` | 59 M | `/mnt/userstore/loki` |
| alertmanager | `data/alertmanager` | 149 K | `/mnt/userstore/alertmanager` |
| uptime-kuma | `data/uptime-kuma` | 23 M | `/mnt/userstore/uptime-kuma` |
| factorio | `data/factorio` | 1.62 G | `/mnt/userstore/factorio/2026` |

Prometheus is the only one big enough to matter for capacity, and `userstore` has 271 G free. Total added is ~6.4 G compressed across both PRs.

## State on hawkstore (already done)

- Sent with `zfs send -p -c -L | zfs recv -x encryption`. The `-x encryption` matters: without it the received dataset lands `encryption=off` inside the encrypted `userstore` parent and raises an `EncryptedDataset` alert (media#69).
- **Verified**: file counts and total apparent bytes compared snapshot-to-snapshot, all identical. All confirmed `aes-256-gcm` / `encryptionroot=userstore`.
- NFS exports created (ids 24-39), each cloned from its source export so `maproot`/`mapall` carry over exactly — `factorio` and `uptime-kuma` use `maproot root`, the monitoring exports do not.

Note this puts Prometheus, Grafana, Loki and Alertmanager data on an **encrypted** pool for the first time; previously only the off-site B2 copies were encrypted.

## Cutover

Not automatic on merge. Per app: scale to 0 → final incremental `zfs send -i` (seconds) → Flux applies → scale up → verify. I'll run this once you merge and report back.

Alertmanager and Prometheus are the monitoring stack itself, so they get cut over last and verified before I call the job done — a silent failure there is the one that would not page.

Nothing is deleted; the `data/*` datasets stay as the rollback path.

## Follow-up

Snapshot and replication tasks still point at the `data` datasets and get repointed after cutover, following the media#69 pattern (new task on the SSD dataset, old one disabled rather than deleted).