### PR TITLE
Fix UniFiGatewayMemoryExhaustionPredicted extrapolating a cold start

### DIFF
--- a/Documentation/runbooks/unifi-network.md
+++ b/Documentation/runbooks/unifi-network.md
@@ -322,6 +322,12 @@ ssh root@10.1.2.1 \
 ssh root@10.1.2.1 'journalctl -u earlyoom --since -7d | tail -40'
 ```
 
+`UniFiGatewayMemoryExhaustionPredicted` stays silent until it has **20 hours** of history for a
+console, and fits the raw metrics rather than the recorded `gateway:unifi_memory_available_bytes:avg3h`.
+Both are deliberate: a `predict_linear` with only minutes of data extrapolates noise, which is
+exactly how this rule went pending on both consoles the moment it was deployed. Silence in the
+first day after a TSDB rebuild, or on a newly adopted console, is the rule working.
+
 **To recover:** `systemctl restart unifi-core` on the affected console. It reclaims the leak
 (~160 MB in the 2026-08-17 case), routing and WAN are unaffected, and unpoller reconnects on its
 own — it does not need touching. Restarting the *Network application* instead, which is what the

--- a/kubernetes/alert-rule-tests/unifi-network.yaml
+++ b/kubernetes/alert-rule-tests/unifi-network.yaml
@@ -349,13 +349,14 @@ tests:
       - eval_time: 6h
         alertname: UniFiGatewayMemoryExhaustionPredicted
         exp_alerts: []
-      # Still silent at 18h: the condition has been true for under two hours.
-      - eval_time: 18h
+      # Silent at 20h. The projection crossed the line around 16h, but the
+      # 20h-of-history guard only clears here, so the `for` starts now.
+      - eval_time: 20h
         alertname: UniFiGatewayMemoryExhaustionPredicted
         exp_alerts: []
-      # Fires at 20h, with ~318 MB still free and the earlyoom kill four days
+      # Fires at 22h, with ~313 MB still free and the earlyoom kill four days
       # out. The 2026-08-17 incident got no warning at all.
-      - eval_time: 20h
+      - eval_time: 22h
         alertname: UniFiGatewayMemoryExhaustionPredicted
         exp_alerts:
           - exp_labels:
@@ -363,7 +364,7 @@ tests:
               site: hawkfield
               name: Bristol
             exp_annotations:
-              summary: 'projected to reach the earlyoom line within 48h — 246.9MiB headroom projected'
+              summary: 'projected to reach the earlyoom line within 48h — 244.3MiB headroom projected'
               runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
       # Nowhere near the line itself — the whole point is that the warning
       # above fires while there is still plenty of memory left.
@@ -396,3 +397,28 @@ tests:
             exp_annotations:
               summary: 'only 190.7MiB free — earlyoom kills the Network app once swap drains'
               runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/unifi-network.md
+
+  # Regression test for the bug this rule shipped with. The predicted rule
+  # originally fit predict_linear over a recorded series, which only exists
+  # from the moment it is first evaluated: on rollout it had four samples,
+  # extrapolated them 48h, projected -1070 MB against 361 MB of real headroom
+  # and went pending on both consoles. Two hours from a false page.
+  #
+  # Ten hours of history and a steep slope is exactly that shape. It must say
+  # nothing rather than guess.
+  - interval: 1m
+    name: a short history must not be extrapolated
+    input_series:
+      - series: 'unpoller_device_memory_installed_bytes{site="hawkfield", name="Bristol", type="udm"}'
+        values: '2094592000+0x600'
+      # 340 MB falling 300 MB/day — ten times the real leak. Without the
+      # history guard this fires; the box is nowhere near trouble.
+      - series: 'unpoller_device_memory_used_bytes{site="hawkfield", name="Bristol", type="udm"}'
+        values: '1754592000+208333x600'
+    alert_rule_test:
+      - eval_time: 5h
+        alertname: UniFiGatewayMemoryExhaustionPredicted
+        exp_alerts: []
+      - eval_time: 10h
+        alertname: UniFiGatewayMemoryExhaustionPredicted
+        exp_alerts: []

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
@@ -235,11 +235,14 @@ groups:
   - name: unifi-gateway-memory
     rules:
       # Headroom swings +/-70 MB with page cache churn, which is wider than a
-      # day of the leak, so every rule here reads the 3h average instead. It
-      # is recorded rather than inlined to keep predict_linear off a nested
-      # subquery. `max by` drops site_name and source: renaming a site mid-leak
-      # already split this series once, and predict_linear across that split
-      # projects nonsense.
+      # day of the leak, so every rule here reads the 3h average instead.
+      # `max by` drops site_name and source: renaming a site mid-leak already
+      # split this series once, and predict_linear across that split projects
+      # nonsense.
+      #
+      # Recorded for the dashboards and for the Critical rule below, both of
+      # which only ever read its current value. The predicted rule deliberately
+      # does NOT read it — see there.
       - record: gateway:unifi_memory_available_bytes:avg3h
         expr: |
           avg_over_time(
@@ -254,8 +257,36 @@ groups:
       # 3.6 days of warning — and clears within two hours of the restart.
       # 48h of lookahead is what buys that lead; 24h of window is what stops
       # the diurnal swing from fitting a slope of its own.
+      #
+      # This fits the raw expression through a subquery rather than reading
+      # gateway:unifi_memory_available_bytes:avg3h, which would be tidier and
+      # is wrong. A recorded series only exists from the moment it is first
+      # evaluated, so on deploy predict_linear fits a handful of noisy points
+      # and extrapolates them 48h: at rollout it projected -1070 MB against
+      # 361 MB of real headroom and went pending on both consoles. The raw
+      # metrics carry full retention, so the subquery is right on its first
+      # evaluation. It costs 288 samples and ~2ms.
+      #
+      # The count guard is the same failure caught generically: below 20h of
+      # history — a rebuilt TSDB, a newly added console — the fit is noise, so
+      # say nothing rather than guess. 145 is a full [24h:10m] window.
       - alert: UniFiGatewayMemoryExhaustionPredicted
-        expr: predict_linear(gateway:unifi_memory_available_bytes:avg3h[24h], 48 * 3600) < 262144000
+        expr: |
+          predict_linear(
+            avg_over_time(
+              (
+                max by (site, name) (unpoller_device_memory_installed_bytes{type="udm"})
+                  - max by (site, name) (unpoller_device_memory_used_bytes{type="udm"})
+              )[3h:1m]
+            )[24h:10m], 48 * 3600
+          ) < 262144000
+            and
+          count_over_time(
+            (
+              max by (site, name) (unpoller_device_memory_installed_bytes{type="udm"})
+                - max by (site, name) (unpoller_device_memory_used_bytes{type="udm"})
+            )[24h:10m]
+          ) >= 120
         for: 2h
         labels:
           severity: warning


### PR DESCRIPTION
Found while verifying #481 on the cluster. **The rule that shipped would have sent a false warning about two hours after rollout.** Follow-up to #481, same issue (#480).

## What happened

One minute after Flux rolled it out:

```
UniFiGatewayMemoryExhaustionPredicted  state=pending  alerts=2
  Bristol  projected to reach the earlyoom line within 48h — -1020MiB headroom projected
  London   projected to reach the earlyoom line within 48h — -206MiB headroom projected
