### PR TITLE
giftlist: wire app metrics through to Prometheus

### DIFF
--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -32,10 +32,13 @@ spec:
         fsGroup: 3026
       containers:
         - name: giftlist
-          image: ghcr.io/clincha-org/giftlist:344a8670adbb804be959418398379504f577c9f4
+          image: ghcr.io/clincha-org/giftlist:462e3e198382d7b1d0e8ac6f3fdc5efcd0703e3f
           ports:
             - containerPort: 8080
               name: http
+              protocol: TCP
+            - containerPort: 9090
+              name: metrics
               protocol: TCP
           env:
             - name: BASE_URL

--- a/kubernetes/flux/applications/base/giftlist/network-policy.yml
+++ b/kubernetes/flux/applications/base/giftlist/network-policy.yml
@@ -31,3 +31,23 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring-scrape
+  namespace: giftlist
+spec:
+  podSelector:
+    matchLabels:
+      name: giftlist
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - protocol: TCP
+          port: 9090

--- a/kubernetes/flux/applications/base/giftlist/service.yml
+++ b/kubernetes/flux/applications/base/giftlist/service.yml
@@ -12,3 +12,7 @@ spec:
       port: 80
       targetPort: http
       protocol: TCP
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+      protocol: TCP

--- a/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
+++ b/kubernetes/flux/infrastructure/hawkfield/monitoring/prometheus.yml
@@ -84,3 +84,11 @@ scrape_configs:
     scrape_interval: 60s
     static_configs:
       - targets: ['media-exporter.media.svc:9114']
+  # Account growth, wishlist/circle/reservation counts and mail-delivery
+  # outcomes, served on a port separate from the public 8080 the Ingress
+  # proxies. Needs its own NetworkPolicy rule (giftlist's default-deny
+  # otherwise blocks this namespace too) — see #487.
+  - job_name: giftlist
+    scrape_interval: 30s
+    static_configs:
+      - targets: ['giftlist.giftlist.svc:9090']


### PR DESCRIPTION
## Summary
- New `metrics`/9090 container+Service port alongside the existing `http`/8080.
- New `allow-monitoring-scrape` NetworkPolicy, same shape as the existing `allow-http` rule, admitting only the `monitoring` namespace on port 9090 — `allow-http` untouched, least-privilege.
- New `giftlist` Prometheus scrape job (`prometheus.yml`), matching `media-exporter`'s shape/comment style.
- Bumps the giftlist image tag to `462e3e198382d7b1d0e8ac6f3fdc5efcd0703e3f` (giftlist#6, adds `/metrics` on :9090).

## Test plan
- [x] `kubectl kustomize` + `kubeconform -strict` on every touched overlay (giftlist, monitoring, and both hawkfield aggregate overlays) — all valid, matching `k8s-validate.yaml`
- [x] `kube-linter lint` against the built hawkfield overlays — no errors
- [x] `kyverno apply` against `kubernetes/policy/` and the built overlays — 10 pass / 0 fail
- [x] `yamllint` on the touched files — clean
- [ ] After merge + Flux reconcile: confirm `up{job="giftlist"}==1` in Prometheus and `giftlist_*` metrics match the live DB; confirm `/metrics` on 9090 is unreachable via either public hostname