### PR TITLE
Deploy giftlist: anon-group dashboard + admin link lookup

### DIFF
--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 3026
       containers:
         - name: giftlist
-          image: ghcr.io/clincha-org/giftlist:0d761604b3e0de876c8e90e173525f1044e0fe22
+          image: ghcr.io/clincha-org/giftlist:a50f89a9c557fde0d7af42062aff426529c4eb50
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary
- Bumps the pinned giftlist image tag to `a50f89a` (giftlist#14).

## Test plan
- [x] giftlist CI green (test + image jobs) on the master push.
- [ ] Post-merge: force Flux reconcile if needed, verify live.