### PR TITLE
Mount secrets as files instead of env vars

### DIFF
--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -35,6 +35,3 @@ checks:
     - "dnsconfig-options"
     # Wants a NetworkPolicy per pod. Worth doing, but it is a project.
     - "non-isolated-pod"
-    # 3 hits (truenas-api-exporter, uptime-kuma bootstrap Job). Legitimate
-    # hardening, but it changes the runtime behaviour of three workloads.
-    - "read-secret-from-env-var"

--- a/kubernetes/flux/infrastructure/base/monitoring/truenas-api-exporter.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/truenas-api-exporter.yml
@@ -22,6 +22,10 @@ spec:
     spec:
       serviceAccountName: truenas-api-exporter
       automountServiceAccountToken: false
+      # Secret files land root-owned; fsGroup is what makes them group-readable
+      # by the nobody user the exporter runs as.
+      securityContext:
+        fsGroup: 65534
       containers:
         - name: exporter
           image: python:3.12-slim
@@ -33,12 +37,11 @@ spec:
               value: "9113"
             # API key for the least-privilege `nasexporter` TrueNAS user
             # (read-only roles). REST rejects non-admin keys, so the exporter
-            # uses the JSON-RPC WebSocket API.
-            - name: TRUENAS_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: truenas-api-credentials
-                  key: api-key
+            # uses the JSON-RPC WebSocket API. Mounted as a file, not an env
+            # var: the script re-reads it per scrape, so a rotation needs no
+            # restart.
+            - name: TRUENAS_API_KEY_FILE
+              value: /secrets/truenas/api-key
           ports:
             - name: metrics
               containerPort: 9113
@@ -63,6 +66,9 @@ spec:
             - mountPath: /app
               name: script
               readOnly: true
+            - mountPath: /secrets/truenas
+              name: api-key
+              readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -78,6 +84,10 @@ spec:
         - name: script
           configMap:
             name: truenas-exporter-script
+        - name: api-key
+          secret:
+            secretName: truenas-api-credentials
+            defaultMode: 0440
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/flux/infrastructure/base/monitoring/unpoller.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/unpoller.yml
@@ -22,24 +22,14 @@ spec:
     spec:
       serviceAccountName: unpoller
       automountServiceAccountToken: false
+      # Secret files land root-owned; fsGroup is what makes them group-readable
+      # by the nobody user unpoller runs as.
+      securityContext:
+        fsGroup: 65534
       containers:
         - name: unpoller
           image: ghcr.io/unpoller/unpoller:v3.4.1
           args: ["--config", "/etc/unpoller/up.conf"]
-          env:
-            # Passwords stay out of the ConfigMap: unpoller overlays
-            # UP_UNIFI_CONTROLLER_<n>_* onto the matching [[unifi.controller]]
-            # block, indexed in file order — Bristol 0, London 1.
-            - name: UP_UNIFI_CONTROLLER_0_PASS
-              valueFrom:
-                secretKeyRef:
-                  name: unifi-poller-credentials
-                  key: bristol-password
-            - name: UP_UNIFI_CONTROLLER_1_PASS
-              valueFrom:
-                secretKeyRef:
-                  name: unifi-poller-credentials
-                  key: london-password
           ports:
             - name: metrics
               containerPort: 9130
@@ -65,6 +55,9 @@ spec:
             - mountPath: /etc/unpoller
               name: config
               readOnly: true
+            - mountPath: /secrets/unifi
+              name: credentials
+              readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -80,6 +73,10 @@ spec:
         - name: config
           configMap:
             name: unpoller-config
+        - name: credentials
+          secret:
+            secretName: unifi-poller-credentials
+            defaultMode: 0440
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
+++ b/kubernetes/flux/infrastructure/base/uptime-kuma/helm-release.yml
@@ -36,9 +36,14 @@ spec:
       hostname: 10.1.2.10
       port: 3306
       database: uptime_kuma
