### PR TITLE
giftlist: deploy the stylesheet cache-bust fix

### DIFF
--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 3026
       containers:
         - name: giftlist
-          image: ghcr.io/clincha-org/giftlist:5e4012d3924d82f961e9723724e89b37b7c421e4
+          image: ghcr.io/clincha-org/giftlist:805478597339732608b65b344cad3276f7c3080f
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary
- Bump giftlist deployment image to `805478597339732608b65b344cad3276f7c3080f` — clincha-org/giftlist#2, fixes thumbnails rendering at full native size for anyone with a cached pre-deploy `style.css`.

## Test plan
- [x] Image built and pushed by giftlist CI on master
- [ ] Flux reconciles and pod comes up healthy