### PR TITLE
giftlist: deploy invite-only circles + anonymous onboarding

### DIFF
--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 3026
       containers:
         - name: giftlist
-          image: ghcr.io/clincha-org/giftlist:fd775cc42dc78458f224e1474afa83942450b816
+          image: ghcr.io/clincha-org/giftlist:344a8670adbb804be959418398379504f577c9f4
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary
- Bumps the giftlist image to `344a8670adbb804be959418398379504f577c9f4`, which includes giftlist#4 (invite-only circles) and giftlist#5 (anonymous-first onboarding + email claim).
- ALLOWED_EMAILS still gates signup — public launch is a separate PR after this deploys and gets exercised by the family.

## Test plan
- [x] `kubectl kustomize` builds clean, image tag resolves correctly in the overlay
- [ ] After Flux reconcile: `/` shows the new landing page for a logged-out visitor, "Start your list" works anonymously, existing family sign-in still works, circles create/join/regenerate work end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)