### PR TITLE
dns: add deluge and prowlarr ingress records

### DIFF
--- a/Ansible/group_vars/adguard.yml
+++ b/Ansible/group_vars/adguard.yml
@@ -70,6 +70,10 @@ adguard_local_dns_entries:
     answer: "10.1.2.205"
   - domain: "photos.clinch-home.com"
     answer: "10.1.2.205"
+  - domain: "deluge.clinch-home.com"
+    answer: "10.1.2.205"
+  - domain: "prowlarr.clinch-home.com"
+    answer: "10.1.2.205"
 
   # Kubernetes ingress — clincha.co.uk
   - domain: "clincha.co.uk"
@@ -109,6 +113,10 @@ adguard_local_dns_entries:
   - domain: "immich.clincha.co.uk"
     answer: "10.1.2.205"
   - domain: "photos.clincha.co.uk"
+    answer: "10.1.2.205"
+  - domain: "deluge.clincha.co.uk"
+    answer: "10.1.2.205"
+  - domain: "prowlarr.clincha.co.uk"
     answer: "10.1.2.205"
 
   # Claude server (Dave)


### PR DESCRIPTION
Follow-on from clincha/media#76, which is merged and live. Both apps are running and reachable — these four A records are the only thing left.

Verified before opening this: with `--resolve` pointing at 10.1.2.205, all four names return **HTTP 200 with a valid certificate** (`ssl_verify_result=0`). So the ingress, cert-manager and routing sides are already correct, and DNS is the sole gap.

The wildcard `||clinch-home.com^$dnstype=HTTPS` / `||clincha.co.uk^$dnstype=HTTPS` user rules already cover both new names, so no ECH change is needed here.