### PR TITLE
Deploy giftlist's moss green restyle

### DIFF
--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 3026
       containers:
         - name: giftlist
-          image: ghcr.io/clincha-org/giftlist:fdec55b23f07df90117beceb3e9bb87a2d7bc311
+          image: ghcr.io/clincha-org/giftlist:a4bdcdfb157ba2d9e9015db3d1156fd6a6b1c0c7
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary
- Bumps the pinned `giftlist` image tag to `a4bdcdf` (clincha-org/giftlist#11, merged), which restyles the app from Material purple/teal to a subtle moss green + warm neutral palette
- Image tag confirmed present in GHCR before opening this PR

## Test plan
- [x] Verified `ghcr.io/clincha-org/giftlist:a4bdcdfb157ba2d9e9015db3d1156fd6a6b1c0c7` exists (CI build succeeded on the giftlist merge commit)
- [ ] Confirm Flux reconciles and the live site at gifts.clinch-home.com shows the new palette after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)