### PR TITLE
Deploy giftlist: single add-item box

### DIFF
--- a/kubernetes/flux/applications/base/giftlist/deployment.yml
+++ b/kubernetes/flux/applications/base/giftlist/deployment.yml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 3026
       containers:
         - name: giftlist
-          image: ghcr.io/clincha-org/giftlist:a50f89a9c557fde0d7af42062aff426529c4eb50
+          image: ghcr.io/clincha-org/giftlist:6c90889a28484acdd7338b29278daef7a30f2727
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary
- Bumps the pinned giftlist image tag to `6c90889` (giftlist#15).

## Test plan
- [x] giftlist CI green (test + image jobs) on the master push.
- [ ] Post-merge: force Flux reconcile if needed, verify live.