### PR TITLE
Point the media Kustomization at its own SOPS key

### DIFF
--- a/kubernetes/flux/infrastructure/base/media/configuration/media-kustomization.yml
+++ b/kubernetes/flux/infrastructure/base/media/configuration/media-kustomization.yml
@@ -16,4 +16,4 @@ spec:
   decryption:
     provider: sops
     secretRef:
-      name: sops-gpg
+      name: sops-gpg-media


### PR DESCRIPTION
**Stage 2b of 3** for [clincha/media#75](https://github.com/clincha/media/issues/75).

> **Draft on purpose.** Do not merge until
> [clincha/media#81](https://github.com/clincha/media/pull/81) is merged **and** the `media`
> Kustomization has reconciled it. Before that, the media repo's secrets have only clincha's
> key as a recipient, and this flip leaves Flux unable to decrypt them.

One line. Flux's `decryption.secretRef` is per-Kustomization, which is the seam that actually
separates the two repos' blast radii.

Only `media` moves. `media-configuration` and `media-controller` source from `flux-system` and
read clincha paths — they stay on `sops-gpg`.

Secret `sops-gpg-media` already exists in `flux-system` on hawkfield, verified byte-identical
to the key in Bitwarden. It is created for future rebuilds by
[#485](https://github.com/clincha-org/clincha/pull/485), which does not apply it to the running
cluster because that play only runs from `cluster-rebuild.yaml`.

### How to tell it worked

A decryption failure here is quiet — the Kustomization goes NotReady while the already-applied
Secret persists and immich and deluge keep running, so nothing pages. Check the Kustomization,
not the apps:

```bash
flux reconcile kustomization media --with-source
flux get kustomization media
```

I will verify this after it merges and report on the issue.