### PR TITLE
giftlist: open signup to the public, rate-limit per IP

### DIFF
--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -54,9 +54,6 @@ spec:
             # without the read-secret-from-env-var exclusion.
             - name: SMTP_PASSWORD_FILE
               value: /etc/giftlist/smtp-password
-            - name: ALLOWED_EMAILS
-              value: >-
-                angus.clinch@gmail.com,c.rueveja@gmail.com,emclinch@gmail.com,christine.clinch62@gmail.com,njlclinch@gmail.com
           livenessProbe:
             httpGet:
               path: /healthz

--- a/kubernetes/flux/applications/base/giftlist/ingress.yml
+++ b/kubernetes/flux/applications/base/giftlist/ingress.yml
@@ -4,6 +4,11 @@ kind: Ingress
 metadata:
   name: giftlist
   namespace: giftlist
+  annotations:
+    # Per-IP, now that ingress-nginx trusts Cloudflare's real client IP
+    # instead of its shared edge pool (clincha#495).
+    nginx.ingress.kubernetes.io/limit-rps: "5"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
## Summary
- Drops `ALLOWED_EMAILS` — signup is now open to anyone. `config.email_allowed()` already returns `True` for everyone when the set is empty, so this is config-only.
- Adds `nginx.ingress.kubernetes.io/limit-rps: "5"` + `limit-burst-multiplier: "5"` on giftlist's Ingress, now meaningful because ingress-nginx trusts Cloudflare's real client IP (clincha#495) instead of its shared edge pool.
- Final step of the public-launch sequence: clincha#495 (real-IP trust) → giftlist#4 (invite-only circles) → giftlist#5 (anonymous-first onboarding) → this.

## Test plan
- [x] `kubectl kustomize` builds clean, both changes render correctly in the overlay
- [ ] After Flux reconcile: register a genuinely new non-family email end-to-end on the live public URL (anonymous start → add item → claim → receive/use real code), confirm it lands circle-less and sees no family data until invited

🤖 Generated with [Claude Code](https://claude.com/claude-code)