### PR TITLE
Deploy giftlist admin panel (image bump)

### DIFF
--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 3026
       containers:
         - name: giftlist
-          image: ghcr.io/clincha-org/giftlist:a1d8f4800a2556063440a4b75a6607adaea3d548
+          image: ghcr.io/clincha-org/giftlist:0d761604b3e0de876c8e90e173525f1044e0fe22
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary
- Bumps the pinned giftlist image tag to `0d76160` (giftlist#13: admin panel with full CRUD on every list and item at `/admin`).
- No manifest/env changes needed — `ADMIN_EMAIL` defaults in-app to `angus.clinch@gmail.com`.

## Test plan
- [x] giftlist CI green on the image build (test + image jobs both succeeded on master push).
- [ ] Post-merge: confirm Flux picks up the new tag (force-reconcile if the poll cadence doesn't catch it), then verify the admin panel live at gifts.clinch-home.com/admin.