### PR TITLE
giftlist: deploy the skip-onboarding / 5-item-limit release

### DIFF
--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 3026
       containers:
         - name: giftlist
-          image: ghcr.io/clincha-org/giftlist:462e3e198382d7b1d0e8ac6f3fdc5efcd0703e3f
+          image: ghcr.io/clincha-org/giftlist:35a09bbe92470042b132a9954ebfd7f5a1cec046
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
Bumps the giftlist image tag to `35a09bbe92470042b132a9954ebfd7f5a1cec046` (giftlist#7).

## Test plan
- [x] `kubectl kustomize` output confirmed the new image tag
- [ ] After merge + Flux reconcile: confirm the new pod is running the new image, and smoke-test `/start` redirecting straight to the list page