-      existingSecret: uptime-kuma-mariadb-credentials
-      existingSecretUsernameKey: username
-      existingSecretPasswordKey: password
+      # Credentials come in as files via the _FILE vars in podEnv below, not
+      # existingSecret. getEnvOrFile() throws if a var and its _FILE twin are
+      # both set, and the chart renders UPTIME_KUMA_DB_USERNAME/PASSWORD
+      # unconditionally under externalDatabase.enabled — so these two must be
+      # blanked explicitly. The chart's own username default is `uptime_kuma`,
+      # which is truthy and would trip that guard.
+      username: ""
+      password: ""
     # /app/data still holds db-config.json, uploads, screenshots and docker-tls
     # — all low-traffic. Mounted from hawkstore NFS rather than a PVC because a
     # Longhorn journal abort silently wedged two volumes with EIO for 18 days on
@@ -50,14 +55,24 @@ spec:
         nfs:
           server: 10.1.2.10
           path: /mnt/userstore/uptime-kuma
+      # 0400 is enough: the release image sets no USER, so the server runs as
+      # root. No fsGroup needed, which keeps it off the NFS mount above.
+      - name: mariadb-credentials
+        secret:
+          secretName: uptime-kuma-mariadb-credentials
+          defaultMode: 0400
     additionalVolumeMounts:
       - name: storage
         mountPath: /app/data
-    # extra/entrypoint.sh chowns /app/data and then drops to PUID:PGID with
-    # `setpriv --clear-groups`, which needs CAP_SETGID. Set root explicitly
-    # rather than by omission: helm leaves a previously-rendered
-    # securityContext in place when the key disappears from values, so the old
-    # non-root one would persist.
+      - name: mariadb-credentials
+        mountPath: /secrets/mariadb
+        readOnly: true
+    # The 2.x image sets no USER and runs `node server/server.js` under
+    # dumb-init directly, so the server is root and the PUID/PGID below are
+    # inert leftovers from the 1.x entrypoint. Set root explicitly rather than
+    # by omission: helm leaves a previously-rendered securityContext in place
+    # when the key disappears from values, so the old non-root one would
+    # persist.
     podSecurityContext:
       runAsUser: 0
       runAsGroup: 0
@@ -67,6 +82,10 @@ spec:
         value: "3019"
       - name: PGID
         value: "3019"
+      - name: UPTIME_KUMA_DB_USERNAME_FILE
+        value: /secrets/mariadb/username
+      - name: UPTIME_KUMA_DB_PASSWORD_FILE
+        value: /secrets/mariadb/password
     # Kept from the SQLite-on-NFS era. MariaDB removes the stall that used to
     # trip these, but the chart's 1s/2s defaults leave no room for a slow query
     # either, and a killed pod is a worse outcome than a slow one.

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/truenas_exporter.py
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/truenas_exporter.py
@@ -16,7 +16,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 NAS_HOST = os.environ.get("TRUENAS_HOST", "10.1.2.10")
 NAS_PORT = int(os.environ.get("TRUENAS_PORT", "443"))
-API_KEY = os.environ["TRUENAS_API_KEY"]
+API_KEY_FILE = os.environ.get("TRUENAS_API_KEY_FILE", "/secrets/truenas/api-key")
 WS_PATH = os.environ.get("TRUENAS_WS_PATH", "/api/current")
 LISTEN = int(os.environ.get("LISTEN_PORT", "9113"))
 
@@ -124,9 +124,13 @@ def rpc(ws, method, params=None):
 
 
 def collect():
+    # Read per scrape, not at import: a SOPS rotation then lands on the next
+    # scrape instead of needing a pod restart.
+    with open(API_KEY_FILE, encoding="utf-8") as f:
+        api_key = f.read().strip()
     ws = WSClient(NAS_HOST, NAS_PORT, WS_PATH)
     try:
