### PR TITLE
Deploy giftlist to hawkfield

### DIFF
--- a/Ansible/group_vars/adguard.yml
+++ b/Ansible/group_vars/adguard.yml
@@ -74,6 +74,8 @@ adguard_local_dns_entries:
     answer: "10.1.2.205"
   - domain: "prowlarr.clinch-home.com"
     answer: "10.1.2.205"
+  - domain: "gifts.clinch-home.com"
+    answer: "10.1.2.205"
 
   # Kubernetes ingress — clincha.co.uk
   - domain: "clincha.co.uk"
@@ -117,6 +119,8 @@ adguard_local_dns_entries:
   - domain: "deluge.clincha.co.uk"
     answer: "10.1.2.205"
   - domain: "prowlarr.clincha.co.uk"
+    answer: "10.1.2.205"
+  - domain: "gifts.clincha.co.uk"
     answer: "10.1.2.205"
 
   # Claude server (Dave)

--- a/Documentation/hawkstore-accounts.md
+++ b/Documentation/hawkstore-accounts.md
@@ -39,11 +39,17 @@ almost every GID in 3003–3022 was also a *different* account's UID; that is ho
 | loki | 3018 | loki | 3018 | `/mnt/userstore/loki` |
 | uptimekuma | 3019 | uptimekuma | 3019 | `/mnt/userstore/uptime-kuma` |
 | s3 | 3020 | s3 | 3020 | rustfs, `/mnt/userstore/s3` |
+| alertmanager | 3021 | alertmanager | 3021 | `/mnt/userstore/alertmanager` |
+| deluge | 3022 | media | 3011 | |
+| prowlarr | 3025 | media | 3011 | |
+| giftlist | 3026 | giftlist | 3026 | `/mnt/userstore/giftlist` |
 
 Shared/auxiliary groups: `media(3011)`, `printing(3023)` (clincha, hawkprint — owns
 `/mnt/userstore/scans`), `family(3024)` (clincha, cclinch, asta).
 
-Free GIDs: 3008–3010, 3012–3014, 3016, 3017, 3021, 3022, 3025+.
+Free GIDs: 3008–3010, 3012–3014, 3016, 3017, 3022, 3025, 3027+.
+
+Free UIDs: 3023, 3024, 3027+.
 
 ## Renumbering, if it is ever needed again
 

--- a/kubernetes/flux/applications/base/giftlist/certificate.yml
+++ b/kubernetes/flux/applications/base/giftlist/certificate.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: giftlist-certificate
+  namespace: giftlist
+spec:
+  secretName: giftlist-certificate-secret
+  issuerRef:
+    name: letsencrypt
+    kind: ClusterIssuer
+  dnsNames:
+    - gifts.clinch-home.com
+    - gifts.clincha.co.uk

--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 3026
       containers:
         - name: giftlist
-          image: ghcr.io/clincha-org/giftlist:583bd6a5a40e10759ef735486a4db8c708e402df
+          image: ghcr.io/clincha-org/giftlist:da7ba1c883a2289fd82b4d34cc107b1eb165a928
           ports:
             - containerPort: 8080
               name: http

--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -98,7 +98,9 @@ spec:
         - name: smtp
           secret:
             secretName: giftlist-smtp
-            defaultMode: 0400
+            # 0440, not 0400: secret files land root-owned, so a non-root
+            # container reads them through the fsGroup and needs group read.
+            defaultMode: 0440
             items:
               - key: password
                 path: smtp-password

--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -1,0 +1,106 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: giftlist
+  namespace: giftlist
+  labels:
+    name: giftlist
+spec:
+  replicas: 1
+  # Enforced by kubernetes/policy/nfs-deployment-requires-recreate.yaml, and
+  # independently required: RollingUpdate surges a second pod at replicas: 1
+  # and the two deadlock on the SQLite file lock.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      name: giftlist
+  template:
+    metadata:
+      labels:
+        name: giftlist
+    spec:
+      serviceAccountName: giftlist
+      automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: giftlist-ghcr
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 3026
+        runAsGroup: 3026
+        fsGroup: 3026
+      containers:
+        - name: giftlist
+          image: ghcr.io/clincha-org/giftlist:583bd6a5a40e10759ef735486a4db8c708e402df
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            - name: BASE_URL
+              value: https://gifts.clinch-home.com
+            - name: DB_PATH
+              value: /data/giftlist.db
+            - name: SMTP_HOST
+              value: smtp.gmail.com
+            - name: SMTP_PORT
+              value: "465"
+            - name: SMTP_USER
+              value: angus.clinch@gmail.com
+            - name: MAIL_FROM
+              value: angus.clinch@gmail.com
+            # A file, not the value: clincha's kube-linter runs addAllBuiltIn
+            # without the read-secret-from-env-var exclusion.
+            - name: SMTP_PASSWORD_FILE
+              value: /etc/giftlist/smtp-password
+            - name: ALLOWED_EMAILS
+              value: >-
+                angus.clinch@gmail.com,c.rueveja@gmail.com,emclinch@gmail.com,christine.clinch62@gmail.com,njlclinch@gmail.com
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /data
+              name: data
+            - mountPath: /etc/giftlist
+              name: smtp
+              readOnly: true
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - name: data
+          nfs:
+            path: /mnt/userstore/giftlist
+            server: 10.1.2.10
+        - name: smtp
+          secret:
+            secretName: giftlist-smtp
+            defaultMode: 0400
+            items:
+              - key: password
+                path: smtp-password
+        - name: tmp
+          emptyDir: {}

