### PR TITLE
Let Renovate's automerge actually reach the merge

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -3,7 +3,7 @@ permissions:
   contents: read
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 */6 * * *'
   workflow_dispatch:
     inputs:
       dryRun:

--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,7 @@
   "dependencyDashboard": false,
   "minimumReleaseAge": "3 days",
   "platformAutomerge": false,
+  "rebaseWhen": "conflicted",
   "automergeStrategy": "squash",
   "prConcurrentLimit": 6,
   "prHourlyLimit": 4,


### PR DESCRIPTION
`automerge: true` has been set for minor/patch/digest since the Renovate rollout, and nothing has ever automerged.

Nothing is blocking the PRs. A dry run against the current tree confirms Renovate itself considers them ready:

```
DRY-RUN: Would merge PR #475 with strategy "squash"
DRY-RUN: Would merge PR #476 with strategy "squash"
DRY-RUN: Would merge PR #477 with strategy "squash"
```

It is a timing race. `platformAutomerge: false` means Renovate has to perform the merge inside its own run, so it can only merge during the ~60s a day the container is alive. `automerge: true` makes `rebaseWhen` default to `behind-base-branch`, so the first thing each run does is rebase every branch that is behind master. On today's 06:39 run the branch heads were pushed at 06:41:09 and the job finished at 06:41:35 — 26 seconds later, with CI on the new heads still queued. Master takes commits most days, so the next run rebases again, and a PR never gets a run where it is simultaneously green and up to date.

**`rebaseWhen: conflicted`** removes the churn: a branch that is already green is left alone, so the next run finds it green and merges it. Renovate still rebases when the PR genuinely conflicts, and still updates the branch when a newer version appears.

**Six-hourly schedule** turns "merges the next day" into "merges the same day". Four runs a day on a public repo.

`platformAutomerge` deliberately stays `false`. Handing the merge to GitHub would be the tidier mechanism, but [GitHub only shows auto-merge on PRs that cannot be merged immediately](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request), and there is no branch protection on `master`, so every green PR is immediately mergeable and the call would be refused — Renovate would log a warning and fall back to exactly this path. Making it work would mean a ruleset with required status checks, which is a separate decision and carries a real hazard here: several checks are path-conditional (`kustomize` runs on #477 but not #475), so listing them as required would leave PRs that never satisfy them stuck forever.

Trade-off worth naming: a branch merged without a rebase has not been retested against the latest master. For single-line version bumps validated by lint/policy jobs that is a small risk, and a genuine conflict still forces a rebase.
