### PR TITLE
Retain Prometheus and Loki data for 2 years

### DIFF
--- a/kubernetes/flux/infrastructure/base/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/prometheus.yml
@@ -74,6 +74,7 @@ spec:
             - --web.enable-remote-write-receiver
             - --config.file=/etc/prometheus/prometheus.yml
             - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time=730d
             - --web.console.libraries=/usr/share/prometheus/console_libraries
             - --web.console.templates=/usr/share/prometheus/consoles
       volumes:

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/loki-values.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/loki-values.yml
@@ -40,9 +40,16 @@ loki:
       s3ForcePathStyle: true
       insecure: true
   limits_config:
-    retention_period: 90d
+    retention_period: 730d
     reject_old_samples: true
     reject_old_samples_max_age: 7d
+  # The chart emits no compactor section, and retention_period alone does
+  # nothing — deletion is the compactor's job and it defaults to off.
+  # delete_request_store is mandatory once retention_enabled is true.
+  structuredConfig:
+    compactor:
+      retention_enabled: true
+      delete_request_store: s3
   pattern_ingester:
     enabled: false
 


### PR DESCRIPTION
Closes #473.

Prometheus had no `--storage.tsdb.retention.time`, so it was running on the
15d default. Loki set `retention_period: 90d` but the running config had
`compactor.retention_enabled: false` — retention is enforced by the
compactor, so nothing has ever been deleted.

Both now set to 730d. At the measured rates (Prometheus 213 MB/day, Loki
119 MB/day on disk) that is ~243 GB over two years against 276 GB free on
`userstore`. Tiering to the `data` pool was considered and dropped; pool
expansion gets revisited when space runs low.

The Loki compactor block goes through `loki.structuredConfig` because the
chart emits no `compactor:` section of its own — `structuredConfig` is
deep-merged over the rendered config (`_helpers.tpl` line 504 in chart
7.3.0). `delete_request_store` is mandatory once `retention_enabled` is
true, otherwise the compactor fails validation on startup.

## Verification

- `kubectl kustomize` renders clean; the `loki-values` ConfigMap hash moves
  from `-tf7c25t5k5` to `-8g86d8mgf4` and the HelmRelease `valuesFrom`
  tracks it, so this triggers a HelmRelease upgrade on its own — no manual
  `flux reconcile --force` needed.
- `yamllint` clean on both files.
- Nothing is deleted by this change: Loki's oldest data is ~71 days old,
  well inside 730d.

Prometheus restarts on rollout. Loki restarts on the HelmRelease upgrade.