--- a/kubernetes/flux/applications/base/giftlist/giftlist-ghcr.sops.yaml
+++ b/kubernetes/flux/applications/base/giftlist/giftlist-ghcr.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: giftlist-ghcr
+    namespace: giftlist
+type: kubernetes.io/dockerconfigjson
+stringData:
+    .dockerconfigjson: ENC[AES256_GCM,data:MBzpkt3XKntTbH1k5K7zGKGoSslH38EpPv/Mqj5HUD5ExxaDGO0/XG8vvIk9TAELMHM3BO0RUO23/WnIvQweC4V91CNXIarKUoiV+tcRCY59X59dihIZTTj+W0NvHoaLrxB9VB+wJVU/fB1biFlVcacdQmsMPhb6BtpvBh670M+tEHToA96KNW6b10gFa/Ep7CJ5aAkyks0p8TUdGmq3l7gPMPQGNpChbmN1GxvfrYJ8TT4=,iv:4CSXqxN8+HK5QiatAbI8DXiWjBPRZSlq6BNxgJViDNk=,tag:CWPW+d2+n4ORYHQYNzOjBQ==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-19T20:26:51Z"
+    mac: ENC[AES256_GCM,data:fwJV12lLfG//i1E4jFrfTvdQZgGFesoFmDFZGfi3mQrsYy+5F7metL5jLAV1RNKICxayxskFAo6vzlY5c4B8L77w14tMIkhdYZpMpbjBXbVC5bDxDVspZPM2Mh/WfjN7U0YR2N82yDdVWCWkLYU/t1tBi3QhakEGgBuAr7L2nAA=,iv:cHhoGob19DjHJ7LSMroPHg6LI6X4lJU5j1gZF6pgyCA=,tag:XIdhqfH7Z37LsIynG0fEeQ==,type:str]
+    pgp:
+        - created_at: "2026-08-19T20:26:51Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA+iIV7UXPYO1AQ/+IslfODb2R2tgzf3aim6qpioZKI3J/xRkxanjiWd0fQ3C
+            4oRUgUvnomaxaqLjc3kcmlAC5UX/lHXLfIKjYVcDG/UxMo4CkE7j4NWbk9+KnqnY
+            HXWGHOL+45UJqnuPD7p1aU7XzQDaehP0IC8s/Lo/lcA8DbmnaE/Mwf2gIcA8OL7C
+            bY3TtCYWr1+2bAcC5o8Xh7mNEFmN3Wo5gJSrjCB/8IPU02+1UDkFasZTRY3Nth8O
+            lfdo7BqwmADNfqvCmo9uIQXxpPNn/cQI3eHT23TAm3bbiSA7lqqkH2eTSA7TU6dk
+            eFyKc71CIesPjvz8Gs0QKju0Gs8utJTassKOL1bNU83TgFp7bDKsCSO0BvkeN7CZ
+            EkNODagA1TXX4FPqPUsptFCvXsUTCHoxOMmIolxUISiwp2PleSaabZ9kGvbe1BiV
+            fa9Kqqa8M78+KwrH+iZAo3dEp0co/RzdBpmXyXJpPfHl+KcS78M6j30bfsdHr3fu
+            4WHVb2TiGHeLHBO2r9qrSSHX/50TnJG3C3y0ucXYm6N03dxeIz81M8EmKm8ePHom
+            r+3Q7e3mDMEEH0OMV+QHD+Yp4KdzKIjev7o0lyiuMBiyFtyp/0CY4q3/ZLNU6L6G
+            GQeEbxEBzEgQW7I3dXYY+vDGuUdQctS7YwfgICjcpDzVJr3I9fwqoqjrQ+IWA9PS
+            XAF24XfW5CPRX2dsnL3o86r9OFOjElwt1dXVtQTqirmXFxVQm+fI6cdQOrEXkMw1
+            HpMxfQ1x4RjMMQAR++QB95xjCMiIOxIpfRe3HdVPgxEb5mfSTnJk7tLH9vdV
+            =vShv
+            -----END PGP MESSAGE-----
+          fp: 76AF39813C2297E8F98C542D42436A07A9BA1DE0
+    version: 3.13.1

--- a/kubernetes/flux/applications/base/giftlist/giftlist-smtp.sops.yaml
+++ b/kubernetes/flux/applications/base/giftlist/giftlist-smtp.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: giftlist-smtp
+    namespace: giftlist
+type: Opaque
+stringData:
+    password: ENC[AES256_GCM,data:DPpuB23VB6mI6qXsbDIyQw==,iv:nkSwyQtqqkj9M1o5FKe1bjsyEL/XDGC0rvjOtQf6iA0=,tag:c0RZX4gpv6DFDV7bZfX5Nw==,type:str]
+sops:
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-19T20:19:22Z"
+    mac: ENC[AES256_GCM,data:prmbG5L6Wb8UjwwhmrMnvFNxVOtXiutdB8bwmZWvYP3cAvwJU8ZuGG5pqwhm0gI9DIxAWgp9mS1hyZHmp9VrIbYO7/klFN9ZTbl6VRvc656BLUDMeBywHCqXKgxbjH/CP5MdBZycHXYyNm8sJuU5kU3sqIBz8/jlLFzfTSJaYNw=,iv:6vehzCQFu3XFiCLd0a3yqOuTLnkSxRLENBvXzpqm4dE=,tag:KRktmMugxjS5CWNLU0BcNA==,type:str]
+    pgp:
+        - created_at: "2026-08-19T20:19:22Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA+iIV7UXPYO1ARAAgAe4/biI6rjrSnxMXq4PKUVTyFehVoZ3aiF2D+iqEv2S
+            bX0HKIQyxmQ16CS7wO8IZsmDd7TJiBKenCCb8LwBOjh5NXmCL94Nz5exmo0q7qb3
+            Pk9pCNY96S/K5sMQAyqqD9Oes5IyCTkoncMrw1QkcuoZdWyijRv5MWaDUVopbCYX
+            yIagTfdNaBEdAfSjU8H/zHjaFOBQQlBKFn7AgvZQEOhvDH3IJYRzCzPFipWC6xkg
+            G02jnJLQsRweMxR7qVRjYuDE54FV1mJht3UopMlX3Xe7zYS0WOFCA0F4iM9VGnvk
+            tdEoF9m5vUJ0p7GsrPmBZjOY2Jb1ogvUBfgc2+FEvHZ2fi1757N2/lljFFkGUtmF
+            +bRlqacp8rMrwKgjkpJ2b3oFSCCSXqN9KX2gL5DhwdbcyHOGCkyKsowb7EGkQcDi
+            78jFQAl36/l8CleJD5tdRv8l1uzkeS1gBBizjMbhb/5hpi1rplUNWCZli9Skg6W4
+            w25wJ6UeBZI8+YyV/orC9EFxjJMqFn567VlN+WIxw9JaHMLwLrXhTc5Iao/U/Dqu
+            JEXc4ep/z3SjVqfU/O5FD5jcUXUDVoA6vnpkfeeBmmsV8Y8q4BtYq5y2/na65iEw
+            KHmEmYVlPz1FOxDy7pC9B6Wpl4o+MkwhnNwpPlBh/aYTZOcJKiYytypaQ1F9k8/S
+            XgFePsgruEAxsbJXxfNyqrHvyrwqM6pvCx186dtJtoqzXe+0mgAM6pBNHCNvKDB7
+            Tt3BdbEeabeUMqoSde3QgYffBYQO5zpijmbrGFHRECGuNwQjxyCpRcJCyOzhst4=
+            =U4RB
+            -----END PGP MESSAGE-----
+          fp: 76AF39813C2297E8F98C542D42436A07A9BA1DE0
+    version: 3.13.1

--- a/kubernetes/flux/applications/base/giftlist/ingress.yml
+++ b/kubernetes/flux/applications/base/giftlist/ingress.yml
@@ -1,0 +1,31 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: giftlist
+  namespace: giftlist
+spec:
+  ingressClassName: nginx
+  tls:
+    - secretName: giftlist-certificate-secret
+  rules:
+    - host: gifts.clinch-home.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: giftlist
+                port:
+                  number: 80
+    - host: gifts.clincha.co.uk
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: giftlist
+                port:
+                  number: 80

--- a/kubernetes/flux/applications/base/giftlist/kustomization.yml
+++ b/kubernetes/flux/applications/base/giftlist/kustomization.yml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yml
+  - serviceaccount.yml
+  - giftlist-smtp.sops.yaml
+  - giftlist-ghcr.sops.yaml
+  - deployment.yml
+  - service.yml
+  - ingress.yml
+  - certificate.yml
+  - network-policy.yml

--- a/kubernetes/flux/applications/base/giftlist/namespace.yml
+++ b/kubernetes/flux/applications/base/giftlist/namespace.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: giftlist

--- a/kubernetes/flux/applications/base/giftlist/network-policy.yml
+++ b/kubernetes/flux/applications/base/giftlist/network-policy.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: giftlist
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-http
+  namespace: giftlist
+spec:
+  podSelector:
+    matchLabels:
+      name: giftlist
+  policyTypes:
+    - Ingress
+  ingress:
+    # Unlike homepage this Service is ClusterIP only, with no MetalLB VIP, so
+    # ingress-nginx is the sole caller. It runs on the pod network here, not
+    # hostNetwork, so a namespaceSelector genuinely matches it.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/kubernetes/flux/applications/base/giftlist/service.yml
+++ b/kubernetes/flux/applications/base/giftlist/service.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: giftlist
+  namespace: giftlist
+spec:
+  selector:
+    name: giftlist
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/kubernetes/flux/applications/base/giftlist/serviceaccount.yml
+++ b/kubernetes/flux/applications/base/giftlist/serviceaccount.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: giftlist
+  namespace: giftlist
+automountServiceAccountToken: false

--- a/kubernetes/flux/applications/hawkfield/giftlist/kustomization.yml
+++ b/kubernetes/flux/applications/hawkfield/giftlist/kustomization.yml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: giftlist
+resources:
+  - ../../base/giftlist

--- a/kubernetes/flux/clusters/hawkfield/applications/giftlist.yml
+++ b/kubernetes/flux/clusters/hawkfield/applications/giftlist.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: giftlist
+  namespace: flux-system
+spec:
+  interval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/flux/applications/hawkfield/giftlist
+  dependsOn:
+    - name: certificate-manager-configuration
+    - name: metallb-configuration
+    - name: ingress-nginx
+  prune: true
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg


### PR DESCRIPTION
Deploys [clincha-org/giftlist](https://github.com/clincha-org/giftlist) at
`gifts.clinch-home.com` — family gift lists where a list's owner can never see who reserved
what, or that anything was reserved at all.

Follows the `homepage` pattern: base + a thin hawkfield overlay + a Flux `Kustomization` at
`clusters/hawkfield/applications/`. No `london`/`dev` overlays — those patch in a
`letsencrypt-staging` issuer that doesn't exist.

## What's already done and verified

- **App** — CI green, image at `ghcr.io/clincha-org/giftlist`, pinned here by digest tag.
  18 tests pass, including the two that hold the owner-blindness invariant down. Both were
  mutation-checked: I broke `items_for` and broke the template, separately and together,
  and confirmed the tests fail.
- **Storage** — dataset `userstore/giftlist` created on the encrypted SSD pool (inherits
  the existing `userstore` encryption root, so no new key to custody), NFS share 42 live.
  Mount-tested from hawk-1: uid 3026 writes, root is squashed.
- **SMTP** — the Gmail app password authenticates against `smtp.gmail.com:465`
  (it's stored with spaces; the secret holds the 16-char form).
- **Locally green** — `yamllint`, `kubeconform`, `kube-linter`, and `kyverno apply` against
  the built overlay.

## Things worth a second look

- **uid/gid 3026.** `Documentation/hawkstore-accounts.md` was stale — it listed 3021/3022
  as free, but they're `alertmanager` and `deluge` live on the NAS, and 3025 is `prowlarr`.
  I checked `user.query` and `group.query` rather than trusting the doc, took 3026 as the
  first pair free in both, and corrected the doc in this PR.
- **Image pull secret rather than a public package.** Package visibility can't be changed
  through the REST API, and GitHub Packages doesn't support fine-grained tokens, so this
  uses a classic token scoped to `read:packages` only. Verified it can pull the manifest
  and nothing else. If you'd rather make the package public later, the secret and the
  `imagePullSecrets` block come straight back out.
- **NetworkPolicy is tighter than homepage's.** This Service is ClusterIP with no MetalLB
  VIP, so ingress-nginx is the only caller; I checked it runs on the pod network here, not
  hostNetwork, so the `namespaceSelector` genuinely matches. No egress restriction, so
  DNS/NFS/SMTP are unaffected.
- **`journal_mode=DELETE`, not WAL** — the database is on NFS, and WAL-on-NFS is what
  crash-looped uptime-kuma.

## After merge

`gifts.clinch-home.com` already resolves publicly to Cloudflare. `gifts.clincha.co.uk` has
no public record and gets one via AdGuard here for LAN use; merging fires
`ansible-adguard.yaml` automatically. I'll reconcile, verify the cert and a 200 on
`/healthz` from on and off network, then run the two-browser reservation test and a pod
restart to confirm state survives.