### PR TITLE
Alert on UniFi gateway memory as a trend, not a threshold

### DIFF
--- a/Documentation/runbooks/unifi-network.md
+++ b/Documentation/runbooks/unifi-network.md
@@ -21,6 +21,8 @@ Alertmanager, plus the one network alert that cannot come from Hawkfield at all.
 | `UniFiPoeBudgetHigh` | warning | PoE draw over 80% of the switch budget, for 30m |
 | `UniFiSwitchPortErrors` | warning | over 1 error/s on a port for 15m |
 | `UniFiWifiChannelUtilisationHigh` | warning | 5GHz channel over 75% utilised for 30m |
+| `UniFiGatewayMemoryExhaustionPredicted` | warning | gateway headroom projected to reach earlyoom's threshold within 48h, for 2h |
+| `UniFiGatewayMemoryCritical` | critical | gateway headroom already under earlyoom's threshold, for 15m |
 
 Alerts carry `site` (`hawkfield` or `london`) and, where the metric has one, `name` — the device
 name rather than its MAC.
@@ -290,6 +292,43 @@ unpoller_device_port_sfp_rx_power   # for the 10G SFP+ ports
 
 Falling `sfp_rx_power` on a port that is throwing errors points at the optic or the fibre.
 
+### `UniFiGatewayMemoryExhaustionPredicted` / `UniFiGatewayMemoryCritical`
+
+A UDM idles at 83–86% memory used, so these two rules deliberately ignore utilisation and watch
+**headroom** — `installed - used`, which is MemAvailable, because unpoller reports `used` as
+`MemTotal - MemAvailable`. Both thresholds are `earlyoom`'s own `-M 256000` (kB), not a guess.
+
+The failure this catches is #480: `unifi-core` leaks, `earlyoom` is configured to `--avoid`
+`unifi-core`, so when memory runs out it SIGTERMs the **UniFi Network application** instead.
+The console dies, the router does not. Expect a report of "the router is down" when routing,
+DNS and WAN are all fine.
+
+```bash
+# headroom now, both consoles
+curl -s http://unpoller.monitoring.svc:9130/metrics \
+  | grep -E '^unpoller_device_memory_(installed|used)_bytes.*udm'
+
+# what is actually holding the memory — needs the console
+ssh root@10.1.2.1 'grep -E "MemAvailable|SwapFree" /proc/meminfo'
+ssh root@10.1.2.1 'ps -eo comm,rss,vsz --sort=-rss | head'
+
+# per-process history the box keeps itself, every 5 minutes.
+# Sum VmRSS + VmSwap — a large share of the growth sits in swap.
+ssh root@10.1.2.1 \
+  "awk -F, '/^timestamp,/{ts=\$3} /^unifi-core,unifi-core,/{print ts,\$6,\$7}' \
+     /var/log/mem_trend/mem_trend_long.csv"
+
+# earlyoom's own verdict
+ssh root@10.1.2.1 'journalctl -u earlyoom --since -7d | tail -40'
+```
+
+**To recover:** `systemctl restart unifi-core` on the affected console. It reclaims the leak
+(~160 MB in the 2026-08-17 case), routing and WAN are unaffected, and unpoller reconnects on its
+own — it does not need touching. Restarting the *Network application* instead, which is what the
+console's Start button does, reclaims nothing: it kills the victim, not the leaker.
+
+This is a reset, not a fix. Confirm the slope afterwards rather than assuming it is gone.
+
 ### `UniFiWifiChannelUtilisationHigh`
 
 5GHz only. 2.4GHz is deliberately not alerted on: it already peaks over 50% at idle here from
@@ -323,7 +362,8 @@ change is live.
 
 - **Paddock AP** — outbuilding, most likely to disconnect for benign reasons.
 - **2.4GHz utilisation** — over 50% at idle. Not alerted on, and should stay that way.
-- **Gateway memory at 83–86%** — normal for a UDM. Not alerted on.
+- **Gateway memory at 83–86%** — normal for a UDM. Still not alerted on as a *utilisation*
+  threshold; #480 added a trend rule on headroom instead. See below.
 - **Firmware updates** — `unpoller_device_upgradable` exists and is 0 across the estate, but
   there is no rule. An informational alert has no severity that routes anywhere except the
   unmuted default, so it would arrive overnight. Add it as a dashboard panel instead.

--- a/kubernetes/alert-rule-tests/unifi-network.yaml
+++ b/kubernetes/alert-rule-tests/unifi-network.yaml
@@ -273,6 +273,15 @@ tests:
         values: '0+0x50'
       - series: 'unpoller_prometheus_refresh_failures_total{site="hawkfield"}'
         values: '0+0x50'
+      # Bristol as measured on 2026-08-18, the morning after unifi-core was
+      # restarted: 2045500 kB installed, 1676608 kB used, so ~352 MB of
+      # headroom sitting flat. This is the value the gateway rules must not
+      # fire on, and the reason #445 refused a utilisation threshold — 82%
+      # used is this box perfectly healthy.
+      - series: 'unpoller_device_memory_installed_bytes{site="hawkfield", name="Bristol", type="udm"}'
+        values: '2094592000+0x50'
+      - series: 'unpoller_device_memory_used_bytes{site="hawkfield", name="Bristol", type="udm"}'
+        values: '1716846592+0x50'
     alert_rule_test:
       - eval_time: 45m
         alertname: UniFiConsoleUnreachable