-        if not rpc(ws, "auth.login_with_api_key", [API_KEY]):
+        if not rpc(ws, "auth.login_with_api_key", [api_key]):
             raise WSError("api key login rejected")
         pools = rpc(ws, "pool.query")
         datasets = rpc(ws, "pool.dataset.query")

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/up.conf
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/up.conf
@@ -14,10 +14,12 @@
 [unifi]
   dynamic = false
 
-# Controller order is load-bearing: UP_UNIFI_CONTROLLER_<n>_PASS binds by index.
 [[unifi.controller]]
   url = "https://10.1.2.1"
   user = "unifipoller"
+  # file:// reads the password from the mounted Secret at startup. Only the
+  # path lives here, so this stays a plain ConfigMap.
+  pass = "file:///secrets/unifi/bristol-password"
   sites = ["all"]
   save_sites = true
   save_dpi = false
@@ -27,6 +29,7 @@
 [[unifi.controller]]
   url = "https://10.2.2.1"
   user = "unifipoller"
+  pass = "file:///secrets/unifi/london-password"
   sites = ["all"]
   save_sites = true
   save_dpi = false

--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap-job.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap-job.yml
@@ -36,6 +36,9 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+        # Secret files land root-owned; fsGroup is what makes them readable
+        # by uid 1000.
+        fsGroup: 1000
       containers:
         # The uptime-kuma image already carries socket.io-client, so the
         # bootstrap always speaks the same protocol version as the server.
@@ -52,16 +55,10 @@ spec:
               value: /app/node_modules
             - name: KUMA_URL
               value: http://uptime-kuma-uptime-kuma:3001
-            - name: KUMA_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: uptime-kuma-admin-credentials
-                  key: username
-            - name: KUMA_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: uptime-kuma-admin-credentials
-                  key: password
+            - name: KUMA_USERNAME_FILE
+              value: /secrets/admin/username
+            - name: KUMA_PASSWORD_FILE
+              value: /secrets/admin/password
           resources:
             requests:
               cpu: 10m
@@ -77,7 +74,14 @@ spec:
           volumeMounts:
             - name: script
               mountPath: /script
+            - name: admin-credentials
+              mountPath: /secrets/admin
+              readOnly: true
       volumes:
         - name: script
           configMap:
             name: uptime-kuma-admin-bootstrap
+        - name: admin-credentials
+          secret:
+            secretName: uptime-kuma-admin-credentials
+            defaultMode: 0440

--- a/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap.js
+++ b/kubernetes/flux/infrastructure/hawkfield/uptime-kuma/admin-bootstrap.js
@@ -1,8 +1,11 @@
+const fs = require("fs");
 const { io } = require("socket.io-client");
 
+const readSecret = (path) => fs.readFileSync(path, "utf8").trim();
+
 const url = process.env.KUMA_URL;
