### PR TITLE
giftlist: deploy the Material Design 2 restyle

### DIFF
--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 3026
       containers:
         - name: giftlist
-          image: ghcr.io/clincha-org/giftlist:01c53c2ccb24a0a1d0f8a0ced6db87550b80549d
+          image: ghcr.io/clincha-org/giftlist:5c6b537977e8e55992aa37e08e8bb9df421de119
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary
- Bumps the giftlist image to `5c6b537` (giftlist#9), a full CSS restyle to Google's Material Design 2. No manifest/behavior changes beyond the tag.

## Test plan
- [x] giftlist CI (tests + image build) green on the source PR
- [x] Restyle verified locally with a headless browser before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)