@@ -316,3 +325,74 @@ tests:
       - eval_time: 45m
         alertname: UniFiWifiChannelUtilisationHigh
         exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiGatewayMemoryExhaustionPredicted
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: UniFiGatewayMemoryCritical
+        exp_alerts: []
+
+  # The #480 leak, replayed. unifi-core took ~30 MB/day out of a console that
+  # idles with ~355 MB of headroom, so nothing is wrong at any single moment
+  # and the box is still four days from an earlyoom kill when this must fire.
+  - interval: 1m
+    name: unifi-core leaks the gateway toward an earlyoom kill
+    input_series:
+      - series: 'unpoller_device_memory_installed_bytes{site="hawkfield", name="Bristol", type="udm"}'
+        values: '2094592000+0x1800'
+      # 340 MB of headroom, falling 30 MB/day = 20833 bytes/min.
+      - series: 'unpoller_device_memory_used_bytes{site="hawkfield", name="Bristol", type="udm"}'
+        values: '1754592000+20833x1800'
+    alert_rule_test:
+      # Six hours in, headroom is still ~328 MB and 48h of lookahead does not
+      # reach the threshold yet.
+      - eval_time: 6h
+        alertname: UniFiGatewayMemoryExhaustionPredicted
+        exp_alerts: []
+      # Still silent at 18h: the condition has been true for under two hours.
+      - eval_time: 18h
+        alertname: UniFiGatewayMemoryExhaustionPredicted
+        exp_alerts: []
+      # Fires at 20h, with ~318 MB still free and the earlyoom kill four days
+      # out. The 2026-08-17 incident got no warning at all.
+      - eval_time: 20h
+        alertname: UniFiGatewayMemoryExhaustionPredicted
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              site: hawkfield
+              name: Bristol
+            exp_annotations:
+              summary: 'projected to reach the earlyoom line within 48h — 246.9MiB headroom projected'
+              runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+      # Nowhere near the line itself — the whole point is that the warning
+      # above fires while there is still plenty of memory left.
+      - eval_time: 24h
+        alertname: UniFiGatewayMemoryCritical
+        exp_alerts: []
+
+  # 256000 kB is where earlyoom starts killing, and it is told to spare
+  # unifi-core, so the process that gets SIGTERM is the Network application.
+  - interval: 1m
+    name: gateway headroom reaches the earlyoom threshold
+    input_series:
+      - series: 'unpoller_device_memory_installed_bytes{site="london", name="London", type="udm"}'
+        values: '2094592000+0x60'
+      # 200 MB of headroom: under earlyoom's 250 MiB, still alive because swap
+      # has not drained past 10% yet.
+      - series: 'unpoller_device_memory_used_bytes{site="london", name="London", type="udm"}'
+        values: '1894592000+0x60'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: UniFiGatewayMemoryCritical
+        exp_alerts: []
+      - eval_time: 20m
+        alertname: UniFiGatewayMemoryCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              site: london
+              name: London
+            exp_annotations:
+              summary: 'only 190.7MiB free — earlyoom kills the Network app once swap drains'
+              runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
@@ -146,8 +146,8 @@ groups:
   # Thresholds here are deliberate guesses. #443 had run for three hours when
   # these were written, so each one is set clear of the observed idle rather
   # than derived from a baseline, and is meant to be revisited against real
-  # data. Gateway memory has no rule at all: the UDMs idle at 83-86% and any
-  # static threshold would either fire immediately or never fire in time.
+  # data. Gateway memory is the exception and lives in its own group below,
+  # anchored on earlyoom's own constants rather than on a guess.
   - name: unifi-health
     rules:
       # Observed idle: Bristol 67 CPU / 71 board, London 74 CPU / 77 board.
@@ -213,4 +213,63 @@ groups:
           severity: warning
         annotations:
           summary: '5GHz channel {{ $value | humanizePercentage }} utilised for 30 minutes'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+  # Gateway memory, added by #480 after unifi-core leaked ~30 MB/day into an
