### PR TITLE
factorio: halve the CPU request to unblock scheduling

### DIFF
--- a/kubernetes/flux/applications/base/factorio/deployment.yml
+++ b/kubernetes/flux/applications/base/factorio/deployment.yml
@@ -18,8 +18,7 @@ metadata:
       factorio writes mods and scenarios outside the mounts
 spec:
   replicas: 1
-  # Required by kubernetes/policy/nfs-deployment-requires-recreate.yaml: a
-  # surged second pod would double-mount the NFS saves.
+  # Enforced by kubernetes/policy/nfs-deployment-requires-recreate.yaml
   strategy:
     type: Recreate
   selector:
@@ -88,8 +87,7 @@ spec:
             failureThreshold: 5
           resources:
             requests:
-              # Steady state is about one busy core; uncapped on CPU, so this
-              # reserves capacity rather than limiting peaks.
+              # Steady state is about one busy core, and there is no CPU limit, so peaks are unaffected.
               cpu: "2"
               memory: "16Gi"
             limits:

--- a/kubernetes/flux/applications/base/factorio/deployment.yml
+++ b/kubernetes/flux/applications/base/factorio/deployment.yml
@@ -18,7 +18,8 @@ metadata:
       factorio writes mods and scenarios outside the mounts
 spec:
   replicas: 1
-  # RollingUpdate deadlocks: no node can double-book the 4-CPU request
+  # Required by kubernetes/policy/nfs-deployment-requires-recreate.yaml: a
+  # surged second pod would double-mount the NFS saves.
   strategy:
     type: Recreate
   selector:
@@ -87,7 +88,9 @@ spec:
             failureThreshold: 5
           resources:
             requests:
-              cpu: "4"
+              # Steady state is about one busy core; uncapped on CPU, so this
+              # reserves capacity rather than limiting peaks.
+              cpu: "2"
               memory: "16Gi"
             limits:
               # Matches the request rather than capping lower: observed working


### PR DESCRIPTION
Three pods requested ~4 CPU each (`factorio`, `media/plex`, `media/tdarr`) on a 3-node cluster with 9400m allocatable per node, so they only fit one per node. Any mass restart could pack two onto one node and leave the third permanently `Pending` — which is what happened to `tdarr` during the #467 cutover.

`factorio` is the one of the three that lives in this repo. Dropping its base request to `cpu: "2"` removes the trap: two ~4-CPU pods always fit across three nodes, so no rescheduling order can strand one. The container has no CPU limit, so peak throughput is unchanged — only the reservation shrinks. The dev and london overlays already patch the request down to `1` and are untouched.

The `strategy: Recreate` comment claimed RollingUpdate deadlocked because no node could double-book the 4-CPU request. That stops being true here, so it now cites the real reason: `kubernetes/policy/nfs-deployment-requires-recreate.yaml`.

## Review

- Checked the memory risk the plan flagged: with CPU no longer forcing a spread, two 16Gi pods could co-locate. `terraform/modules/ubuntu-server/variables.tf` sizes the nodes at 10 cores / 64Gi, so 32Gi on one node is comfortable and the stranding does not reappear as a memory constraint.
- Trimmed the two new comments to one line each; both had a second line restating generic Kubernetes request-vs-limit semantics, against the repo's comment rule.
- Verified all 37 overlays build with `kubectl kustomize` and that hawkfield resolves to `cpu: "2"` while dev and london stay at `"1"`. yamllint clean.

Follow-up, not in this PR: `media/plex` and `media/tdarr` still request 4 CPU each and live in `clincha/media`, a separate Flux source. Lowering those to `1` (limits stay at 8) would free a further ~6 CPU of reservation.

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)