-const username = process.env.KUMA_USERNAME;
-const password = process.env.KUMA_PASSWORD;
+const username = readSecret(process.env.KUMA_USERNAME_FILE);
+const password = readSecret(process.env.KUMA_PASSWORD_FILE);
 
 const done = (code, msg) => {
     console.log(msg);
@@ -21,7 +24,7 @@ socket.on("connect_error", (err) => done(1, `connect failed: ${err.message}`));
 
 socket.on("connect", () => {
     socket.emit("setup", username, password, (res) => {
-        // The username comes from the environment; interpolating it into the
+        // The username comes from a mounted Secret; interpolating it into the
         // log is what CodeQL flags as clear-text logging of sensitive data.
         if (res.ok) {
             return done(0, "created admin user");


### PR DESCRIPTION
Closes #440.

Four workloads took credentials through `env`/`envFrom`. An env var is readable from `/proc/<pid>/environ`, leaks into crash dumps, and cannot be rotated without a restart. All four now read from a mounted path, and `read-secret-from-env-var` comes off the `.kube-linter.yaml` exclusion list.

## Changes

| Workload | Before | After |
| --- | --- | --- |
| `truenas-api-exporter` | `TRUENAS_API_KEY` secretKeyRef | `TRUENAS_API_KEY_FILE`, read per scrape |
| uptime-kuma bootstrap Job | `KUMA_USERNAME`/`KUMA_PASSWORD` | `*_FILE` + `readFileSync` |
| uptime-kuma | chart `existingSecret` | `UPTIME_KUMA_DB_*_FILE` |
| `unpoller` | `UP_UNIFI_CONTROLLER_<n>_PASS` | `pass = "file://…"` in `up.conf` |

The exporter reads the key inside `collect()` rather than at import, so a SOPS rotation lands on the next scrape instead of needing a restart.

## Two things that differ from the plan on the issue

**A fourth workload.** The issue names three, but `unpoller` landed after it was filed and adds two more `secretKeyRef` hits. The exclusion cannot come off with those still there, so it is converted too. unpoller v3.4.1 resolves a `file://` prefix on `pass` (`getPassFromFile`, trimmed), so the two env vars are dropped outright rather than converted — only the path lives in the ConfigMap.

**`fsGroup`, not bare `defaultMode: 0400`.** The plan specified `0400` with no `fsGroup`. Secret files land root-owned, so on the three non-root pods that file is unreadable by the container — and `kubernetes/policy/nonroot-pod-with-secret-needs-fsgroup.yaml` rejects exactly this, so CI would have failed. Those three get an `fsGroup` and `0440`. uptime-kuma is the exception: its image sets no `USER` (verified against the registry image config for `2.4.0` — `User: None`, entrypoint straight to `node server/server.js`), so it runs as root, keeps `0400`, and takes no `fsGroup` — which also keeps a recursive chown off its NFS mount.

## The uptime-kuma guard

`getEnvOrFile()` throws if a var and its `_FILE` twin are both set, and chart 4.1.0 renders `UPTIME_KUMA_DB_USERNAME`/`PASSWORD` unconditionally under `externalDatabase.enabled`. The issue expected both to fall back to `value: ""`, but only `password` does — the chart's `username` default is `uptime_kuma`, which is truthy and would trip the guard. Both are blanked explicitly.

Verified `getEnvOrFile` exists in 2.4.0 (the pinned tag), not just 2.5.0.

## Not fixed here

This does not get the DB password off disk. `setup-database.js` still calls `writeDBConfig()`, which persists it in plaintext to `/app/data/db-config.json` on the NFS mount. That is true today too — flagging it so this is not read as fixing it.

Also corrected a stale comment in `helm-release.yml`: it described a 1.x `extra/entrypoint.sh` that chowns `/app/data` and drops to `PUID:PGID` via `setpriv`. That file does not exist in 2.4.0 and the image has no PUID handling, so the `PUID`/`PGID` podEnv vars are inert. Left in place — removing them is a behaviour question, not a comment fix.

## Verification

Local, at the versions the Quality workflow pins:

- `kube-linter` 0.8.3 over the built hawkfield overlays — no lint errors (was 2 before the unpoller change).
- `kyverno` 1.18.2 — must-fail fixtures rejected, must-pass accepted, all 336 resources across every overlay pass.
- `yamllint` 1.38.0, `ruff` 0.16.2, `gitleaks` 8.28.0 clean; `node --check` and `py_compile` on the two scripts.

Deploy-side, after Flux reconciles: `truenas_scrape_success 1` and the Prometheus target still up; the bootstrap Job completing with "admin user already exists"; uptime-kuma ready with history intact; `unpoller_*` series still flowing for both controllers.

Rollout note: uptime-kuma is `Recreate`, so a short outage. The bootstrap Job spec is immutable but already carries `kustomize.toolkit.fluxcd.io/force: "enabled"`, so Flux recreates it.

`base/monitoring` is also consumed by london/dev, which have neither Secret. Those pods fail today with `CreateContainerConfigError` and will now hang in `ContainerCreating` — equally broken, no regression, and neither is a deployed cluster.