```

Actual headroom at that moment was **361 MB and healthy**.

The cause is that the rule fit `predict_linear` over `gateway:unifi_memory_available_bytes:avg3h`. **A recorded series only exists from the moment the recording rule is first evaluated.** It had 4 samples:

```
count_over_time(gateway:unifi_memory_available_bytes:avg3h[24h])  =  4
predict_linear(gateway:unifi_memory_available_bytes:avg3h[24h], 48*3600)  =  -1070 MB
```

`for: 2h` was the only thing standing between that and Telegram.

## Why my tests missed it

In promtool the recording rule and the input series both start at t=0, so by the first assertion the fit had hours of clean synthetic data. Production starts a recording rule against metrics that already have two years of history — the one case the test could not express. The replay in #481 was done with subqueries over real data, so it was never exercising the expression that actually shipped.

## Fix

Fit the raw expression through a subquery instead. The raw `unpoller_device_memory_*` metrics carry full retention, so it is correct on its first evaluation:

| | recorded series | raw subquery |
| --- | --- | --- |
| projected, at rollout | **−1070 MB** | **+751 MB** |
| correct? | no | yes |

The nested subquery is exactly what the recording rule was introduced to avoid — that rationale was wrong. Measured live: **288 samples, ~2ms**.

The recording rule stays. `UniFiGatewayMemoryCritical` and the dashboards only ever read its current value, which is correct immediately and was `inactive` throughout.

Also added a `count_over_time(...[24h:10m]) >= 120` guard — the same failure caught generically, for a rebuilt TSDB or a newly adopted console. The subquery step is fixed at 10m, so the guard is independent of `evaluation_interval` and cannot silently mute itself if that changes.

## Tests

New regression test, `a short history must not be extrapolated`: ten hours of history falling at 300 MB/day, ten times the real leak. Must stay silent.

I verified it **fails** when the guard is removed rather than trusting a green run — the mistake that let this through the first time.

```
promtool check rules   SUCCESS: 20 rules found
promtool test rules    SUCCESS
yamllint               clean
kubectl kustomize      OK
```

The leak-replay test now fires at 22h rather than 20h: the projection still crosses around 16h, and the history guard clears at 20h, so the `for: 2h` starts there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)