### PR TITLE
Isolate the app namespaces with NetworkPolicies (#441)

### DIFF
--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -26,6 +26,11 @@ checks:
     # The alloy and loki Ingresses target Services created by HelmReleases,
     # which Flux renders at runtime and kustomize output cannot contain.
     - "dangling-ingress"
+    # Same cause: the loki-gateway and uptime-kuma NetworkPolicies select pods
+    # the Loki and uptime-kuma charts render, so no Deployment in the built
+    # output carries the labels. Both selectors were checked against the
+    # running pods; re-check there, not here, if one is suspected wrong.
+    - "dangling-networkpolicy"
 
     # --- Not a linting change --------------------------------------------
     # Org conventions; single-owner repo.
@@ -33,8 +38,6 @@ checks:
     - "required-annotation-email"
     - "no-node-affinity"
     - "dnsconfig-options"
-    # Wants a NetworkPolicy per pod. Worth doing, but it is a project.
-    - "non-isolated-pod"
     # 3 hits (truenas-api-exporter, uptime-kuma bootstrap Job). Legitimate
     # hardening, but it changes the runtime behaviour of three workloads.
     - "read-secret-from-env-var"

--- a/kubernetes/flux/applications/base/factorio/kustomization.yml
+++ b/kubernetes/flux/applications/base/factorio/kustomization.yml
@@ -5,3 +5,4 @@ resources:
   - serviceaccount.yml
   - deployment.yml
   - service.yml
+  - network-policy.yml

--- a/kubernetes/flux/applications/base/factorio/network-policy.yml
+++ b/kubernetes/flux/applications/base/factorio/network-policy.yml
@@ -1,0 +1,32 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: factorio
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-game-traffic
+  namespace: factorio
+spec:
+  podSelector:
+    matchLabels:
+      name: factorio
+  policyTypes:
+    - Ingress
+  ingress:
+    # The Service is externalTrafficPolicy: Local, so players keep their real
+    # source address. They arrive from the internet over a port forward, so
+    # there is no narrower range than "anywhere" to write here.
+    - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: UDP
+          port: 34197

--- a/kubernetes/flux/applications/base/homepage/kustomization.yml
+++ b/kubernetes/flux/applications/base/homepage/kustomization.yml
@@ -8,3 +8,4 @@ resources:
   - service.yml
   - ingress.yml
   - certificate.yml
+  - network-policy.yml

--- a/kubernetes/flux/applications/base/homepage/network-policy.yml
+++ b/kubernetes/flux/applications/base/homepage/network-policy.yml
@@ -1,0 +1,41 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: homepage
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-http
+  namespace: homepage
+spec:
+  podSelector:
+    matchLabels:
+      name: homepage
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+        # The site is also served straight off a MetalLB VIP, and that Service
+        # is externalTrafficPolicy: Cluster, which SNATs every caller. Which
+        # address it is SNATed to depends on where the pod lands: a client
+        # reaching a pod on another node arrives from that node's Calico
+        # tunnel address, one reaching a pod on the announcing node arrives
+        # from the node's LAN address. Both ranges have to be allowed or the
+        # rule works or fails depending on scheduling.
+        - ipBlock:
+            cidr: 10.233.64.0/18
+        - ipBlock:
+            cidr: 10.1.2.0/24
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/kubernetes/flux/infrastructure/base/monitoring/kustomization.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/kustomization.yml
@@ -16,3 +16,4 @@ resources:
   - grafana.yml
   - certificate.yml
   - ingress.yml
+  - network-policy.yml

--- a/kubernetes/flux/infrastructure/base/monitoring/network-policy.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/network-policy.yml
@@ -1,0 +1,120 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: monitoring
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# Prometheus scrapes the exporters, Alloy remote-writes to Prometheus and
+# pushes to Loki, the Loki gateway fronts Loki, and Grafana reads both. Those
+# flows are all internal to this namespace, and half of them belong to pods the
+# Loki and Alloy charts render, whose labels move on a chart bump. Pinning each
+# one would buy nothing over isolating the namespace as a whole and would break
+# quietly the next time Renovate bumps a chart.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: monitoring
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-nginx
+  namespace: monitoring
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    # The five UIs published under clinch-home.com: Grafana, Prometheus,
+    # Alertmanager, the Loki gateway and the Alloy UI. Ports rather than pod
+    # selectors, because three of the five are chart-rendered.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 3000
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 9090
+        - protocol: TCP
+          port: 9093
+        - protocol: TCP
+          port: 12345
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-media-log-push
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/component: gateway
+  policyTypes:
+    - Ingress
+  ingress:
+    # The media namespace runs an Alloy sidecar per app that tails file logs
+    # and pushes them here directly, not through the Ingress.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: media
+      ports:
+        - protocol: TCP
+          port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-external-ingest
+  namespace: monitoring
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - alloy-syslog
+          - graphite-exporter
+  policyTypes:
+    - Ingress
+  ingress:
+    # hawkstore and the UniFi consoles ship syslog and graphite metrics to the
+    # shared VIP. Both Services are externalTrafficPolicy: Cluster, so the
+    # sender's address is replaced by the node's — its Calico tunnel address
+    # when the pod sits elsewhere, its LAN address when the pod sits on the
+    # node announcing the VIP. Neither range identifies the sender, so this
+    # cannot be narrowed to hawkstore without moving the Services to Local.
+    - from:
+        - ipBlock:
+            cidr: 10.233.64.0/18
+        - ipBlock:
+            cidr: 10.1.2.0/24
+      ports:
+        # Service port 514 targets container port 1514; the policy matches the
+        # container port, so 514 here would silently drop every syslog line.
+        - protocol: TCP
+          port: 1514
+        - protocol: UDP
+          port: 1514
+        - protocol: TCP
+          port: 9109
+        - protocol: UDP
+          port: 9109

--- a/kubernetes/flux/infrastructure/base/uptime-kuma/kustomization.yml
+++ b/kubernetes/flux/infrastructure/base/uptime-kuma/kustomization.yml
@@ -6,3 +6,4 @@ resources:
   - helm-repository.yml
   - ingress.yml
   - namespace.yml
+  - network-policy.yml

--- a/kubernetes/flux/infrastructure/base/uptime-kuma/network-policy.yml
+++ b/kubernetes/flux/infrastructure/base/uptime-kuma/network-policy.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: uptime-kuma
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-http
+  namespace: uptime-kuma
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: uptime-kuma
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+        # The admin bootstrap Job drives the same port from inside the
+        # namespace to create the initial user.
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 3001


### PR DESCRIPTION
Closes #441.

Every pod in the cluster accepted traffic from every other pod. This adds a default-deny ingress policy to each namespace this repo owns manifests in — `factorio`, `homepage`, `monitoring`, `uptime-kuma` — then allows back only the flows that actually exist, and takes `non-isolated-pod` off the kube-linter exclusion list.

## Checked the CNI first

The issue asked for this before writing any policy, since a policy that is silently ignored is worse than none. Calico is the CNI and it does enforce: in a scratch namespace, a pod-to-pod request returning `HTTP 200` before a default-deny timed out (curl exit 28) after it.

Kubelet probes are **not** caught by a default-deny — the test pod stayed `Ready` through four probe cycles with nothing allowing the node address. So no rule here exists to keep probes alive.

## The external paths were measured, not assumed

A Service on `externalTrafficPolicy: Cluster` replaces the caller's address, and *which* address depends on where the pod is scheduled:

| pod placement | source the pod sees |
|---|---|
| on another node | announcing node's Calico tunnel address (`10.233.x.x`) |
| on the announcing node | node's LAN address (`10.1.2.x`) |

Allowing only one of the two would leave a rule that works or fails depending on scheduling — the sort of intermittent failure that is miserable to debug — so `homepage` and the syslog/graphite ingest ports allow both `10.233.64.0/18` and `10.1.2.0/24`. Neither range identifies the sender, so these cannot be narrowed to "just hawkstore" without moving the Services to `Local`.

`factorio` is `externalTrafficPolicy: Local`, keeps the real client address, and takes players from the internet over a port forward, so `0.0.0.0/0` on 34197/UDP is the honest rule.

One trap worth flagging: `alloy-syslog`'s Service port 514 targets **container port 1514**, and NetworkPolicy matches the container port. Writing 514 would have silently dropped every syslog line.

## Why `monitoring` allows its own namespace wholesale

Prometheus scraping the exporters, Alloy remote-writing to Prometheus and pushing to Loki, the gateway fronting Loki, and Grafana reading both are all internal to the namespace — and half those pods are rendered by the Loki and Alloy charts, whose labels move on a bump. Pinning each flow buys nothing over isolating the namespace and would break quietly the next time Renovate bumps a chart. The meaningful win here is cross-namespace isolation.

Crossing into `monitoring`: `ingress-nginx` for the five published UIs, and `media`, whose Alloy sidecars push app logs straight to the Loki gateway rather than through the Ingress. That second one is easy to miss and would have broken all media log shipping.

## Verification

Policy logic was exercised in throwaway namespaces against the real Calico, using stand-in pods carrying the same labels — no production workload was touched, and the scratch namespaces are deleted:

| case | expected | result |
|---|---|---|
| same-namespace peer → gateway | allowed | allowed |
| same-namespace peer → ingest | allowed | allowed |
| `media` stand-in namespace → gateway | allowed | allowed |
| `media` stand-in namespace → ingest | denied | denied |
| `matchExpressions ... In` scoping ingest | allowed | allowed |

All gates run locally and pass: **kube-linter** (with `non-isolated-pod` removed), **yamllint**, **Kyverno** (must-fail fixtures still rejected, all 37 overlays clean), **kubeconform** 37/37. `kubectl apply --dry-run=server` accepts all nine policies.

`dangling-networkpolicy` joins the exclusions for exactly the reason `dangling-ingress` is already there: the loki-gateway and uptime-kuma policies select pods their charts render, which kustomize output cannot contain. Both selectors were checked against the running pods.

## Not covered

`ingress-nginx`, `certificate-manager` and `metallb` are Helm-only namespaces with no raw manifests here, and `media` lives in its own repo — none are reachable by this repo's lint gate. Isolating them is worth doing but carries real outage risk (the cert-manager webhook and MetalLB's host-network speakers), so it is deliberately not bundled in here. Happy to raise that as a follow-up.

Only ingress is filtered. Egress default-deny is a separate and much riskier project — DNS, NFS and internet egress all become failure modes — and the issue scoped this to ingress.