### PR TITLE
Scrape media-exporter for library and playback metrics

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
@@ -73,3 +73,14 @@ scrape_configs:
         regex: ';.+'
         target_label: site
         replacement: london
+  # Library composition, Plex playback decisions and Tdarr encode progress,
+  # polled from the Radarr/Sonarr/Tdarr/Tautulli APIs by media-exporter in the
+  # media namespace (clincha/media#50). It serves a cached payload built on its
+  # own 15m timer, so a scrape never reaches those APIs and costs nothing.
+  # Scraped rather than pushed: monitoring's default-deny-ingress admits no
+  # remote-write from another namespace, and media has no ingress policy of its
+  # own — see #487.
+  - job_name: media-exporter
+    scrape_interval: 60s
+    static_configs:
+      - targets: ['media-exporter.media.svc:9114']


### PR DESCRIPTION
Companion to [clincha/media#87](https://github.com/clincha/media/pull/87), which adds `media-exporter` to the media namespace for [clincha/media#50](https://github.com/clincha/media/issues/50). This is the one line that makes its metrics reach Prometheus.

`media-exporter` polls the Radarr, Sonarr, Tdarr and Tautulli APIs and publishes library composition, Plex playback decisions and Tdarr encode progress — none of which Prometheus could see before, since nothing in `media` exposed metrics.

## Why scraped and not pushed

The obvious shape was an Alloy sidecar remote-writing to Prometheus, mirroring the media log sidecars. It does not work: `monitoring` has carried a `default-deny-ingress` NetworkPolicy since 2026-08-16, and nothing in it admits a remote-write from another namespace. A pod in `media` cannot open a TCP connection to `prometheus:9090` at all — DNS resolves, the connect times out.

Scraping needs no exemption, because `media` has no ingress policy of its own. It also matches `truenas-api`, `unifi` and `truenas-hawkstore`, which are all static targets here already, and it lets the media side drop a container, a WAL and an emptyDir.

The exporter serves a cached payload built on its own 15m timer, so the 60s scrape never reaches the four app APIs — same reasoning as the `truenas-api` comment above it.

## Related

Chasing the timeout down found that the same NetworkPolicy has been silently dropping **kubelet, cAdvisor and kube-state-metrics for two of the three nodes since 2026-08-16 17:34** — filed as #487. That is a separate fix; this PR does not depend on it, and deliberately routes around it rather than waiting.

## Verification

`media-exporter` is already running in the cluster, and Prometheus can reach it:

```
$ kubectl -n monitoring exec deploy/prometheus -- wget -qO- http://media-exporter.media.svc:9114/metrics | head -3
# HELP media_library_files Files in the library
# TYPE media_library_files gauge
media_library_files{bit_depth="10",codec="av1",quality="WEBRip-1080p",section="series"} 16
```

The scrape target and every dashboard panel query were verified against live data before opening this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)