### PR TITLE
ingress-nginx: trust Cloudflare's real client IP

### DIFF
--- a/kubernetes/flux/infrastructure/hawkfield/ingress-nginx/values.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/ingress-nginx/values.yml
@@ -1,6 +1,16 @@
 controller:
   replicaCount: 3
   minAvailable: 2
+  config:
+    use-forwarded-headers: "true"
+    forwarded-for-header: "CF-Connecting-IP"
+    # Cloudflare's published edge ranges (https://www.cloudflare.com/ips-v4,
+    # https://www.cloudflare.com/ips-v6), fetched fresh rather than hardcoded
+    # from memory. Only trusted as the source of the forwarded-for header when
+    # the TCP peer is inside these ranges, so gifts.clincha.co.uk (LAN, no
+    # Cloudflare hop) still resolves to the real peer IP.
+    proxy-real-ip-cidr: >-
+      173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22,2400:cb00::/32,2606:4700::/32,2803:f800::/32,2405:b500::/32,2405:8100::/32,2a06:98c0::/29,2c0f:f248::/32
   metrics:
     enabled: true
     service:


### PR DESCRIPTION
## Summary
- `use-forwarded-headers`/`forwarded-for-header: CF-Connecting-IP`/`proxy-real-ip-cidr` on the shared ingress-nginx controller, so it resolves the real visitor IP behind Cloudflare instead of the edge IP.
- `proxy-real-ip-cidr` is Cloudflare's published IPv4+IPv6 ranges (fetched fresh from `cloudflare.com/ips-v4`/`ips-v6` today, not hardcoded from memory) — it only trusts the forwarded header when the TCP peer is in those ranges, so `gifts.clincha.co.uk` (LAN, bypasses Cloudflare) keeps resolving to the real LAN peer IP.
- Prerequisite for per-IP rate limiting on giftlist's Ingress (a later PR) — without this, rate limiting would throttle by Cloudflare's shared edge pool, not the actual abuser.
- No giftlist-specific changes; this is cluster-wide (every app behind this controller).

## Test plan
- [x] `kubectl kustomize kubernetes/flux/infrastructure/hawkfield/ingress-nginx` builds cleanly
- [x] `yamllint` clean
- [ ] After merge + Flux reconcile: confirm a Cloudflare-fronted request to `gifts.clinch-home.com` and a direct LAN request to `gifts.clincha.co.uk` both show the real client IP in ingress-nginx access logs
- [ ] Spot-check at least one other app behind this controller still resolves correctly (blast radius is cluster-wide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)