### PR TITLE
giftlist: deploy the link-preview image

### DIFF
--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 3026
       containers:
         - name: giftlist
-          image: ghcr.io/clincha-org/giftlist:da7ba1c883a2289fd82b4d34cc107b1eb165a928
+          image: ghcr.io/clincha-org/giftlist:5e4012d3924d82f961e9723724e89b37b7c421e4
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary
- Bump giftlist deployment image to `5e4012d3924d82f961e9723724e89b37b7c421e4` — clincha-org/giftlist#1 (add-item now scrapes title/price/image from a pasted URL).
- No other manifest changes: the app's NetworkPolicy has no Egress `policyTypes`, so outbound HTTP to arbitrary sites for scraping is already permitted.

## Test plan
- [x] New image built and pushed by giftlist CI (`image` job, run succeeded on master)
- [ ] Flux reconciles and the pod comes up healthy on `/healthz`