### PR TITLE
giftlist: deploy the birthday/sizes profile fields

### DIFF
--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 3026
       containers:
         - name: giftlist
-          image: ghcr.io/clincha-org/giftlist:805478597339732608b65b344cad3276f7c3080f
+          image: ghcr.io/clincha-org/giftlist:fd775cc42dc78458f224e1474afa83942450b816
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary
- Bump giftlist deployment image to `fd775cc42dc78458f224e1474afa83942450b816` — clincha-org/giftlist#3.

## Test plan
- [x] Image built and pushed by giftlist CI on master
- [ ] Flux reconciles and pod comes up healthy