+  # earlyoom kill loop that took the Hawkfield console down for 15 minutes.
+  #
+  # #445 shipped no rule here because the UDMs idle at 83-86% used, so any
+  # static utilisation threshold fires immediately or never fires in time.
+  # That reasoning held for utilisation; it does not hold for headroom.
+  #
+  # `installed - used` is MemAvailable. unpoller reports used as
+  # MemTotal - MemAvailable, verified against /proc/meminfo on both consoles
+  # (1676608 kB reported vs 1677908 kB measured), so the difference is the
+  # exact quantity earlyoom gates on and not a cache-inflated proxy.
+  #
+  # earlyoom on UniFi OS runs with `-M 256000 -s 10` and kills only when
+  # memory AND swap are both under, having been told to `--avoid` unifi-core
+  # itself. So the leaker is spared and the Network application is killed in
+  # its place. 256000 kB is the 262144000 below: both rules sit on earlyoom's
+  # own line rather than on a number we picked.
+  - name: unifi-gateway-memory
+    rules:
+      # Headroom swings +/-70 MB with page cache churn, which is wider than a
+      # day of the leak, so every rule here reads the 3h average instead. It
+      # is recorded rather than inlined to keep predict_linear off a nested
+      # subquery. `max by` drops site_name and source: renaming a site mid-leak
+      # already split this series once, and predict_linear across that split
+      # projects nonsense.
+      - record: gateway:unifi_memory_available_bytes:avg3h
+        expr: |
+          avg_over_time(
+            (
+              max by (site, name) (unpoller_device_memory_installed_bytes{type="udm"})
+                - max by (site, name) (unpoller_device_memory_used_bytes{type="udm"})
+            )[3h:1m]
+          )
+
+      # The rule the incident asked for. Replayed against 11-18 Aug it first
+      # fires 14 Aug 06:00 and stays firing to the 17 Aug 21:22 kill loop —
+      # 3.6 days of warning — and clears within two hours of the restart.
+      # 48h of lookahead is what buys that lead; 24h of window is what stops
+      # the diurnal swing from fitting a slope of its own.
+      - alert: UniFiGatewayMemoryExhaustionPredicted
+        expr: predict_linear(gateway:unifi_memory_available_bytes:avg3h[24h], 48 * 3600) < 262144000
+        for: 2h
+        labels:
+          severity: warning
+        annotations:
+          summary: 'projected to reach the earlyoom line within 48h — {{ $value | humanize1024 }}B headroom projected'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+      # Already at the line. earlyoom needs swap under 10% as well, so this is
+      # not yet a kill — it is the last quiet moment before one.
+      - alert: UniFiGatewayMemoryCritical
+        expr: gateway:unifi_memory_available_bytes:avg3h < 262144000
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'only {{ $value | humanize1024 }}B free — earlyoom kills the Network app once swap drains'
           runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md


### PR DESCRIPTION
Closes part 2 of #480 — the alerting gap the 2026-08-17 incident exposed.

## Why there was no rule

#445 deliberately shipped **no gateway memory rule**: the UDMs idle at 83–86% used, so any static utilisation threshold either fires immediately or never fires in time. That reasoning was right about *utilisation* — and it is why the `unifi-core` leak ran blind for a week and surfaced as "the router is down".

## Headroom is the signal, and it is exact

`unpoller_device_memory_used_bytes` is `MemTotal - MemAvailable`. Verified live against `/proc/meminfo` on Bristol at the same moment:

| | |
| --- | --- |
| unpoller `used` | 1676608 kB |
| `MemTotal - MemAvailable` | 1677908 kB |

So `installed - used` **is** MemAvailable — the exact quantity `earlyoom` gates on, not a cache-inflated proxy. earlyoom on UniFi OS runs as:

```
/usr/bin/earlyoom -n -r60 -M256000 -s10 -p --avoid (^|/)(ubios-udapi-ser|systemd-network|unifi-core)$
```

`-M 256000` (kB) is the `262144000` in both rules — **both thresholds are earlyoom's own line, not a guess.** Note the `--avoid`: earlyoom is explicitly told to spare `unifi-core`, which is why it SIGTERMs the Network application instead. The leaker is protected; the victim is killed.

## Replayed against the real incident

`predict_linear` over a 24h window, 48h of lookahead, `for: 2h`, on the 3h-averaged headroom:

| console | first fires | sustained from | incident |
| --- | --- | --- | --- |
| Bristol | 13 Aug 06:50 | **14 Aug 06:00** | 17 Aug 21:22 |
| London | 13 Aug 11:30 | 13 Aug 11:30 | (never tripped) |

**3.6 days of warning**, and it clears within two hours of the `unifi-core` restart — no lingering post-fix noise.

Tuning that mattered:
- Raw headroom swings ±70 MB with page cache churn, wider than a full day of the leak. The 3h average cuts that to ±17 MB. Recorded rather than inlined so `predict_linear` is not sitting on a nested subquery.
- `max by (site, name)` drops `site_name` and `source`. The London site rename already split this series once on 11 Aug, and `predict_linear` across that split projects nonsense (881 MB → 34 MB in one step).
- 1h smoothing / `for: 1h` gave 5–6 alert episodes over the week; 3h / `for: 2h` gives 2.

## Tests

Unit tests cover both rules firing *and* staying silent, and the baseline "fires nothing" test now replays the real post-restart idle (2045500 kB installed, 1676608 kB used). Verified the tests bite by breaking the threshold and watching them fail, rather than trusting a green run.

```
promtool check rules ...   SUCCESS: 20 rules found
promtool test rules ...    SUCCESS
yamllint                   clean
kubectl kustomize          builds, rules present in the ConfigMap
```

## Not in this PR

Part 1 of #480 — stopping the leak itself — is still open, and the measurements have moved; see the issue comment. Part 3 (a scheduled restart) should wait until this alert has proven itself, since the whole point is to drive it from the alert rather than a blind cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)