### PR TITLE
Admit node telemetry senders through the monitoring network policies

### DIFF
--- a/Documentation/runbooks/telemetry-coverage.md
+++ b/Documentation/runbooks/telemetry-coverage.md
@@ -1,0 +1,124 @@
+# Runbook: telemetry coverage alerts
+
+Covers `KubeletTelemetryMissing`, `CadvisorTelemetryMissing`, `NodeExporterTelemetryMissing`
+(warning) and `KubeStateMetricsMissing` (critical), delivered to Telegram by Alertmanager.
+
+## The alerts
+
+| Alert | Severity | Fires when |
+| --- | --- | --- |
+| `KubeletTelemetryMissing` | warning | `up{job="kubelet"}` covers fewer than 3 nodes for 15m |
+| `CadvisorTelemetryMissing` | warning | `up{job="cadvisor"}` covers fewer than 3 nodes for 15m |
+| `NodeExporterTelemetryMissing` | warning | `up{job="integrations/unix"}` covers fewer than 3 `k8s-hawk-*` instances for 15m |
+| `KubeStateMetricsMissing` | critical | no `kube_pod_info` series at all for 15m |
+
+These exist because **none of these targets can ever be `up == 0`.** Prometheus does not scrape
+any of them. They arrive by `remote_write` from the Alloy DaemonSet, so a sender that cannot
+deliver makes its series stop arriving — the targets go *absent*, and every alert keyed on
+`up == 0` is blind to it. Grafana panels do not error either; they just thin out.
+
+`KubeStateMetricsMissing` is critical rather than warning because `PodRestartingFrequently` and
+`PodCrashLooping` are both built on `kube_*` series. When it fires, those two alerts are not
+"quiet" — they are incapable of firing.
+
+The node count is hardcoded as 3. It cannot be derived, because the only source of a node count
+is kube-state-metrics, which is one of the things that goes missing. **Adding a node means
+editing these three expressions.**
+
+## How the data reaches you
+
+```
+kubelet / cAdvisor / kube-state-metrics / node exporter
+  → Alloy DaemonSet (scrape, one pod per node, hostNetwork)
+  → remote_write http://prometheus.monitoring.svc:9090/api/v1/write
+  → Prometheus → alert rules → Alertmanager → Telegram
+```
+
+The Alloy pods run `hostNetwork: true`, which is what makes them report the node rather than the
+pod. It also means they have **no pod IP**, so no `podSelector` in any NetworkPolicy can match
+them, and their traffic reaches Prometheus from the sending node's **Calico VXLAN tunnel
+address** (in the pod CIDR, not the LAN range) whenever the two are on different nodes.
+
+- Rules: `kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml`
+- Alloy config: `kubernetes/flux/infrastructure/base/monitoring/helm-release-alloy.yml`
+- Policies: `kubernetes/flux/infrastructure/base/monitoring/network-policy.yml`
+- Prometheus alert state: <https://prometheus.clinch-home.com/alerts>
+
+## Triage
+
+Check what is actually arriving:
+
+```bash
+kubectl -n monitoring exec deploy/prometheus -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=count%20by(job)(up)'
+```
+
+Then find which node is missing:
+
+```bash
+kubectl -n monitoring exec deploy/prometheus -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=up%7Bjob%3D%22kubelet%22%7D'
+```
+
+### 1. Is the sender alive?
+
+```bash
+kubectl -n monitoring get pod -l app.kubernetes.io/name=alloy -o wide
+kubectl -n monitoring logs <alloy-pod> -c alloy --tail=50 | grep -i remote_write
+```
+
+A blocked or unreachable receiver looks like this, and **names nothing useful**:
+
+```
+level=warn msg="Failed to send batch, retrying" component_id=prometheus.remote_write.local
+  err="Post \"http://prometheus.monitoring.svc:9090/api/v1/write\": context deadline exceeded"
+level=error msg="final error sending batch, no retries left, dropping data"
+```
+
+`context deadline exceeded` on the POST means the TCP connection never completed. That is a
+network path problem, not an Alloy problem.
+
+### 2. Is a NetworkPolicy eating it?
+
+This is what caused [#487](https://github.com/clincha-org/clincha/issues/487). Confirm on the
+wire rather than by reading YAML — run this on the node **Prometheus** is on:
+
+```bash
+sudo tcpdump -nni any 'tcp port 9090 and tcp[tcpflags] & tcp-syn != 0'
+```
+
+A dropped flow arrives on `vxlan.calico In` and never appears on the destination's `caliXXXX`
+interface, with the same sequence number retransmitting every few seconds and no SYN-ACK:
+
+```
+vxlan.calico In IP 10.233.103.0.49866 > 10.233.70.68.9090: Flags [S], seq 1781783217
+vxlan.calico In IP 10.233.103.0.49866 > 10.233.70.68.9090: Flags [S], seq 1781783217
+```
+
+A permitted flow shows the `cali…  Out` hop and a SYN-ACK straight back.
+
+Note the source address: `10.233.103.0` is **k8s-hawk-2's VXLAN tunnel address**, not
+`10.1.2.102`. Map them with:
+
+```bash
+kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"  "}{.metadata.annotations.projectcalico\.org/IPv4VXLANTunnelAddr}{"\n"}{end}'
+```
+
+Only `ipBlock` rules can admit these senders. `allow-node-remote-write` and `allow-log-push` in
+`network-policy.yml` are the two that do; if either loses its `ipBlock`, this breaks again.
+
+### 3. Is only one node reporting?
+
+If exactly one node survives, that node is almost certainly the one running the receiving pod —
+node-local traffic never crosses the policy. That asymmetry is the signature of a policy
+problem rather than a sender problem.
+
+Logs have the same failure mode against a different receiver: the Loki gateway. When it bites
+there, `{job="pod-logs"}` and the journal stream survive only for the node the gateway runs on,
+while the `media` namespace sidecars keep working (they are pods, so `allow-log-push` matches
+them by namespace). Per-node log counts can look healthy because those sidecar streams carry a
+`node` label too — split by `job` before concluding anything:
+
+```
+sum by (node, job)(count_over_time({node=~"k8s-hawk-.*"}[10m]))
+```

--- a/kubernetes/flux/infrastructure/base/monitoring/network-policy.yml
+++ b/kubernetes/flux/infrastructure/base/monitoring/network-policy.yml
@@ -60,7 +60,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-media-log-push
+  name: allow-log-push
   namespace: monitoring
 spec:
   podSelector:
@@ -79,6 +79,51 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+    # The Alloy DaemonSet ships each node's journal and pod logs here. See
+    # allow-node-remote-write below for why this cannot be a podSelector.
+    - from:
+        - ipBlock:
+            cidr: 10.233.64.0/18
+        - ipBlock:
+            cidr: 10.1.2.0/24
+      ports:
+        - protocol: TCP
+          port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-node-remote-write
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes:
+    - Ingress
+  ingress:
+    # kubelet, cAdvisor, kube-state-metrics and the node exporters reach
+    # Prometheus by remote_write from the Alloy DaemonSet, never by scrape.
+    # Those pods are hostNetwork, so they have no pod IP and podSelector --
+    # including the allow-same-namespace rule above -- never matches them. An
+    # ipBlock is the only selector that does.
+    #
+    # The address is the *sender node's Calico VXLAN tunnel address*, measured
+    # on the wire (10.233.103.0 from k8s-hawk-2, 10.233.123.128 from
+    # k8s-hawk-3), not its LAN address: cross-node traffic to a pod leaves via
+    # vxlan.calico. Those addresses come out of the pod CIDR and Calico
+    # reallocates the block on a node rebuild, so pinning them as /32s would
+    # re-break this the same silent way. Node-local traffic arrives as
+    # 10.1.2.0/24 and Calico admits it regardless; it is listed so the rule
+    # does not depend on that behaviour staying true.
+    - from:
+        - ipBlock:
+            cidr: 10.233.64.0/18
+        - ipBlock:
+            cidr: 10.1.2.0/24
+      ports:
+        - protocol: TCP
+          port: 9090
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
@@ -68,7 +68,10 @@ groups:
       # metal outside the cluster, which reach Prometheus through the Ingress
       # and are unaffected by anything inside it.
       - alert: NodeExporterTelemetryMissing
-        expr: count(up{job="integrations/unix", instance=~"k8s-hawk-.+"}) < 3 or absent(up{job="integrations/unix", instance=~"k8s-hawk-.+"})
+        expr: |
+          count(up{job="integrations/unix", instance=~"k8s-hawk-.+"}) < 3
+            or
+          absent(up{job="integrations/unix", instance=~"k8s-hawk-.+"})
         for: 15m
         labels:
           severity: warning

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/alert-rules.yml
@@ -34,6 +34,60 @@ groups:
           summary: 'stuck in CrashLoopBackOff for over 15 minutes'
           runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/pod-restarts.md
 
+  # kubelet, cAdvisor, kube-state-metrics and the node exporters all reach
+  # Prometheus by remote_write from the Alloy DaemonSet, never by scrape. When
+  # a sender cannot deliver, its series stop arriving: the targets go ABSENT,
+  # they never go up == 0. Nothing keyed on up == 0 can see that, which is how
+  # clincha#487 hid two thirds of the cluster's container telemetry for three
+  # days behind panels that merely thinned out. These key on target count.
+  #
+  # Three is the cluster's node count, hardcoded because the count itself is
+  # only knowable from kube-state-metrics, which is one of the things that
+  # goes missing. Adding a node means changing this number with it.
+  - name: telemetry-coverage
+    rules:
+      - alert: KubeletTelemetryMissing
+        expr: count(up{job="kubelet"}) < 3 or absent(up{job="kubelet"})
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'kubelet metrics arriving from fewer than 3 nodes — container telemetry has a blind spot'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/telemetry-coverage.md
+
+      - alert: CadvisorTelemetryMissing
+        expr: count(up{job="cadvisor"}) < 3 or absent(up{job="cadvisor"})
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'cAdvisor metrics arriving from fewer than 3 nodes — per-container CPU and memory has a blind spot'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/telemetry-coverage.md
+
+      # Scoped to the cluster nodes: this job also carries the VMs and bare
+      # metal outside the cluster, which reach Prometheus through the Ingress
+      # and are unaffected by anything inside it.
+      - alert: NodeExporterTelemetryMissing
+        expr: count(up{job="integrations/unix", instance=~"k8s-hawk-.+"}) < 3 or absent(up{job="integrations/unix", instance=~"k8s-hawk-.+"})
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'host metrics arriving from fewer than 3 cluster nodes — node CPU, memory and disk has a blind spot'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/telemetry-coverage.md
+
+      # One instance cluster-wide, so this is absent-or-nothing rather than a
+      # count. Every kube_* series in Grafana and the pod-restart alerts above
+      # depend on it.
+      - alert: KubeStateMetricsMissing
+        expr: absent(kube_pod_info)
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'no kube-state-metrics series at all — pod restart and crashloop alerts cannot fire'
+          runbook_url: https://github.com/clincha-org/clincha/blob/master/Documentation/runbooks/telemetry-coverage.md
+
   # unpoller serves a 60s cache rather than polling on scrape, so every value
   # here is up to a minute stale. Nothing below has a `for` shorter than 5m,
   # which keeps that staleness well inside the noise.


### PR DESCRIPTION
Closes #487.

## What was broken

The `default-deny-ingress` set added to `monitoring` on 2026-08-16 dropped **every Alloy DaemonSet push that crosses a node boundary**. Measured on the wire before and after:

| | before | after |
| --- | --- | --- |
| `kubelet` targets | 1 | 3 |
| `cadvisor` targets | 1 | 3 |
| `ingress-nginx` targets | 1 | 3 |
| `kube_pod_info` series | 0 | 74 |
| `integrations/unix` cluster nodes | 1 | 3 |
| `pod-logs` / journal nodes | 1 | 3 |
| `media-exporter` | absent | scraped |

## Two corrections to the issue

**The suggested `ipBlock: 10.1.2.0/24` would not have fixed it.** `tcpdump` on the node running Prometheus shows the blocked SYNs arriving from the sender's **Calico VXLAN tunnel address**, not its LAN address — cross-node traffic to a pod leaves via `vxlan.calico`:

```
vxlan.calico In IP 10.233.103.0.49866 > 10.233.70.68.9090: Flags [S], seq 1781783217
vxlan.calico In IP 10.233.103.0.49866 > 10.233.70.68.9090: Flags [S], seq 1781783217   # same seq, no SYN-ACK
```

`10.233.103.0` is k8s-hawk-2's tunnel address; `10.233.123.128` is k8s-hawk-3's. Those come out of the pod CIDR, so the rule has to admit `10.233.64.0/18`. Pinning the three as `/32`s would re-break this silently the next time Calico reallocates a node's block on rebuild.

**Loki was not spared.** The same capture against the gateway shows hawk-1 and hawk-2 tunnel addresses being dropped on 8080. The per-node log counts looked healthy only because the `media` namespace sidecars carry a `node` label too — they are pods, so `allow-media-log-push` matched them. Splitting by `job` shows only the gateway's own node had `pod-logs` and journal streams. Metrics and logs each kept a *different* node alive, because Prometheus is on hawk-1 and the gateway on hawk-3.

Damage was therefore wider than filed: kubelet, cAdvisor, kube-state-metrics, ingress-nginx **and the node exporters** for two nodes, plus journal and pod logs for two nodes.

## The fix

- `allow-node-remote-write` — new, admits the node addresses to Prometheus:9090.
- `allow-media-log-push` → `allow-log-push` — same rule for the gateway's 8080. Renamed because it is no longer only the media namespace.

`ipBlock` is the only selector that can match these senders at all: the Alloy pods are `hostNetwork`, so they have no pod IP and `allow-same-namespace`'s `podSelector: {}` never matched them.

## Why nothing alerted

Prometheus scrapes none of this — it all arrives by `remote_write`. A blocked sender makes its targets **absent**, never `up == 0`, so every alert keyed on `up == 0` was blind and the panels merely thinned out. The new `telemetry-coverage` group keys on target count instead. All four rules evaluated to `1` against the live outage and went quiet once the policies were applied, so they would have caught this within 15 minutes.

The node count is hardcoded as 3 — it can't be derived, since the only source of a node count is kube-state-metrics, which is one of the things that disappears. Adding a node means editing those expressions; the runbook says so.

## Verification

- `promtool check rules` — SUCCESS, 24 rules
- `yamllint` — clean
- **The two policies are already applied to the live cluster**, which is where the "after" column above comes from. Telemetry has been recovering since. They are additive allow-rules, identical to what this PR has Flux converge on — but Flux may prune them before this merges, in which case the outage silently resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)