### PR TITLE
Deploy giftlist feedback feature

### DIFF
--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 3026
       containers:
         - name: giftlist
-          image: ghcr.io/clincha-org/giftlist:5c6b537977e8e55992aa37e08e8bb9df421de119
+          image: ghcr.io/clincha-org/giftlist:fdec55b23f07df90117beceb3e9bb87a2d7bc311
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary
- Bumps the pinned giftlist image from `5c6b537...` to `fdec55b23f07df90117beceb3e9bb87a2d7bc311` (clincha-org/giftlist#10, merged), which adds the `/feedback` page, the `feedback` table, and the `giftlist_feedback_total` metric.
- The Grafana `giftlist` dashboard already has a "Feedback received" stat panel wired to that metric (added ahead of this deploy) — it's been showing no-data until now.

## Test plan
- [x] Image tag confirmed present in GHCR (`ghcr.io/clincha-org/giftlist:fdec55b...`)
- [ ] After Flux reconciles: confirm pod comes up healthy, `/feedback` reachable on the live site, `giftlist_feedback_total` starts reporting on the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)